### PR TITLE
feat: add first pdf2m3 ingest slice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
         shell: bash
         run: cargo install cargo-llvm-cov --locked
 
+      - name: Install npm dependencies for shared lint script
+        shell: bash
+        run: npm install
+
       - name: Run formatting and clippy gates
         shell: bash
         run: bash ./scripts/lint.sh

--- a/crates/youaskm3-ingest/examples/pdf2m3.rs
+++ b/crates/youaskm3-ingest/examples/pdf2m3.rs
@@ -1,0 +1,35 @@
+use std::{env, error::Error, fs, path::Path};
+
+use youaskm3_ingest::{PdfMarkdownInput, derive_title_from_path, render_pdf_markdown};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("pdf2m3 example failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut arguments = env::args().skip(1);
+    let input_path = arguments
+        .next()
+        .ok_or("usage: cargo run -p youaskm3-ingest --example pdf2m3 -- <input.txt> <output.md> [source.pdf]")?;
+    let output_path = arguments
+        .next()
+        .ok_or("usage: cargo run -p youaskm3-ingest --example pdf2m3 -- <input.txt> <output.md> [source.pdf]")?;
+    let source_path = arguments.next().unwrap_or_else(|| input_path.clone());
+
+    let extracted_text = fs::read_to_string(&input_path)?;
+    let markdown = render_pdf_markdown(&PdfMarkdownInput {
+        title: derive_title_from_path(&source_path),
+        source_path,
+        extracted_text,
+    })?;
+
+    if let Some(parent) = Path::new(&output_path).parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    fs::write(output_path, markdown)?;
+    Ok(())
+}

--- a/crates/youaskm3-ingest/examples/pdf2m3.rs
+++ b/crates/youaskm3-ingest/examples/pdf2m3.rs
@@ -26,10 +26,50 @@ fn run() -> Result<(), Box<dyn Error>> {
         extracted_text,
     })?;
 
-    if let Some(parent) = Path::new(&output_path).parent() {
-        fs::create_dir_all(parent)?;
-    }
+    ensure_output_directory(Path::new(&output_path))?;
 
     fs::write(output_path, markdown)?;
     Ok(())
+}
+
+fn ensure_output_directory(output_path: &Path) -> Result<(), Box<dyn Error>> {
+    if let Some(parent) = output_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_output_directory;
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    #[test]
+    fn output_in_current_directory_does_not_require_parent_creation() {
+        assert!(ensure_output_directory(PathBuf::from("out.md").as_path()).is_ok());
+    }
+
+    #[test]
+    fn nested_output_path_creates_missing_parent_directory() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("youaskm3-pdf2m3-{unique}"));
+        let output_path = root.join("nested").join("out.md");
+
+        ensure_output_directory(&output_path)
+            .expect("creating nested parent directories should succeed");
+
+        assert!(root.join("nested").is_dir());
+
+        fs::remove_dir_all(root).expect("temporary directory cleanup should succeed");
+    }
 }

--- a/crates/youaskm3-ingest/src/lib.rs
+++ b/crates/youaskm3-ingest/src/lib.rs
@@ -219,7 +219,10 @@ mod tests {
             render_pdf_markdown(&input),
             Err(PdfMarkdownError::MissingTitle)
         );
-        assert_eq!(PdfMarkdownError::MissingTitle.to_string(), "missing PDF title");
+        assert_eq!(
+            PdfMarkdownError::MissingTitle.to_string(),
+            "missing PDF title"
+        );
     }
 
     #[test]

--- a/crates/youaskm3-ingest/src/lib.rs
+++ b/crates/youaskm3-ingest/src/lib.rs
@@ -1,18 +1,188 @@
 #![forbid(unsafe_code)]
 #![warn(clippy::all, clippy::pedantic)]
 
+use std::fmt;
+
 /// Returns the stable identifier for the ingest crate.
 #[must_use]
 pub const fn crate_name() -> &'static str {
     "youaskm3-ingest"
 }
 
