### PR TITLE
docs: align roadmap with Traverse v0.1 baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Most personal knowledge tooling traps context inside proprietary silos, hosted b
 
 ## How it works
 
-The system keeps specs in `openspec/specs/`, business logic in Rust crates that compile to `wasm32-wasip1`, frontend glue in strict TypeScript, and knowledge artifacts in markdown and static indexes tracked by git. A future `m3` workflow will ingest content into `knowledge/`, generate indexes at build time, and expose that knowledge through a WASM MCP module that can run in the browser, CLI, or other hosts.
+The system keeps specs in `openspec/specs/`, business logic in Rust crates that compile to `wasm32-wasip1`, frontend glue in strict TypeScript, and knowledge artifacts in markdown and static indexes tracked by git. A future `m3` workflow will ingest content into `knowledge/`, generate indexes at build time, and expose that knowledge through the approved Traverse v0.1 app-consumable runtime, browser consumer, and MCP release surfaces.
 
 ## Milestones
 
@@ -35,7 +35,7 @@ Roadmap source: [SPEC.md](SPEC.md#8-milestones) and [GitHub Project 3](https://g
 |---|---|
 | Business logic | Rust to WASM |
 | MCP interface | WASM MCP module |
-| Runtime model | Traverse / UMA |
+| Runtime model | Traverse v0.1 / UMA |
 | UI | Web Components + PWA shell |
 | Scripting | TypeScript |
 | Knowledge format | Markdown + Mermaid + static JSON |

--- a/SPEC.md
+++ b/SPEC.md
@@ -42,7 +42,7 @@ Anyone can fork it, fill it with their own knowledge, and run their own instance
 |---|---|---|
 | Business logic | **Rust → WASM** | Portable, safe, fast. Runs anywhere. |
 | WASM runtime | **Wasmtime** (CLI/server) / **browser native** | Same module, different host |
-| Runtime model | **Traverse / UMA** | Contract-driven, governed, explainable |
+| Runtime model | **Traverse v0.1 / UMA** | Contract-driven, governed, explainable release surface |
 | MCP interface | **WASM MCP module** | Portable MCP server compiled to WASM |
 
 ### Frontend
@@ -166,6 +166,17 @@ idea → /openspec:proposal → proposal.md + design.md + tasks.md + spec delta
 - A PR that drifts from the approved spec must update the spec first (new proposal cycle).
 - Spec changes require explicit review — they are not incidental to code review.
 - The spec is the contract. If code and spec disagree, the spec wins.
+
+### Traverse integration baseline
+
+youaskm3 integrates with Traverse through documented public release surfaces instead of private Traverse internals. The current baseline is the Traverse v0.1 app-consumable release path:
+
+- versioned consumer bundle: Traverse `docs/app-consumable-consumer-bundle.md`
+- browser-hosted path: Traverse browser consumer package and browser adapter docs
+- MCP-facing path: Traverse `traverse-mcp` stdio server and MCP library surface
+- validation path: Traverse `youaskm3` integration, compatibility conformance, published artifact, and real shell validation scripts
+
+Roadmap work that touches runtime, MCP, browser hosting, or fork-and-run setup must pin an approved Traverse release pairing and include the relevant Traverse validation path.
 
 ### Spec format (OpenSpec)
 
@@ -293,17 +304,19 @@ Dual-licensed: **MIT** and **Apache-2.0**. Users choose.
 - [ ] Spec: `openspec/specs/mcp-interface/spec.md`
 - [ ] `contracts/mcp-tools.json` — UMA contracts for all MCP tools
 - [ ] `youaskm3-search` crate: WASM vector search
-- [ ] `youaskm3-mcp` crate: WASM MCP server module
-- [ ] MCP tools: `search`, `remember`, `recall`, `connect`
-- [ ] Runs in browser (browser WASM), CLI (wasmtime), edge
-- [ ] Built on Traverse runtime model
+- [ ] Traverse v0.1 release pairing pinned for runtime, browser consumer, and MCP surfaces
+- [ ] `youaskm3-mcp` crate acts as a thin integration adapter over the supported Traverse MCP/library surface where possible
+- [ ] MCP tools: `search`, `remember`, `recall`, `connect` mapped to contract-defined Traverse-compatible tool semantics
+- [ ] Runs through documented Traverse MCP/CLI validation paths before claiming browser, CLI, or edge compatibility
+- [ ] Built on the Traverse v0.1 app-consumable runtime model, not a bespoke runtime fork
 - [ ] 100% test coverage on all crates
 
 ### M3 — Chat interface *(v0.3)*
 - [ ] Spec: `openspec/specs/pwa-shell/spec.md`
 - [ ] PWA shell: installable, offline-capable
 - [ ] Web Components: `<m3-chat>`, `<m3-result>`, `<m3-source>`
-- [ ] WASM MCP runs client-side — zero server cost
+- [ ] Browser-hosted runtime path consumes the Traverse browser consumer package/adapter or its approved release successor
+- [ ] WASM/MCP behavior is validated through the Traverse `youaskm3` real shell validation path
 - [ ] youaskm3.com serves author's instance
 - [ ] Claude API integration (configurable key)
 - [ ] Works with any MCP-compatible LLM
@@ -313,6 +326,7 @@ Dual-licensed: **MIT** and **Apache-2.0**. Users choose.
 - [ ] `m3 build` — generates index, compiles WASM, prepares site
 - [ ] `m3 sync` — incremental re-index on content changes
 - [ ] GitHub Actions template included in repo
+- [ ] Traverse release pairing and compatibility conformance commands documented for forked instances
 - [ ] One-command setup documented in README
 - [ ] Setup time target: under 15 minutes
 


### PR DESCRIPTION
## What this changes
Aligns the youaskm3 roadmap with the current Traverse framework state after reviewing the Traverse repo on April 21, 2026. The roadmap now treats Traverse as a versioned public release surface rather than a vague runtime model, and updates M2-M4 to reference the consumer bundle, browser adapter, MCP surface, and conformance validation path.

## Spec reference
openspec/specs/mcp-interface/spec.md - Preserve portability across hosts
openspec/specs/pwa-shell/spec.md - Provide an installable browser shell

## Spec delta (if spec changed)
Updates SPEC.md roadmap/source-of-truth language to add the Traverse integration baseline and revise affected M2-M4 milestone criteria.

## Test coverage
Docs-only change. npm run format was attempted, but the command currently fails on pre-existing baseline formatting issues across multiple repo files, not only this diff.

## Breaking changes
none

## Issue
closes #33
