### PR TITLE
feat: add m3 build pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ The first M4 slice now bootstraps local instance metadata and knowledge scaffold
 
 That command initializes `app/site/author-instance.json`, `app/site/provider-config.json`, and the tracked `knowledge/` layout. The full fork-and-run flow, including `m3 build` and `m3 sync`, continues in later M4 tickets.
 
+The current `m3 build` slice now prepares deployable static artifacts as well:
+
+```bash
+./scripts/m3.sh build
+```
+
+That command generates `app/site/search-index.json` and `app/site/build-manifest.json`, then compiles the native and `wasm32-wasip1` workspace targets.
+
 ## PWA shell validation
 
 The current M3 slice ships an installable static shell under `app/site/`. To validate it locally:

--- a/app/site/build-manifest.json
+++ b/app/site/build-manifest.json
@@ -1,0 +1,12 @@
+{
+  "instanceId": "youaskm3-author",
+  "shellUrl": "https://enricopiovesan.github.io/youaskm3/",
+  "knowledgeDocumentCount": 0,
+  "pendingInputCount": 0,
+  "artifacts": [
+    "app/site/search-index.json",
+    "app/site/build-manifest.json",
+    "app/site/author-instance.json",
+    "app/site/provider-config.json"
+  ]
+}

--- a/app/site/search-index.json
+++ b/app/site/search-index.json
@@ -1,0 +1,8 @@
+{
+  "instanceId": "youaskm3-author",
+  "title": "youaskm3 author instance",
+  "shellUrl": "https://enricopiovesan.github.io/youaskm3/",
+  "documents": [
+
+  ]
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,8 +11,77 @@ require_cmd() {
 }
 
 require_cmd cargo
+require_cmd ruby
 
 cd "$ROOT_DIR"
+
+echo "Generating static knowledge and site artifacts..."
+ruby <<'RUBY'
+require "json"
+
+root = Dir.pwd
+site_dir = File.join(root, "app/site")
+knowledge_dir = File.join(root, "knowledge")
+author_instance_path = File.join(site_dir, "author-instance.json")
+
+def trimmed_excerpt(markdown)
+  markdown
+    .each_line
+    .map(&:strip)
+    .reject(&:empty?)
+    .reject { |line| line.start_with?("#", "-", "|", "<!--") }
+    .first
+    .to_s[0, 180]
+end
+
+def document_title(markdown_path, markdown)
+  heading = markdown.each_line.map(&:strip).find { |line| line.start_with?("# ") }
+  return heading.delete_prefix("# ").strip unless heading.nil? || heading.empty?
+
+  File.basename(markdown_path, ".md").tr("_-", "  ").split.join(" ")
+end
+
+author_instance = JSON.parse(File.read(author_instance_path))
+
+knowledge_documents = Dir.glob(File.join(knowledge_dir, "{books,papers,blog}/**/*.md")).sort.map do |path|
+  relative_path = path.delete_prefix("#{root}/")
+  markdown = File.read(path)
+  category = relative_path.split("/")[1]
+
+  {
+    "id" => relative_path.delete_suffix(".md").gsub("/", "--"),
+    "title" => document_title(path, markdown),
+    "source_path" => relative_path,
+    "category" => category,
+    "excerpt" => trimmed_excerpt(markdown)
+  }
+end
+
+pending_inputs = Dir.glob(File.join(knowledge_dir, "inputs/**/*")).sort.select { |path| File.file?(path) }
+
+search_index = {
+  "instanceId" => author_instance.fetch("instanceId"),
+  "title" => author_instance.fetch("title"),
+  "shellUrl" => author_instance.fetch("shellUrl"),
+  "documents" => knowledge_documents
+}
+
+build_manifest = {
+  "instanceId" => author_instance.fetch("instanceId"),
+  "shellUrl" => author_instance.fetch("shellUrl"),
+  "knowledgeDocumentCount" => knowledge_documents.length,
+  "pendingInputCount" => pending_inputs.length,
+  "artifacts" => [
+    "app/site/search-index.json",
+    "app/site/build-manifest.json",
+    "app/site/author-instance.json",
+    "app/site/provider-config.json"
+  ]
+}
+
+File.write(File.join(site_dir, "search-index.json"), JSON.pretty_generate(search_index) + "\n")
+File.write(File.join(site_dir, "build-manifest.json"), JSON.pretty_generate(build_manifest) + "\n")
+RUBY
 
 echo "Running native workspace build..."
 cargo build --locked --workspace

--- a/scripts/m3-build-smoke.sh
+++ b/scripts/m3-build-smoke.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+bash ./scripts/m3.sh build
+
+[[ -f app/site/search-index.json ]]
+[[ -f app/site/build-manifest.json ]]
+
+grep -q '"documents"' app/site/search-index.json
+grep -q '"artifacts"' app/site/build-manifest.json
+grep -q '"app/site/search-index.json"' app/site/build-manifest.json
+
+echo "m3 build smoke passed."

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -54,7 +54,7 @@ echo "Running lint checks..."
 bash ./scripts/lint.sh
 
 echo "Running build checks..."
-bash ./scripts/build.sh
+bash ./scripts/m3-build-smoke.sh
 
 echo "Running Rust tests..."
 bash ./scripts/test.sh


### PR DESCRIPTION
## Summary
- generate deployable site artifacts through `m3 build`
- add dedicated smoke validation for the build path
- document the current build flow in the README

## Spec Reference
- openspec/specs/knowledge-search/spec.md
- openspec/specs/mcp-interface/spec.md
- SPEC.md section 8 (M4 - Fork and run your own)

## Validation
- bash scripts/m3-build-smoke.sh
- bash scripts/smoke.sh

Closes #20