+/// Metadata and extracted text needed to render a PDF-backed markdown artifact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PdfMarkdownInput {
+    /// Human-readable title for the generated document.
+    pub title: String,
+    /// Source PDF path or identifier used for traceability.
+    pub source_path: String,
+    /// Extracted plain text content from the PDF.
+    pub extracted_text: String,
+}
+
+/// Errors returned when PDF ingest input is incomplete.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PdfMarkdownError {
+    /// The title was empty after trimming.
+    MissingTitle,
+    /// The source path was empty after trimming.
+    MissingSourcePath,
+    /// The extracted text was empty after trimming.
+    MissingExtractedText,
+}
+
+impl fmt::Display for PdfMarkdownError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingTitle => f.write_str("missing PDF title"),
+            Self::MissingSourcePath => f.write_str("missing PDF source path"),
+            Self::MissingExtractedText => f.write_str("missing extracted PDF text"),
+        }
+    }
+}
+
+impl std::error::Error for PdfMarkdownError {}
+
+/// Builds a stable markdown artifact from extracted PDF text.
+///
+/// # Errors
+///
+/// Returns an error if the title, source path, or extracted text is empty after trimming.
+pub fn render_pdf_markdown(input: &PdfMarkdownInput) -> Result<String, PdfMarkdownError> {
+    let title = input.title.trim();
+    let source_path = input.source_path.trim();
+    let extracted_text = input.extracted_text.trim();
+
+    if title.is_empty() {
+        return Err(PdfMarkdownError::MissingTitle);
+    }
+
+    if source_path.is_empty() {
+        return Err(PdfMarkdownError::MissingSourcePath);
+    }
+
+    if extracted_text.is_empty() {
+        return Err(PdfMarkdownError::MissingExtractedText);
+    }
+
+    let paragraphs = normalize_pdf_text(extracted_text);
+    let body = paragraphs.join("\n\n");
+
+    Ok(format!(
+        "# {title}\n\n## Source\n\n- type: pdf\n- path: `{source_path}`\n- ingested_by: `pdf2m3`\n\n## Extracted Text\n\n{body}\n"
+    ))
+}
+
+/// Derives a human-readable title from a PDF file path or file name.
+#[must_use]
+pub fn derive_title_from_path(path: &str) -> String {
+    let trimmed = path.trim();
+    let file_name = trimmed
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(trimmed)
+        .strip_suffix(".pdf")
+        .unwrap_or(trimmed);
+
+    let normalized = file_name
+        .chars()
+        .map(|character| {
+            if matches!(character, '-' | '_' | '.') {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>();
+
+    normalized.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Normalizes extracted PDF text into markdown-friendly paragraphs.
+#[must_use]
+pub fn normalize_pdf_text(text: &str) -> Vec<String> {
+    let normalized_newlines = text.replace("\r\n", "\n").replace('\r', "\n");
+    let mut paragraphs = Vec::new();
+    let mut current_lines: Vec<String> = Vec::new();
+
+    for line in normalized_newlines.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.is_empty() {
+            if !current_lines.is_empty() {
+                paragraphs.push(current_lines.join(" "));
+                current_lines.clear();
+            }
+            continue;
+        }
+
+        current_lines.push(trimmed.to_string());
+    }
+
+    if !current_lines.is_empty() {
+        paragraphs.push(current_lines.join(" "));
+    }
+
+    paragraphs
+}
+
 #[cfg(test)]
 mod tests {
-    use super::crate_name;
+    use super::{
+        PdfMarkdownError, PdfMarkdownInput, crate_name, derive_title_from_path, normalize_pdf_text,
+        render_pdf_markdown,
+    };
 
     #[test]
     fn crate_name_matches_package() {
         assert_eq!(crate_name(), "youaskm3-ingest");
+    }
+
+    #[test]
+    fn derive_title_from_path_uses_file_stem() {
+        assert_eq!(
+            derive_title_from_path("ref/Universal_Microservices-Architecture.pdf"),
+            "Universal Microservices Architecture"
+        );
+    }
+
+    #[test]
+    fn normalize_pdf_text_collapses_lines_into_paragraphs() {
+        let normalized = normalize_pdf_text("Line one\nline two\n\nLine three\r\nline four\r\n");
+
+        assert_eq!(
+            normalized,
+            vec![
+                "Line one line two".to_string(),
+                "Line three line four".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn render_pdf_markdown_includes_traceability_metadata() {
+        let input = PdfMarkdownInput {
+            title: "Universal Microservices Architecture".to_string(),
+            source_path: "ref/book.pdf".to_string(),
+            extracted_text: "First paragraph.\nStill first paragraph.\n\nSecond paragraph."
+                .to_string(),
+        };
+        let expected = "# Universal Microservices Architecture\n\n## Source\n\n- type: pdf\n- path: `ref/book.pdf`\n- ingested_by: `pdf2m3`\n\n## Extracted Text\n\nFirst paragraph. Still first paragraph.\n\nSecond paragraph.\n";
+
+        assert_eq!(render_pdf_markdown(&input), Ok(expected.to_string()));
+    }
+
+    #[test]
+    fn render_pdf_markdown_rejects_missing_text() {
+        let input = PdfMarkdownInput {
+            title: "Example".to_string(),
+            source_path: "ref/example.pdf".to_string(),
+            extracted_text: "   ".to_string(),
+        };
+
+        assert_eq!(
+            render_pdf_markdown(&input),
+            Err(PdfMarkdownError::MissingExtractedText)
+        );
     }
 }

--- a/crates/youaskm3-ingest/src/lib.rs
+++ b/crates/youaskm3-ingest/src/lib.rs
@@ -67,9 +67,10 @@ pub fn render_pdf_markdown(input: &PdfMarkdownInput) -> Result<String, PdfMarkdo
 
     let paragraphs = normalize_pdf_text(extracted_text);
     let body = paragraphs.join("\n\n");
+    let source_line = render_source_line(source_path);
 
     Ok(format!(
-        "# {title}\n\n## Source\n\n- type: pdf\n- path: `{source_path}`\n- ingested_by: `pdf2m3`\n\n## Extracted Text\n\n{body}\n"
+        "# {title}\n\n## Source\n\n- type: pdf\n- {source_line}\n- ingested_by: `pdf2m3`\n\n## Extracted Text\n\n{body}\n"
     ))
 }
 
@@ -126,6 +127,10 @@ pub fn normalize_pdf_text(text: &str) -> Vec<String> {
     paragraphs
 }
 
+fn render_source_line(source_path: &str) -> String {
+    format!("path: {}", source_path.trim())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -167,9 +172,22 @@ mod tests {
             extracted_text: "First paragraph.\nStill first paragraph.\n\nSecond paragraph."
                 .to_string(),
         };
-        let expected = "# Universal Microservices Architecture\n\n## Source\n\n- type: pdf\n- path: `ref/book.pdf`\n- ingested_by: `pdf2m3`\n\n## Extracted Text\n\nFirst paragraph. Still first paragraph.\n\nSecond paragraph.\n";
+        let expected = "# Universal Microservices Architecture\n\n## Source\n\n- type: pdf\n- path: ref/book.pdf\n- ingested_by: `pdf2m3`\n\n## Extracted Text\n\nFirst paragraph. Still first paragraph.\n\nSecond paragraph.\n";
 
         assert_eq!(render_pdf_markdown(&input), Ok(expected.to_string()));
+    }
+
+    #[test]
+    fn render_pdf_markdown_keeps_source_label_with_backticks_stable() {
+        let input = PdfMarkdownInput {
+            title: "Example".to_string(),
+            source_path: "notes/`quoted`.pdf".to_string(),
+            extracted_text: "Paragraph.".to_string(),
+        };
+
+        let markdown = render_pdf_markdown(&input).expect("rendering markdown should succeed");
+
+        assert!(markdown.contains("- path: notes/`quoted`.pdf\n"));
     }
 
     #[test]

--- a/crates/youaskm3-ingest/src/lib.rs
+++ b/crates/youaskm3-ingest/src/lib.rs
@@ -185,7 +185,10 @@ mod tests {
             extracted_text: "Paragraph.".to_string(),
         };
 
-        let markdown = render_pdf_markdown(&input).expect("rendering markdown should succeed");
+        let markdown_result = render_pdf_markdown(&input);
+
+        assert!(markdown_result.is_ok());
+        let markdown = markdown_result.unwrap_or_default();
 
         assert!(markdown.contains("- path: notes/`quoted`.pdf\n"));
     }
@@ -201,6 +204,47 @@ mod tests {
         assert_eq!(
             render_pdf_markdown(&input),
             Err(PdfMarkdownError::MissingExtractedText)
+        );
+    }
+
+    #[test]
+    fn render_pdf_markdown_rejects_missing_title() {
+        let input = PdfMarkdownInput {
+            title: "   ".to_string(),
+            source_path: "ref/example.pdf".to_string(),
+            extracted_text: "Paragraph.".to_string(),
+        };
+
+        assert_eq!(
+            render_pdf_markdown(&input),
+            Err(PdfMarkdownError::MissingTitle)
+        );
+        assert_eq!(PdfMarkdownError::MissingTitle.to_string(), "missing PDF title");
+    }
+
+    #[test]
+    fn render_pdf_markdown_rejects_missing_source_path() {
+        let input = PdfMarkdownInput {
+            title: "Example".to_string(),
+            source_path: "   ".to_string(),
+            extracted_text: "Paragraph.".to_string(),
+        };
+
+        assert_eq!(
+            render_pdf_markdown(&input),
+            Err(PdfMarkdownError::MissingSourcePath)
+        );
+        assert_eq!(
+            PdfMarkdownError::MissingSourcePath.to_string(),
+            "missing PDF source path"
+        );
+    }
+
+    #[test]
+    fn missing_extracted_text_error_has_stable_message() {
+        assert_eq!(
+            PdfMarkdownError::MissingExtractedText.to_string(),
+            "missing extracted PDF text"
         );
     }
 }

--- a/tools/pdf2m3/README.md
+++ b/tools/pdf2m3/README.md
@@ -2,4 +2,22 @@
 
 `pdf2m3` will convert source PDFs into structured markdown that fits the knowledge layout described in [SPEC.md](../../SPEC.md).
 
-> Coming in M1.
+The first M1 slice uses `pdftotext` for extraction and the `youaskm3-ingest` crate for deterministic markdown rendering.
+
+## Usage
+
+```bash
+tools/pdf2m3/pdf2m3.sh <input.pdf> <output.md> [source-label]
+```
+
+Example:
+
+```bash
+tools/pdf2m3/pdf2m3.sh ref/book.pdf knowledge/papers/book/index.md
+```
+
+The generated markdown includes:
+
+- a document title derived from the PDF file name
+- source traceability metadata
+- normalized extracted text grouped into markdown paragraphs

--- a/tools/pdf2m3/pdf2m3.sh
+++ b/tools/pdf2m3/pdf2m3.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+if [[ "$#" -lt 2 || "$#" -gt 3 ]]; then
+  echo "Usage: tools/pdf2m3/pdf2m3.sh <input.pdf> <output.md> [source-label]" >&2
+  exit 1
+fi
+
+require_cmd cargo
+require_cmd pdftotext
+
+INPUT_PDF="$1"
+OUTPUT_MD="$2"
+SOURCE_LABEL="${3:-$INPUT_PDF}"
+TEMP_TEXT="$(mktemp)"
+trap 'rm -f "$TEMP_TEXT"' EXIT
+
+cd "$ROOT_DIR"
+
+pdftotext "$INPUT_PDF" "$TEMP_TEXT"
+cargo run --quiet -p youaskm3-ingest --example pdf2m3 -- "$TEMP_TEXT" "$OUTPUT_MD" "$SOURCE_LABEL"
+
+echo "Generated markdown artifact at ${OUTPUT_MD}"


### PR DESCRIPTION
## What this changes
Adds the first reviewable pdf2m3 ingestion slice: deterministic Rust rendering for extracted PDF text, a runnable example entrypoint, and a thin shell wrapper around pdftotext for local markdown generation.

## Spec reference
openspec/specs/knowledge-ingest/spec.md — Capture source material with traceability

## Spec delta (if spec changed)
none

## Test coverage
Focused ingest checks added and cargo test/clippy pass for youaskm3-ingest.

## Breaking changes
none