### PR TITLE
feat: add incremental m3 sync flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ The current `m3 build` slice now prepares deployable static artifacts as well:
 
 That command generates `app/site/search-index.json` and `app/site/build-manifest.json`, then compiles the native and `wasm32-wasip1` workspace targets.
 
+Incremental updates now have a dedicated path as well:
+
+```bash
+./scripts/m3.sh sync
+```
+
+`m3 sync` re-checks tracked knowledge and instance metadata, refreshes the generated JSON artifacts only when the source fingerprint changes, and skips the Rust rebuild path when nothing relevant changed.
+
 ## PWA shell validation
 
 The current M3 slice ships an installable static shell under `app/site/`. To validate it locally:

--- a/app/site/search-index.json
+++ b/app/site/search-index.json
@@ -2,6 +2,7 @@
   "instanceId": "youaskm3-author",
   "title": "youaskm3 author instance",
   "shellUrl": "https://enricopiovesan.github.io/youaskm3/",
+  "sourceFingerprint": "8049373a1a474a63d5d48700ba4ae23fff1fc6fe40ed96b30df11feed3ad8238",
   "documents": [
 
   ]

--- a/app/site/sync-state.json
+++ b/app/site/sync-state.json
@@ -1,15 +1,10 @@
 {
   "instanceId": "youaskm3-author",
-  "shellUrl": "https://enricopiovesan.github.io/youaskm3/",
   "sourceFingerprint": "8049373a1a474a63d5d48700ba4ae23fff1fc6fe40ed96b30df11feed3ad8238",
   "knowledgeDocumentCount": 0,
   "pendingInputCount": 0,
-  "artifacts": [
-    "app/site/search-index.json",
-    "app/site/build-manifest.json",
-    "app/site/sync-state.json",
-    "app/site/author-instance.json",
-    "app/site/provider-config.json"
+  "trackedSourcePaths": [
+    "app/site/author-instance.json"
   ],
   "sources": [
     {

--- a/docs/knowledge-index-generation.md
+++ b/docs/knowledge-index-generation.md
@@ -48,6 +48,21 @@ Index generation runs in three places:
 
 Until the generator is implemented, contributors must update the managed section manually when adding processed knowledge artifacts. Manual edits should follow the same ordering and source-traceability rules so the later generator can adopt the file without churn.
 
+## Incremental Sync Rules
+
+`m3 build` remains the full preparation path: it refreshes generated site artifacts and recompiles the Rust workspace for native and `wasm32-wasip1` targets.
+
+`m3 sync` is the incremental path for already-initialized instances:
+
+| Change | `m3 sync` behavior | Full rebuild required |
+|---|---|---:|
+| Processed markdown added, removed, or edited under `knowledge/books/`, `knowledge/papers/`, or `knowledge/blog/` | Recompute `app/site/search-index.json`, `app/site/build-manifest.json`, and `app/site/sync-state.json` | no |
+| Raw captures added or removed under `knowledge/inputs/` | Refresh counts and tracked pending-input paths in generated site artifacts | no |
+| `app/site/author-instance.json` changes | Refresh generated site artifacts so published metadata stays aligned | no |
+| Rust code, frontend shell code, or dependency changes | `m3 sync` does not rebuild binaries or static shell assets | yes |
+
+The incremental path is deterministic: it compares the current source fingerprint to the last generated `app/site/sync-state.json` and only rewrites artifacts when tracked inputs change. The sync state records every source path and content hash so later validations can trace exactly which files fed a generated artifact set.
+
 ## Non-Goals
 
 This M1 flow does not define vector embeddings, federation-wide index exchange, browser storage, or MCP search execution. Those belong to later `knowledge-search`, `federation`, and `mcp-interface` implementation tickets.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,72 +16,7 @@ require_cmd ruby
 cd "$ROOT_DIR"
 
 echo "Generating static knowledge and site artifacts..."
-ruby <<'RUBY'
-require "json"
-
-root = Dir.pwd
-site_dir = File.join(root, "app/site")
-knowledge_dir = File.join(root, "knowledge")
-author_instance_path = File.join(site_dir, "author-instance.json")
-
-def trimmed_excerpt(markdown)
-  markdown
-    .each_line
-    .map(&:strip)
-    .reject(&:empty?)
-    .reject { |line| line.start_with?("#", "-", "|", "<!--") }
-    .first
-    .to_s[0, 180]
-end
-
-def document_title(markdown_path, markdown)
-  heading = markdown.each_line.map(&:strip).find { |line| line.start_with?("# ") }
-  return heading.delete_prefix("# ").strip unless heading.nil? || heading.empty?
-
-  File.basename(markdown_path, ".md").tr("_-", "  ").split.join(" ")
-end
-
-author_instance = JSON.parse(File.read(author_instance_path))
-
-knowledge_documents = Dir.glob(File.join(knowledge_dir, "{books,papers,blog}/**/*.md")).sort.map do |path|
-  relative_path = path.delete_prefix("#{root}/")
-  markdown = File.read(path)
-  category = relative_path.split("/")[1]
-
-  {
-    "id" => relative_path.delete_suffix(".md").gsub("/", "--"),
-    "title" => document_title(path, markdown),
-    "source_path" => relative_path,
-    "category" => category,
-    "excerpt" => trimmed_excerpt(markdown)
-  }
-end
-
-pending_inputs = Dir.glob(File.join(knowledge_dir, "inputs/**/*")).sort.select { |path| File.file?(path) }
-
-search_index = {
-  "instanceId" => author_instance.fetch("instanceId"),
-  "title" => author_instance.fetch("title"),
-  "shellUrl" => author_instance.fetch("shellUrl"),
-  "documents" => knowledge_documents
-}
-
-build_manifest = {
-  "instanceId" => author_instance.fetch("instanceId"),
-  "shellUrl" => author_instance.fetch("shellUrl"),
-  "knowledgeDocumentCount" => knowledge_documents.length,
-  "pendingInputCount" => pending_inputs.length,
-  "artifacts" => [
-    "app/site/search-index.json",
-    "app/site/build-manifest.json",
-    "app/site/author-instance.json",
-    "app/site/provider-config.json"
-  ]
-}
-
-File.write(File.join(site_dir, "search-index.json"), JSON.pretty_generate(search_index) + "\n")
-File.write(File.join(site_dir, "build-manifest.json"), JSON.pretty_generate(build_manifest) + "\n")
-RUBY
+ruby ./scripts/generate-site-artifacts.rb
 
 echo "Running native workspace build..."
 cargo build --locked --workspace

--- a/scripts/generate-site-artifacts.rb
+++ b/scripts/generate-site-artifacts.rb
@@ -1,0 +1,114 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "digest"
+require "fileutils"
+require "json"
+
+root = File.expand_path("..", __dir__)
+output_dir = File.expand_path(ARGV[0] || File.join(root, "app/site"), root)
+knowledge_dir = File.join(root, "knowledge")
+author_instance_path = File.join(root, "app/site/author-instance.json")
+
+abort("Missing required file: app/site/author-instance.json") unless File.file?(author_instance_path)
+
+def trimmed_excerpt(markdown)
+  markdown
+    .each_line
+    .map(&:strip)
+    .reject(&:empty?)
+    .reject { |line| line.start_with?("#", "-", "|", "<!--") }
+    .first
+    .to_s[0, 180]
+end
+
+def document_title(markdown_path, markdown)
+  heading = markdown.each_line.map(&:strip).find { |line| line.start_with?("# ") }
+  return heading.delete_prefix("# ").strip unless heading.nil? || heading.empty?
+
+  File.basename(markdown_path, ".md").tr("_-", "  ").split.join(" ")
+end
+
+def normalize_relative_path(path, root)
+  path.delete_prefix("#{root}/")
+end
+
+def source_entry(path, root, kind)
+  relative_path = normalize_relative_path(path, root)
+
+  {
+    "path" => relative_path,
+    "kind" => kind,
+    "sha256" => Digest::SHA256.hexdigest(File.read(path))
+  }
+end
+
+author_instance = JSON.parse(File.read(author_instance_path))
+
+processed_document_paths = Dir.glob(File.join(knowledge_dir, "{books,papers,blog}/**/*.md")).sort
+pending_input_paths = Dir.glob(File.join(knowledge_dir, "inputs/**/*")).sort.select { |path| File.file?(path) }
+
+source_entries = [
+  source_entry(author_instance_path, root, "instance-manifest")
+]
+
+source_entries.concat(processed_document_paths.map { |path| source_entry(path, root, "processed-knowledge") })
+source_entries.concat(pending_input_paths.map { |path| source_entry(path, root, "pending-input") })
+
+source_fingerprint = Digest::SHA256.hexdigest(
+  source_entries.map { |entry| [entry.fetch("path"), entry.fetch("kind"), entry.fetch("sha256")].join(":") }.join("\n")
+)
+
+knowledge_documents = processed_document_paths.map do |path|
+  relative_path = normalize_relative_path(path, root)
+  markdown = File.read(path)
+  matching_source = source_entries.find { |entry| entry.fetch("path") == relative_path }
+  category = relative_path.split("/")[1]
+
+  {
+    "id" => relative_path.delete_suffix(".md").gsub("/", "--"),
+    "title" => document_title(path, markdown),
+    "source_path" => relative_path,
+    "category" => category,
+    "excerpt" => trimmed_excerpt(markdown),
+    "content_sha256" => matching_source.fetch("sha256")
+  }
+end
+
+search_index = {
+  "instanceId" => author_instance.fetch("instanceId"),
+  "title" => author_instance.fetch("title"),
+  "shellUrl" => author_instance.fetch("shellUrl"),
+  "sourceFingerprint" => source_fingerprint,
+  "documents" => knowledge_documents
+}
+
+build_manifest = {
+  "instanceId" => author_instance.fetch("instanceId"),
+  "shellUrl" => author_instance.fetch("shellUrl"),
+  "sourceFingerprint" => source_fingerprint,
+  "knowledgeDocumentCount" => knowledge_documents.length,
+  "pendingInputCount" => pending_input_paths.length,
+  "artifacts" => [
+    "app/site/search-index.json",
+    "app/site/build-manifest.json",
+    "app/site/sync-state.json",
+    "app/site/author-instance.json",
+    "app/site/provider-config.json"
+  ],
+  "sources" => source_entries
+}
+
+sync_state = {
+  "instanceId" => author_instance.fetch("instanceId"),
+  "sourceFingerprint" => source_fingerprint,
+  "knowledgeDocumentCount" => knowledge_documents.length,
+  "pendingInputCount" => pending_input_paths.length,
+  "trackedSourcePaths" => source_entries.map { |entry| entry.fetch("path") },
+  "sources" => source_entries
+}
+
+FileUtils.mkdir_p(output_dir)
+File.write(File.join(output_dir, "search-index.json"), JSON.pretty_generate(search_index) + "\n")
+File.write(File.join(output_dir, "build-manifest.json"), JSON.pretty_generate(build_manifest) + "\n")
+File.write(File.join(output_dir, "sync-state.json"), JSON.pretty_generate(sync_state) + "\n")

--- a/scripts/m3-sync-smoke.sh
+++ b/scripts/m3-sync-smoke.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+mkdir -p \
+  "$TEMP_DIR/app/site" \
+  "$TEMP_DIR/knowledge/blog" \
+  "$TEMP_DIR/knowledge/books" \
+  "$TEMP_DIR/knowledge/papers" \
+  "$TEMP_DIR/knowledge/inputs/articles" \
+  "$TEMP_DIR/scripts"
+
+cp "$ROOT_DIR/app/site/author-instance.json" "$TEMP_DIR/app/site/author-instance.json"
+cp "$ROOT_DIR/app/site/provider-config.json" "$TEMP_DIR/app/site/provider-config.json"
+cp "$ROOT_DIR/scripts/m3.sh" "$TEMP_DIR/scripts/m3.sh"
+cp "$ROOT_DIR/scripts/m3-sync.sh" "$TEMP_DIR/scripts/m3-sync.sh"
+cp "$ROOT_DIR/scripts/generate-site-artifacts.rb" "$TEMP_DIR/scripts/generate-site-artifacts.rb"
+
+cat <<'EOF' > "$TEMP_DIR/knowledge/blog/first-note.md"
+# First Note
+
+Portable knowledge should stay queryable.
+EOF
+
+(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh sync
+)
+
+[[ -f "$TEMP_DIR/app/site/search-index.json" ]]
+[[ -f "$TEMP_DIR/app/site/build-manifest.json" ]]
+[[ -f "$TEMP_DIR/app/site/sync-state.json" ]]
+
+cp "$TEMP_DIR/app/site/search-index.json" "$TEMP_DIR/app/site/search-index.initial.json"
+cp "$TEMP_DIR/app/site/build-manifest.json" "$TEMP_DIR/app/site/build-manifest.initial.json"
+cp "$TEMP_DIR/app/site/sync-state.json" "$TEMP_DIR/app/site/sync-state.initial.json"
+
+second_sync_output="$(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh sync
+)"
+
+grep -q "already up to date" <<<"$second_sync_output"
+cmp -s "$TEMP_DIR/app/site/search-index.initial.json" "$TEMP_DIR/app/site/search-index.json"
+cmp -s "$TEMP_DIR/app/site/build-manifest.initial.json" "$TEMP_DIR/app/site/build-manifest.json"
+cmp -s "$TEMP_DIR/app/site/sync-state.initial.json" "$TEMP_DIR/app/site/sync-state.json"
+
+cat <<'EOF' > "$TEMP_DIR/knowledge/blog/second-note.md"
+# Second Note
+
+Incremental sync should only rebuild generated metadata.
+EOF
+
+third_sync_output="$(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh sync
+)"
+
+grep -q "Detected source changes" <<<"$third_sync_output"
+grep -q '"knowledge/blog/second-note.md"' "$TEMP_DIR/app/site/search-index.json"
+grep -q '"sourceFingerprint"' "$TEMP_DIR/app/site/build-manifest.json"
+grep -q '"trackedSourcePaths"' "$TEMP_DIR/app/site/sync-state.json"
+
+echo "m3 sync smoke passed."

--- a/scripts/m3-sync.sh
+++ b/scripts/m3-sync.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SITE_DIR="$ROOT_DIR/app/site"
+SYNC_STATE_FILE="$SITE_DIR/sync-state.json"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd ruby
+
+cd "$ROOT_DIR"
+
+if [[ ! -f "$SITE_DIR/author-instance.json" ]]; then
+  echo "Missing required file: app/site/author-instance.json" >&2
+  echo "Run ./scripts/m3.sh init before trying to sync a new instance." >&2
+  exit 1
+fi
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "$temp_dir"' EXIT
+
+ruby ./scripts/generate-site-artifacts.rb "$temp_dir"
+
+if [[ -f "$SYNC_STATE_FILE" ]] && cmp -s "$temp_dir/sync-state.json" "$SYNC_STATE_FILE"; then
+  echo "No knowledge or instance metadata changes detected; static artifacts are already up to date."
+  exit 0
+fi
+
+cp "$temp_dir/search-index.json" "$SITE_DIR/search-index.json"
+cp "$temp_dir/build-manifest.json" "$SITE_DIR/build-manifest.json"
+cp "$temp_dir/sync-state.json" "$SITE_DIR/sync-state.json"
+
+echo "Detected source changes; refreshed static artifacts."
+echo "- app/site/search-index.json"
+echo "- app/site/build-manifest.json"
+echo "- app/site/sync-state.json"

--- a/scripts/m3.sh
+++ b/scripts/m3.sh
@@ -7,7 +7,7 @@ COMMAND="${1:-}"
 cd "$ROOT_DIR"
 
 usage() {
-  echo "Usage: ./scripts/m3.sh {init|add|build|test|lint|smoke|status}" >&2
+  echo "Usage: ./scripts/m3.sh {init|add|build|sync|test|lint|smoke|status}" >&2
 }
 
 slugify_url() {
@@ -72,6 +72,9 @@ case "$COMMAND" in
     ;;
   build)
     bash ./scripts/build.sh
+    ;;
+  sync)
+    bash ./scripts/m3-sync.sh
     ;;
   test)
     bash ./scripts/test.sh

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -56,6 +56,9 @@ bash ./scripts/lint.sh
 echo "Running build checks..."
 bash ./scripts/m3-build-smoke.sh
 
+echo "Validating incremental sync..."
+bash ./scripts/m3-sync-smoke.sh
+
 echo "Running Rust tests..."
 bash ./scripts/test.sh
 


### PR DESCRIPTION
## Summary
- add a real `m3 sync` path for incremental artifact refreshes
- record deterministic source fingerprints and traceability metadata for generated site artifacts
- validate the sync contract with dedicated smoke coverage and updated docs

## Spec Reference
- openspec/specs/knowledge-ingest/spec.md
- openspec/specs/knowledge-search/spec.md
- SPEC.md section 8 (M4 - Fork and run your own)

## Validation
- bash scripts/m3-sync-smoke.sh
- bash scripts/smoke.sh

Closes #21