### PR TITLE
feat: add url ingest pipeline

### DIFF
--- a/crates/youaskm3-ingest/examples/url2m3.rs
+++ b/crates/youaskm3-ingest/examples/url2m3.rs
@@ -1,0 +1,76 @@
+use std::{env, error::Error, fs, path::Path};
+
+use youaskm3_ingest::{UrlMarkdownInput, derive_title_from_url, render_url_markdown};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("url2m3 example failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut arguments = env::args().skip(1);
+    let input_path = arguments
+        .next()
+        .ok_or("usage: cargo run -p youaskm3-ingest --example url2m3 -- <input.txt> <output.md> <source-url> [title]")?;
+    let output_path = arguments
+        .next()
+        .ok_or("usage: cargo run -p youaskm3-ingest --example url2m3 -- <input.txt> <output.md> <source-url> [title]")?;
+    let source_url = arguments
+        .next()
+        .ok_or("usage: cargo run -p youaskm3-ingest --example url2m3 -- <input.txt> <output.md> <source-url> [title]")?;
+    let title = arguments
+        .next()
+        .unwrap_or_else(|| derive_title_from_url(&source_url));
+
+    let captured_text = fs::read_to_string(&input_path)?;
+    let markdown = render_url_markdown(&UrlMarkdownInput {
+        title,
+        source_url,
+        captured_text,
+    })?;
+
+    ensure_output_directory(Path::new(&output_path))?;
+
+    fs::write(output_path, markdown)?;
+    Ok(())
+}
+
+fn ensure_output_directory(output_path: &Path) -> Result<(), Box<dyn Error>> {
+    if let Some(parent) = output_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_output_directory;
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    #[test]
+    fn output_in_current_directory_does_not_require_parent_creation() {
+        assert!(ensure_output_directory(PathBuf::from("out.md").as_path()).is_ok());
+    }
+
+    #[test]
+    fn nested_output_path_creates_missing_parent_directory() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |duration| duration.as_nanos());
+        let root = std::env::temp_dir().join(format!("youaskm3-url2m3-{unique}"));
+        let output_path = root.join("nested").join("out.md");
+
+        assert!(ensure_output_directory(&output_path).is_ok());
+        assert!(root.join("nested").is_dir());
+        assert!(fs::remove_dir_all(root).is_ok());
+    }
+}

--- a/crates/youaskm3-ingest/src/lib.rs
+++ b/crates/youaskm3-ingest/src/lib.rs
@@ -20,6 +20,17 @@ pub struct PdfMarkdownInput {
     pub extracted_text: String,
 }
 
+/// Metadata and captured text needed to render a URL-backed markdown artifact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UrlMarkdownInput {
+    /// Human-readable title for the generated document.
+    pub title: String,
+    /// Source URL used for traceability.
+    pub source_url: String,
+    /// Captured text content fetched from the URL.
+    pub captured_text: String,
+}
+
 /// Errors returned when PDF ingest input is incomplete.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PdfMarkdownError {
@@ -42,6 +53,29 @@ impl fmt::Display for PdfMarkdownError {
 }
 
 impl std::error::Error for PdfMarkdownError {}
+
+/// Errors returned when URL ingest input is incomplete.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UrlMarkdownError {
+    /// The title was empty after trimming.
+    MissingTitle,
+    /// The source URL was empty after trimming.
+    MissingSourceUrl,
+    /// The captured text was empty after trimming.
+    MissingCapturedText,
+}
+
+impl fmt::Display for UrlMarkdownError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingTitle => f.write_str("missing URL title"),
+            Self::MissingSourceUrl => f.write_str("missing source URL"),
+            Self::MissingCapturedText => f.write_str("missing captured URL text"),
+        }
+    }
+}
+
+impl std::error::Error for UrlMarkdownError {}
 
 /// Markdown content ready to be split into index-friendly chunks.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -141,6 +175,36 @@ pub fn render_pdf_markdown(input: &PdfMarkdownInput) -> Result<String, PdfMarkdo
     ))
 }
 
