### PR TITLE
feat: add installable PWA shell baseline

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   deploy:
-    name: Deploy Placeholder Site
+    name: Deploy PWA Shell
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -29,7 +29,7 @@ jobs:
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
 
-      - name: Upload placeholder site artifact
+      - name: Upload PWA shell artifact
         uses: actions/upload-pages-artifact@v4
         with:
           path: app/site

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Most personal knowledge tooling traps context inside proprietary silos, hosted b
 
 > Coming in M4. This milestone prepares the repository, specs, toolchain, and validation flow so a future contributor can implement the one-command setup path with confidence.
 
+## PWA shell validation
+
+The current M3 slice ships an installable static shell under `app/site/`. To validate it locally:
+
+- run `bash scripts/pwa-shell-smoke.sh`
+- serve `app/site/` with a static file server such as `python3 -m http.server --directory app/site 4173`
+- open the served page in a browser and confirm the manifest and standalone shell are recognized
+
 ## How it works
 
 The system keeps specs in `openspec/specs/`, business logic in Rust crates that compile to `wasm32-wasip1`, frontend glue in strict TypeScript, and knowledge artifacts in markdown and static indexes tracked by git. A future `m3` workflow will ingest content into `knowledge/`, generate indexes at build time, and expose that knowledge through the approved Traverse v0.1 app-consumable runtime, browser consumer, and MCP release surfaces.

--- a/app/pwa/manifest.webmanifest
+++ b/app/pwa/manifest.webmanifest
@@ -1,9 +1,0 @@
-{
-  "name": "youaskm3",
-  "short_name": "youaskm3",
-  "start_url": "/",
-  "display": "standalone",
-  "background_color": "#f6f2ea",
-  "theme_color": "#1f3c34",
-  "description": "Portable personal knowledge layer shell for youaskm3."
-}

--- a/app/site/icon.svg
+++ b/app/site/icon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">youaskm3 icon</title>
+  <desc id="desc">Rounded square knowledge shell icon with a layered m3 monogram.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#17352f" />
+      <stop offset="100%" stop-color="#29584f" />
+    </linearGradient>
+    <linearGradient id="ink" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f7f0e3" />
+      <stop offset="100%" stop-color="#d6c3a1" />
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="56" fill="url(#bg)" />
+  <path
+    d="M53 171V83h27l27 44 27-44h27v88h-24v-49l-22 35h-16l-22-35v49Zm100 0V83h28l27 44 27-44h-11"
+    fill="none"
+    stroke="url(#ink)"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="17"
+  />
+</svg>

--- a/app/site/index.html
+++ b/app/site/index.html
@@ -3,12 +3,247 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#17352f" />
+    <meta
+      name="description"
+      content="Installable offline shell for the youaskm3 knowledge interface."
+    />
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="icon" href="./icon.svg" type="image/svg+xml" />
     <title>youaskm3</title>
