### PR TITLE
docs: define knowledge index generation flow

### DIFF
--- a/docs/knowledge-index-generation.md
+++ b/docs/knowledge-index-generation.md
@@ -1,0 +1,53 @@
+# Knowledge Index Generation
+
+This document defines the M1 index generation flow for `knowledge/index.md`. It is intentionally a contract before a full implementation: generated search artifacts must follow this shape so later Rust, CLI, and MCP work can depend on stable repository semantics.
+
+## Inputs
+
+The generator reads processed markdown artifacts from these directories:
+
+| Directory | Included in search index | Notes |
+|---|---:|---|
+| `knowledge/books/` | yes | Book directories use a local `index.md` plus chapter files such as `ch01-*.md`. |
+| `knowledge/papers/` | yes | Paper directories use a local `index.md` and optional section files. |
+| `knowledge/blog/` | yes | Blog posts are single markdown files named by slug. |
+| `knowledge/inputs/` | no | Raw captures stay pending until an ingest tool promotes them into a processed category. |
+
+Each processed artifact must preserve source traceability in markdown metadata or a `## Source` section. The first supported promotion path is `tools/pdf2m3/pdf2m3.sh`, which renders PDF text into structured markdown suitable for `knowledge/papers/` or `knowledge/books/`.
+
+## Outputs
+
+The generator owns the managed section in `knowledge/index.md` between:
+
+```md
+<!-- youaskm3:index:start -->
+<!-- youaskm3:index:end -->
+```
+
+The managed section contains:
+
+| Section | Content |
+|---|---|
+| Summary | Counts for processed books, papers, blog posts, and pending raw inputs. |
+| Books | Stable links to each book directory index. |
+| Papers | Stable links to each paper directory index. |
+| Blog | Stable links to each blog markdown file. |
+| Pending Inputs | Counts and paths for raw captures that still need ingest. |
+
+Ordering is deterministic: category order is books, papers, blog, then pending inputs; entries inside each category sort by repository-relative path using bytewise ascending order.
+
+## Trigger Points
+
+Index generation runs in three places:
+
+| Trigger | Expected behavior |
+|---|---|
+| Local ingest | `m3 add` promotes content, then refreshes `knowledge/index.md` before returning. |
+| Pull request validation | CI verifies the managed index is current once the generator exists. |
+| Nightly rebuild | `.github/workflows/index.yml` refreshes derived knowledge artifacts on `main`. |
+
+Until the generator is implemented, contributors must update the managed section manually when adding processed knowledge artifacts. Manual edits should follow the same ordering and source-traceability rules so the later generator can adopt the file without churn.
+
+## Non-Goals
+
+This M1 flow does not define vector embeddings, federation-wide index exchange, browser storage, or MCP search execution. Those belong to later `knowledge-search`, `federation`, and `mcp-interface` implementation tickets.

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -14,3 +14,18 @@ This directory is the source-controlled knowledge store for a youaskm3 instance.
 ## Ingest path
 
 `m3 add` will populate this structure in M1. Until then, this index defines the intended layout and keeps the repository structure explicit for contributors.
+
+## Generated Map
+
+The generated portion of this file is managed by the M1 knowledge index flow documented in [docs/knowledge-index-generation.md](../docs/knowledge-index-generation.md). Until the generator lands, contributors should update this section manually using the same deterministic ordering rules.
+
+<!-- youaskm3:index:start -->
+| Category | Processed entries | Pending inputs |
+|---|---:|---:|
+| `books/` | 0 | 0 |
+| `papers/` | 0 | 0 |
+| `blog/` | 0 | 0 |
+| `inputs/` | 0 | 0 |
+
+No processed knowledge artifacts have been committed yet.
+<!-- youaskm3:index:end -->

--- a/openspec/specs/knowledge-search/spec.md
+++ b/openspec/specs/knowledge-search/spec.md
@@ -25,3 +25,23 @@ The system SHALL preserve enough source context in search responses to let downs
 - GIVEN multiple knowledge files match a query
 - WHEN the search capability ranks and returns results
 - THEN each result can be associated with a source path or equivalent metadata
+
+### Requirement: Generate a deterministic knowledge index
+
+The system SHALL define a deterministic generation flow for `knowledge/index.md` that derives the master map from processed knowledge content rather than hand-maintained search metadata.
+
+#### Scenario: Refresh the master knowledge map
+
+- GIVEN processed markdown artifacts exist under `knowledge/books/`, `knowledge/papers/`, and `knowledge/blog/`
+- WHEN the index generation flow runs
+- THEN `knowledge/index.md` is updated from those artifacts with stable ordering, source paths, and category counts
+
+### Requirement: Separate raw captures from searchable artifacts
+
+The system SHALL exclude raw captures under `knowledge/inputs/` from the searchable index until an ingest workflow promotes them into a processed knowledge category.
+
+#### Scenario: Leave captured notes out of search results
+
+- GIVEN a raw transcript is stored under `knowledge/inputs/transcripts/`
+- WHEN the knowledge index is regenerated
+- THEN the transcript is reported as pending ingest instead of being treated as searchable knowledge


### PR DESCRIPTION
## Summary
- define deterministic knowledge index generation rules and trigger points
- update the knowledge-search OpenSpec with generated-index requirements
- add a managed section to knowledge/index.md for the future generator

## Spec reference
- openspec/specs/knowledge-search/spec.md
- SPEC.md section 10
- SPEC.md section 8 (M1 - Knowledge layer)

## Validation
- bash scripts/smoke.sh

Closes #8