### PR TITLE
feat: expand MCP tool contracts and validation

### DIFF
--- a/app/components/mcp-tools-contract.test.ts
+++ b/app/components/mcp-tools-contract.test.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+type JsonSchema = {
+  additionalProperties?: boolean;
+  properties?: Record<string, unknown>;
+  required?: string[];
+  type: string | string[];
+};
+
+type ToolContract = {
+  description: string;
+  error_schema: JsonSchema;
+  input_schema: JsonSchema;
+  name: string;
+  output_schema: JsonSchema;
+};
+
+type ContractDocument = {
+  tools: ToolContract[];
+};
+
+function readContracts(): ContractDocument {
+  const contractPath = path.resolve(
+    process.cwd(),
+    "contracts",
+    "mcp-tools.json"
+  );
+  const raw = readFileSync(contractPath, "utf8");
+
+  return JSON.parse(raw) as ContractDocument;
+}
+
+describe("mcp-tools contracts", () => {
+  it("defines the expected initial tool set", () => {
+    const contracts = readContracts();
+
+    expect(contracts.tools.map((tool) => tool.name)).toEqual([
+      "search",
+      "remember",
+      "recall",
+      "connect",
+      "list_sources",
+      "status"
+    ]);
+  });
+
+  it("requires structured input, output, and error schemas for each tool", () => {
+    const contracts = readContracts();
+
+    for (const tool of contracts.tools) {
+      expect(tool.description.length).toBeGreaterThan(0);
+      expect(tool.input_schema.type).toBe("object");
+      expect(tool.output_schema.type).toBe("object");
+      expect(tool.error_schema.type).toBe("object");
+      expect(tool.input_schema.additionalProperties).toBe(false);
+      expect(tool.output_schema.additionalProperties).toBe(false);
+      expect(tool.error_schema.additionalProperties).toBe(false);
+      expect(tool.error_schema.required).toEqual(["code", "message"]);
+      expect(tool.error_schema.properties).toMatchObject({
+        code: { type: "string" },
+        message: { type: "string" }
+      });
+    }
+  });
+
+  it("pins the richer contract details for the first execution slice", () => {
+    const contracts = readContracts();
+    const searchContract = contracts.tools.find((tool) => tool.name === "search");
+    const rememberContract = contracts.tools.find(
+      (tool) => tool.name === "remember"
+    );
+    const statusContract = contracts.tools.find((tool) => tool.name === "status");
+
+    expect(searchContract).toBeDefined();
+    expect(searchContract?.output_schema.properties).toHaveProperty("results");
+    expect(rememberContract?.input_schema.required).toEqual([
+      "source",
+      "source_type"
+    ]);
+    expect(rememberContract?.output_schema.required).toEqual([
+      "accepted",
+      "entry_id",
+      "stored_path"
+    ]);
+    expect(statusContract?.output_schema.required).toEqual([
+      "status",
+      "last_sync_at",
+      "indexed_sources"
+    ]);
+  });
+});

--- a/contracts/mcp-tools.json
+++ b/contracts/mcp-tools.json
@@ -19,11 +19,43 @@
           "results": {
             "type": "array",
             "items": {
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "excerpt": {
+                  "type": "string"
+                },
+                "source_path": {
+                  "type": "string"
+                },
+                "score": {
+                  "type": "number"
+                }
+              },
+              "required": ["id", "title", "excerpt", "source_path", "score"],
+              "additionalProperties": false
             }
           }
         },
         "required": ["results"],
+        "additionalProperties": false
+      },
+      "error_schema": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "message"],
         "additionalProperties": false
       }
     },
@@ -35,9 +67,19 @@
         "properties": {
           "source": {
             "type": "string"
+          },
+          "source_type": {
+            "type": "string",
+            "enum": ["text", "url", "file"]
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
-        "required": ["source"],
+        "required": ["source", "source_type"],
         "additionalProperties": false
       },
       "output_schema": {
@@ -45,9 +87,28 @@
         "properties": {
           "accepted": {
             "type": "boolean"
+          },
+          "entry_id": {
+            "type": "string"
+          },
+          "stored_path": {
+            "type": "string"
           }
         },
-        "required": ["accepted"],
+        "required": ["accepted", "entry_id", "stored_path"],
+        "additionalProperties": false
+      },
+      "error_schema": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "message"],
         "additionalProperties": false
       }
     },
@@ -70,11 +131,40 @@
           "matches": {
             "type": "array",
             "items": {
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "source_path": {
+                  "type": "string"
+                },
+                "matched_on": {
+                  "type": "string"
+                }
+              },
+              "required": ["id", "title", "source_path", "matched_on"],
+              "additionalProperties": false
             }
           }
         },
         "required": ["matches"],
+        "additionalProperties": false
+      },
+      "error_schema": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "message"],
         "additionalProperties": false
       }
     },
@@ -97,11 +187,40 @@
           "connections": {
             "type": "array",
             "items": {
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "from": {
+                  "type": "string"
+                },
+                "to": {
+                  "type": "string"
+                },
+                "relationship": {
+                  "type": "string"
+                },
+                "supporting_source_path": {
+                  "type": "string"
+                }
+              },
+              "required": ["from", "to", "relationship", "supporting_source_path"],
+              "additionalProperties": false
             }
           }
         },
         "required": ["connections"],
+        "additionalProperties": false
+      },
+      "error_schema": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "message"],
         "additionalProperties": false
       }
     },
@@ -119,11 +238,40 @@
           "sources": {
             "type": "array",
             "items": {
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "source_type": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                }
+              },
+              "required": ["id", "title", "source_type", "path"],
+              "additionalProperties": false
             }
           }
         },
         "required": ["sources"],
+        "additionalProperties": false
+      },
+      "error_schema": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "message"],
         "additionalProperties": false
       }
     },
@@ -140,9 +288,29 @@
         "properties": {
           "status": {
             "type": "string"
+          },
+          "last_sync_at": {
+            "type": ["string", "null"]
+          },
+          "indexed_sources": {
+            "type": "integer",
+            "minimum": 0
           }
         },
-        "required": ["status"],
+        "required": ["status", "last_sync_at", "indexed_sources"],
+        "additionalProperties": false
+      },
+      "error_schema": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "message"],
         "additionalProperties": false
       }
     }


### PR DESCRIPTION
## What this changes
Expands the initial MCP tool contracts with explicit output and error schemas, and adds deterministic validation tests so the contract surface is enforced in-repo instead of relying on informal structure.

## Spec reference
openspec/specs/mcp-interface/spec.md - Expose contract-defined knowledge tools

## Spec delta (if spec changed)
none

## Test coverage
- npm test
- npm run lint
- npm run typecheck

## Breaking changes
none

## Issue
closes #11