+    <style>
+      :root {
+        --bg: #f4efe4;
+        --paper: rgba(255, 252, 246, 0.9);
+        --ink: #17352f;
+        --muted: #587168;
+        --line: rgba(23, 53, 47, 0.14);
+        --accent: #bd8b39;
+        --accent-soft: rgba(189, 139, 57, 0.15);
+        --shadow: 0 24px 80px rgba(23, 53, 47, 0.12);
+        --radius: 28px;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: Georgia, "Times New Roman", serif;
+        color: var(--ink);
+        background:
+          radial-gradient(circle at top left, rgba(189, 139, 57, 0.18), transparent 28%),
+          linear-gradient(180deg, #fbf7f0 0%, var(--bg) 100%);
+      }
+
+      .shell {
+        width: min(1100px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 28px 0 40px;
+      }
+
+      .hero,
+      .panel {
+        backdrop-filter: blur(18px);
+        background: var(--paper);
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        box-shadow: var(--shadow);
+      }
+
+      .hero {
+        padding: 28px;
+      }
+
+      .eyebrow {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        padding: 8px 12px;
+        border-radius: 999px;
+        background: var(--accent-soft);
+        color: var(--ink);
+        font-size: 0.9rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+
+      h1 {
+        margin: 18px 0 12px;
+        font-size: clamp(2.4rem, 6vw, 4.8rem);
+        line-height: 0.94;
+        letter-spacing: -0.04em;
+      }
+
+      .hero p,
+      .panel p,
+      .sources li,
+      .status li {
+        color: var(--muted);
+        line-height: 1.6;
+      }
+
+      .hero-copy {
+        max-width: 44rem;
+        font-size: 1.08rem;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: 1.45fr 0.95fr;
+        gap: 18px;
+        margin-top: 18px;
+      }
+
+      .panel {
+        padding: 24px;
+      }
+
+      .panel h2 {
+        margin: 0 0 14px;
+        font-size: 1.1rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+
+      .prompt {
+        margin: 0 0 16px;
+        padding: 16px 18px;
+        border-radius: 20px;
+        background: #efe7d8;
+        font-size: 1rem;
+      }
+
+      .answer {
+        margin: 0;
+        padding: 18px 18px 0;
+        border-top: 1px solid var(--line);
+        font-size: 1.02rem;
+      }
+
+      .sources {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: grid;
+        gap: 12px;
+      }
+
+      .sources li {
+        padding: 16px;
+        border-radius: 20px;
+        background: rgba(23, 53, 47, 0.04);
+        border: 1px solid rgba(23, 53, 47, 0.08);
+      }
+
+      .source-label {
+        display: block;
+        margin-bottom: 6px;
+        font-size: 0.8rem;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--ink);
+      }
+
+      .status {
+        margin: 16px 0 0;
+        padding-left: 18px;
+      }
+
+      .install-note {
+        margin-top: 20px;
+        padding: 14px 16px;
+        border-radius: 18px;
+        background: rgba(23, 53, 47, 0.06);
+        border: 1px dashed rgba(23, 53, 47, 0.22);
+      }
+
+      @media (max-width: 860px) {
+        .grid {
+          grid-template-columns: 1fr;
+        }
+
+        .shell {
+          width: min(100% - 20px, 720px);
+          padding-top: 20px;
+        }
+
+        .hero,
+        .panel {
+          padding: 20px;
+        }
+      }
+    </style>
   </head>
   <body>
-    <main>
-      <h1>youaskm3</h1>
-      <p>Foundation site placeholder for GitHub Pages.</p>
+    <main class="shell">
+      <section class="hero">
+        <div class="eyebrow">M3 PWA Shell Baseline</div>
+        <h1>your knowledge, installable</h1>
+        <p class="hero-copy">
+          This shell is the static, offline-capable container for the future
+          chat experience. It already includes manifest metadata, service worker
+          registration, and reserved surfaces for answer rendering and source
+          attribution.
+        </p>
+        <div class="install-note">
+          Install from a supported browser after Pages deployment to validate
+          the standalone shell path for M3.
+        </div>
+      </section>
+
+      <section class="grid" aria-label="PWA shell preview">
+        <article class="panel">
+          <h2>Conversation Shell</h2>
+          <p class="prompt">What did I save about portable MCP clients?</p>
+          <div class="answer">
+            <p>
+              Portable MCP work in youaskm3 is designed to remain source-aware,
+              client-runnable, and hosted as static assets instead of depending
+              on a bespoke server runtime.
+            </p>
+            <p>
+              This placeholder answer proves the shell can reserve a stable
+              response area while later milestones wire in the real runtime and
+              components.
+            </p>
+          </div>
+        </article>
+
+        <aside class="panel">
+          <h2>Sources</h2>
+          <ul class="sources">
+            <li>
+              <span class="source-label">Spec</span>
+              <strong>openspec/specs/mcp-interface/spec.md</strong>
+              <div>Defines the contract-shaped MCP surface for knowledge tools.</div>
+            </li>
+            <li>
+              <span class="source-label">Roadmap</span>
+              <strong>SPEC.md, M3 - Chat interface</strong>
+              <div>Requires an installable shell that can host the future client experience.</div>
+            </li>
+          </ul>
+
+          <h2 style="margin-top: 22px">Offline Status</h2>
+          <ul class="status">
+            <li>Manifest linked from the served HTML shell.</li>
+            <li>Service worker registers and caches the shell assets.</li>
+            <li>Static assets stay compatible with GitHub Pages deployment.</li>
+          </ul>
+        </aside>
+      </section>
     </main>
+    <script>
+      if ("serviceWorker" in navigator) {
+        window.addEventListener("load", () => {
+          navigator.serviceWorker.register("./sw.js").catch((error) => {
+            console.error("Service worker registration failed", error);
+          });
+        });
+      }
+    </script>
   </body>
 </html>

--- a/app/site/manifest.webmanifest
+++ b/app/site/manifest.webmanifest
@@ -1,0 +1,18 @@
+{
+  "name": "youaskm3",
+  "short_name": "youaskm3",
+  "start_url": "./",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#f4efe4",
+  "theme_color": "#17352f",
+  "description": "Portable personal knowledge layer shell for youaskm3.",
+  "icons": [
+    {
+      "src": "./icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/app/site/sw.js
+++ b/app/site/sw.js
@@ -1,0 +1,56 @@
+const CACHE_NAME = "youaskm3-pwa-shell-v1";
+const OFFLINE_ASSETS = [
+  "./",
+  "./index.html",
+  "./manifest.webmanifest",
+  "./icon.svg",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(OFFLINE_ASSETS)),
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key !== CACHE_NAME)
+          .map((key) => caches.delete(key)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.method !== "GET") {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+
+      return fetch(event.request)
+        .then((response) => {
+          if (!response.ok) {
+            return response;
+          }
+
+          const responseClone = response.clone();
+          caches
+            .open(CACHE_NAME)
+            .then((cache) => cache.put(event.request, responseClone));
+
+          return response;
+        })
+        .catch(() => caches.match("./index.html"));
+    }),
+  );
+});

--- a/scripts/pwa-shell-smoke.sh
+++ b/scripts/pwa-shell-smoke.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SITE_DIR="$ROOT_DIR/app/site"
+HTML_FILE="$SITE_DIR/index.html"
+MANIFEST_FILE="$SITE_DIR/manifest.webmanifest"
+SERVICE_WORKER_FILE="$SITE_DIR/sw.js"
+ICON_FILE="$SITE_DIR/icon.svg"
+
+require_file() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    echo "PWA shell smoke failed: missing file $path" >&2
+    exit 1
+  fi
+}
+
+require_pattern() {
+  local pattern="$1"
+  local path="$2"
+  local message="$3"
+
+  if ! grep -Eq "$pattern" "$path"; then
+    echo "PWA shell smoke failed: $message" >&2
+    exit 1
+  fi
+}
+
+require_file "$HTML_FILE"
+require_file "$MANIFEST_FILE"
+require_file "$SERVICE_WORKER_FILE"
+require_file "$ICON_FILE"
+
+require_pattern '<link rel="manifest" href="\./manifest\.webmanifest"' "$HTML_FILE" "index.html is not linked to the served manifest."
+require_pattern 'navigator\.serviceWorker\.register\("\./sw\.js"\)' "$HTML_FILE" "index.html does not register the service worker."
+require_pattern '"display":[[:space:]]*"standalone"' "$MANIFEST_FILE" "manifest is not installable."
+require_pattern '"icons":[[:space:]]*\[' "$MANIFEST_FILE" "manifest is missing icons."
+require_pattern 'CACHE_NAME = "youaskm3-pwa-shell-v1"' "$SERVICE_WORKER_FILE" "service worker cache name is missing."
+require_pattern 'caches\.match\("\./index\.html"\)' "$SERVICE_WORKER_FILE" "service worker is missing the offline document fallback."
+
+echo "PWA shell smoke passed."

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -44,6 +44,9 @@ cd "$ROOT_DIR"
 echo "Validating m3 add ingest routing..."
 bash ./scripts/m3-add-smoke.sh
 
+echo "Validating PWA shell assets..."
+bash ./scripts/pwa-shell-smoke.sh
+
 echo "Running lint checks..."
 bash ./scripts/lint.sh
 


### PR DESCRIPTION
## What this changes
Ships the first real M3 PWA shell baseline out of `app/site/` instead of a placeholder page.

- adds an installable manifest served from the Pages artifact directory
- registers a service worker with cached shell assets and offline document fallback
- turns the static page into a source-aware chat shell placeholder with reserved answer/source surfaces
- adds `scripts/pwa-shell-smoke.sh` and wires it into the repo smoke flow
- documents local shell validation in the README

## Spec reference
openspec/specs/pwa-shell/spec.md - Provide an installable browser shell

## Spec delta (if spec changed)
none

## Test coverage
- `bash scripts/pwa-shell-smoke.sh`
- `npm run lint`
- `npm test -- --run app/components/index.test.ts app/components/mcp-tools-contract.test.ts`
- `bash scripts/smoke.sh`

## Breaking changes
none

## Issue
closes #15