+/// Builds a stable markdown artifact from URL-captured text.
+///
+/// # Errors
+///
+/// Returns an error if the title, source URL, or captured text is empty after trimming.
+pub fn render_url_markdown(input: &UrlMarkdownInput) -> Result<String, UrlMarkdownError> {
+    let title = input.title.trim();
+    let source_url = input.source_url.trim();
+    let captured_text = input.captured_text.trim();
+
+    if title.is_empty() {
+        return Err(UrlMarkdownError::MissingTitle);
+    }
+
+    if source_url.is_empty() {
+        return Err(UrlMarkdownError::MissingSourceUrl);
+    }
+
+    if captured_text.is_empty() {
+        return Err(UrlMarkdownError::MissingCapturedText);
+    }
+
+    let paragraphs = normalize_pdf_text(captured_text);
+    let body = paragraphs.join("\n\n");
+
+    Ok(format!(
+        "# {title}\n\n## Source\n\n- type: url\n- url: {source_url}\n- ingested_by: `url2m3`\n\n## Captured Text\n\n{body}\n"
+    ))
+}
+
 /// Derives a human-readable title from a PDF file path or file name.
 #[must_use]
 pub fn derive_title_from_path(path: &str) -> String {
@@ -153,6 +217,35 @@ pub fn derive_title_from_path(path: &str) -> String {
         .unwrap_or(trimmed);
 
     let normalized = file_name
+        .chars()
+        .map(|character| {
+            if matches!(character, '-' | '_' | '.') {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>();
+
+    normalized.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Derives a human-readable title from a URL.
+#[must_use]
+pub fn derive_title_from_url(url: &str) -> String {
+    let trimmed = url.trim().trim_end_matches('/');
+    let without_fragment = trimmed.split('#').next().unwrap_or(trimmed);
+    let without_query = without_fragment
+        .split('?')
+        .next()
+        .unwrap_or(without_fragment);
+    let last_segment = without_query
+        .rsplit('/')
+        .next()
+        .filter(|segment| !segment.is_empty())
+        .unwrap_or("url capture");
+
+    let normalized = last_segment
         .chars()
         .map(|character| {
             if matches!(character, '-' | '_' | '.') {
@@ -307,8 +400,9 @@ fn render_source_line(source_path: &str) -> String {
 mod tests {
     use super::{
         ChunkingOptions, MarkdownChunk, MarkdownChunkError, MarkdownChunkInput, PdfMarkdownError,
-        PdfMarkdownInput, chunk_markdown, crate_name, derive_title_from_path, normalize_pdf_text,
-        render_pdf_markdown,
+        PdfMarkdownInput, UrlMarkdownError, UrlMarkdownInput, chunk_markdown, crate_name,
+        derive_title_from_path, derive_title_from_url, normalize_pdf_text, render_pdf_markdown,
+        render_url_markdown,
     };
 
     #[test]
@@ -322,6 +416,15 @@ mod tests {
             derive_title_from_path("ref/Universal_Microservices-Architecture.pdf"),
             "Universal Microservices Architecture"
         );
+    }
+
+    #[test]
+    fn derive_title_from_url_uses_last_path_segment() {
+        assert_eq!(
+            derive_title_from_url("https://example.com/posts/portable-knowledge.html?ref=m3"),
+            "portable knowledge html"
+        );
+        assert_eq!(derive_title_from_url("https://example.com/"), "example com");
     }
 
     #[test]
@@ -364,6 +467,19 @@ mod tests {
         let markdown = markdown_result.unwrap_or_default();
 
         assert!(markdown.contains("- path: notes/`quoted`.pdf\n"));
+    }
+
+    #[test]
+    fn render_url_markdown_includes_traceability_metadata() {
+        let input = UrlMarkdownInput {
+            title: "Portable Knowledge".to_string(),
+            source_url: "https://example.com/portable-knowledge".to_string(),
+            captured_text: "First paragraph.\nStill first paragraph.\n\nSecond paragraph."
+                .to_string(),
+        };
+        let expected = "# Portable Knowledge\n\n## Source\n\n- type: url\n- url: https://example.com/portable-knowledge\n- ingested_by: `url2m3`\n\n## Captured Text\n\nFirst paragraph. Still first paragraph.\n\nSecond paragraph.\n";
+
+        assert_eq!(render_url_markdown(&input), Ok(expected.to_string()));
     }
 
     #[test]
@@ -421,6 +537,49 @@ mod tests {
         assert_eq!(
             PdfMarkdownError::MissingExtractedText.to_string(),
             "missing extracted PDF text"
+        );
+    }
+
+    #[test]
+    fn render_url_markdown_rejects_incomplete_input() {
+        let valid = UrlMarkdownInput {
+            title: "Example".to_string(),
+            source_url: "https://example.com".to_string(),
+            captured_text: "Body.".to_string(),
+        };
+
+        assert_eq!(
+            render_url_markdown(&UrlMarkdownInput {
+                title: " ".to_string(),
+                ..valid.clone()
+            }),
+            Err(UrlMarkdownError::MissingTitle)
+        );
+        assert_eq!(
+            UrlMarkdownError::MissingTitle.to_string(),
+            "missing URL title"
+        );
+        assert_eq!(
+            render_url_markdown(&UrlMarkdownInput {
+                source_url: " ".to_string(),
+                ..valid.clone()
+            }),
+            Err(UrlMarkdownError::MissingSourceUrl)
+        );
+        assert_eq!(
+            UrlMarkdownError::MissingSourceUrl.to_string(),
+            "missing source URL"
+        );
+        assert_eq!(
+            render_url_markdown(&UrlMarkdownInput {
+                captured_text: " ".to_string(),
+                ..valid
+            }),
+            Err(UrlMarkdownError::MissingCapturedText)
+        );
+        assert_eq!(
+            UrlMarkdownError::MissingCapturedText.to_string(),
+            "missing captured URL text"
         );
     }
 

--- a/scripts/m3.sh
+++ b/scripts/m3.sh
@@ -10,31 +10,55 @@ usage() {
   echo "Usage: ./scripts/m3.sh {add|build|test|lint|smoke|status}" >&2
 }
 
+slugify_url() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's#^https?://##; s#[^a-z0-9]+#-#g; s#^-+##; s#-+$##'
+}
+
 run_add() {
-  if [[ "$#" -ne 1 ]]; then
-    echo "Usage: ./scripts/m3.sh add <file.pdf>" >&2
+  if [[ "$#" -lt 1 || "$#" -gt 2 ]]; then
+    echo "Usage: ./scripts/m3.sh add <file.pdf|url> [title]" >&2
     exit 1
   fi
 
   local source_path="$1"
   local source_name="${source_path##*/}"
   local source_stem
+  local title="${2:-}"
 
-  case "$source_name" in
-    *.pdf|*.PDF)
-      source_stem="${source_name%.*}"
+  case "$source_path" in
+    http://*|https://*)
+      source_stem="$(slugify_url "$source_path")"
+      if [[ -n "$title" ]]; then
+        bash "$ROOT_DIR/tools/url2m3/url2m3.sh" \
+          "$source_path" \
+          "knowledge/inputs/articles/${source_stem}.md" \
+          "$title"
+      else
+        bash "$ROOT_DIR/tools/url2m3/url2m3.sh" \
+          "$source_path" \
+          "knowledge/inputs/articles/${source_stem}.md"
+      fi
       ;;
     *)
-      echo "m3 add currently routes PDF files through tools/pdf2m3/pdf2m3.sh." >&2
-      echo "Use a .pdf input for this M1 slice." >&2
-      exit 1
+      case "$source_name" in
+        *.pdf|*.PDF)
+          source_stem="${source_name%.*}"
+          ;;
+        *)
+          echo "m3 add currently routes PDF files and HTTP(S) URLs." >&2
+          echo "Use a .pdf input or URL for this M1 slice." >&2
+          exit 1
+          ;;
+      esac
+
+      bash "$ROOT_DIR/tools/pdf2m3/pdf2m3.sh" \
+        "$source_path" \
+        "knowledge/papers/${source_stem}/index.md" \
+        "$source_path"
       ;;
   esac
-
-  bash "$ROOT_DIR/tools/pdf2m3/pdf2m3.sh" \
-    "$source_path" \
-    "knowledge/papers/${source_stem}/index.md" \
-    "$source_path"
 }
 
 case "$COMMAND" in

--- a/tools/url2m3/README.md
+++ b/tools/url2m3/README.md
@@ -1,5 +1,24 @@
 # url2m3
 
-`url2m3` will ingest web articles, transcripts, and other URL-backed content into the markdown-oriented knowledge workspace.
+`url2m3` ingests web articles, transcripts, and other URL-backed content into the markdown-oriented knowledge workspace.
 
-> Coming in M1.
+The first M1 slice uses `curl` for capture and the `youaskm3-ingest` crate for deterministic markdown rendering. `m3 add` uses this path as the repo-level entry point for HTTP and HTTPS URLs and writes the result into `knowledge/inputs/articles/<slug>.md`.
+
+## Usage
+
+```bash
+tools/url2m3/url2m3.sh <url> <output.md> [title]
+```
+
+Example:
+
+```bash
+tools/url2m3/url2m3.sh https://example.com/post knowledge/inputs/articles/example-com-post.md
+./scripts/m3.sh add https://example.com/post
+```
+
+The generated markdown includes:
+
+- a document title derived from the URL or supplied title
+- source URL traceability metadata
+- normalized captured text grouped into markdown paragraphs

--- a/tools/url2m3/url2m3.sh
+++ b/tools/url2m3/url2m3.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+if [[ "$#" -lt 2 || "$#" -gt 3 ]]; then
+  echo "Usage: tools/url2m3/url2m3.sh <url> <output.md> [title]" >&2
+  exit 1
+fi
+
+require_cmd cargo
+require_cmd curl
+
+SOURCE_URL="$1"
+OUTPUT_MD="$2"
+TITLE="${3:-}"
+TEMP_TEXT="$(mktemp)"
+trap 'rm -f "$TEMP_TEXT"' EXIT
+
+cd "$ROOT_DIR"
+
+curl -LsS "$SOURCE_URL" > "$TEMP_TEXT"
+
+if [[ -n "$TITLE" ]]; then
+  cargo run --quiet -p youaskm3-ingest --example url2m3 -- "$TEMP_TEXT" "$OUTPUT_MD" "$SOURCE_URL" "$TITLE"
+else
+  cargo run --quiet -p youaskm3-ingest --example url2m3 -- "$TEMP_TEXT" "$OUTPUT_MD" "$SOURCE_URL"
+fi
+
+echo "Generated markdown artifact at ${OUTPUT_MD}"


### PR DESCRIPTION
## Summary
- add deterministic URL-backed markdown rendering to youaskm3-ingest
- add a repo-local tools/url2m3/url2m3.sh wrapper and example entrypoint
- route m3 add through url2m3 for HTTP(S) inputs and document the workflow

## Spec reference
- openspec/specs/knowledge-ingest/spec.md
- SPEC.md section 8 (M1 - Knowledge layer)
- SPEC.md section 10

## Validation
- cargo run --quiet -p youaskm3-ingest --example url2m3 -- <tmp-input> <tmp-output> <source-url>
- bash scripts/smoke.sh

Closes #9