### PR TITLE
feat: define federation registry contract

### DIFF
--- a/app/components/federation-registry-contract.test.ts
+++ b/app/components/federation-registry-contract.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+type FederationInstance = {
+  author_instance_url?: string;
+  description: string;
+  name: string;
+  repo?: string;
+  search_index_url: string;
+  since: string;
+  topics: string[];
+  url: string;
+};
+
+type FederationRegistryDocument = {
+  instances: FederationInstance[];
+  registry_repository: string;
+};
+
+type JsonSchema = {
+  properties?: Record<string, unknown>;
+  required?: string[];
+};
+
+function readRegistrySchema(): JsonSchema {
+  const schemaPath = path.resolve(
+    process.cwd(),
+    "contracts",
+    "federation-instances.schema.json"
+  );
+
+  return JSON.parse(readFileSync(schemaPath, "utf8")) as JsonSchema;
+}
+
+function readRegistryExample(): FederationRegistryDocument {
+  const examplePath = path.resolve(
+    process.cwd(),
+    "contracts",
+    "federation-instances.example.json"
+  );
+
+  return JSON.parse(readFileSync(examplePath, "utf8")) as FederationRegistryDocument;
+}
+
+describe("federation registry contract", () => {
+  it("pins the canonical registry repository and required fields", () => {
+    const schema = readRegistrySchema();
+    const instanceSchema = schema.properties?.instances as { items: JsonSchema };
+
+    expect(schema.required).toEqual(["registry_repository", "instances"]);
+    expect(instanceSchema.items.required).toEqual([
+      "name",
+      "url",
+      "search_index_url",
+      "description",
+      "topics",
+      "since"
+    ]);
+  });
+
+  it("provides a compliant example entry for join requests", () => {
+    const example = readRegistryExample();
+    const [entry] = example.instances;
+
+    expect(example.registry_repository).toBe("https://github.com/youaskm3/registry");
+    expect(example.instances).toHaveLength(1);
+    expect(entry.name.length).toBeGreaterThan(0);
+    expect(entry.url).toMatch(/^https:\/\/.+\/$/u);
+    expect(entry.search_index_url).toMatch(/^https:\/\/.+\/search-index\.json$/u);
+    expect(entry.description.length).toBeGreaterThan(0);
+    expect(entry.topics.length).toBeGreaterThan(0);
+    expect(entry.since).toMatch(/^\d{4}-\d{2}-\d{2}$/u);
+  });
+});

--- a/contracts/federation-instances.example.json
+++ b/contracts/federation-instances.example.json
@@ -1,0 +1,15 @@
+{
+  "registry_repository": "https://github.com/youaskm3/registry",
+  "instances": [
+    {
+      "name": "Enrico Piovesan",
+      "url": "https://enricopiovesan.github.io/youaskm3/",
+      "search_index_url": "https://enricopiovesan.github.io/youaskm3/search-index.json",
+      "description": "Author instance covering WASM, UMA, distributed systems, and architecture writing.",
+      "topics": ["WASM", "UMA", "distributed systems", "architecture"],
+      "since": "2026-04-01",
+      "author_instance_url": "https://enricopiovesan.github.io/youaskm3/author-instance.json",
+      "repo": "https://github.com/enricopiovesan/youaskm3"
+    }
+  ]
+}

--- a/contracts/federation-instances.schema.json
+++ b/contracts/federation-instances.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://youaskm3.com/contracts/federation-instances.schema.json",
+  "title": "youaskm3 federation registry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["registry_repository", "instances"],
+  "properties": {
+    "registry_repository": {
+      "type": "string",
+      "const": "https://github.com/youaskm3/registry",
+      "description": "Canonical repository that accepts registry pull requests."
+    },
+    "instances": {
+      "type": "array",
+      "description": "Federation members listed in deterministic path order.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "url",
+          "search_index_url",
+          "description",
+          "topics",
+          "since"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^https://.+"
+          },
+          "search_index_url": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^https://.+/search-index\\.json$"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "topics": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "since": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+          },
+          "author_instance_url": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^https://.+/author-instance\\.json$"
+          },
+          "repo": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^https://github\\.com/.+"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/federation-registry.md
+++ b/docs/federation-registry.md
@@ -1,0 +1,62 @@
+# Federation Registry
+
+This document defines the first public contract for joining the `youaskm3` federation. It is the maintainer-facing companion to [openspec/specs/federation/spec.md](../openspec/specs/federation/spec.md) and keeps the M5 registry workflow explicit before the nightly crawl and `/explore` experience land.
+
+## Registry repository
+
+Federation registrations are reviewed in the public registry repository:
+
+- `https://github.com/youaskm3/registry`
+
+That repository is the canonical home for `instances.json`, review discussions, and the future nightly crawl output.
+
+## Required metadata
+
+Every registry entry must provide the minimum metadata needed for discoverability and crawlability:
+
+| Field | Why it is required |
+|---|---|
+| `name` | Human-readable instance or maintainer name. |
+| `url` | Canonical published shell URL for the instance. |
+| `search_index_url` | Static search artifact that later federation jobs will fetch. |
+| `description` | One-paragraph summary of what the instance covers. |
+| `topics` | Searchable tags that help explain the instance's focus. |
+| `since` | Join date in `YYYY-MM-DD` format for traceability. |
+
+Optional but recommended metadata:
+
+| Field | Why it helps |
+|---|---|
+| `author_instance_url` | Points directly at the published author-instance manifest. |
+| `repo` | Lets maintainers review the public source behind the instance. |
+
+The canonical schema lives at [`contracts/federation-instances.schema.json`](../contracts/federation-instances.schema.json), and a compliant example lives at [`contracts/federation-instances.example.json`](../contracts/federation-instances.example.json).
+
+## Join workflow
+
+Use this process when registering a new instance:
+
+1. Confirm the shell URL is public and the instance is a real `youaskm3` deployment.
+2. Confirm `search-index.json` is published and fetchable from the declared `search_index_url`.
+3. Add one object to `instances.json` following the schema and example contract.
+4. Open a pull request against `youaskm3/registry` describing the instance, its topics, and the published URLs being added.
+5. Wait for maintainer review. The registry stays pull-request-driven; there is no direct database or admin-panel write path.
+
+## Review and removal rules
+
+- The registry maintainer reviews registrations for schema compliance and public accessibility.
+- Entries can be updated or removed by pull request.
+- The maintainer may remove entries that are persistently offline, malformed, or no longer represent a valid `youaskm3` instance.
+
+## Example entry
+
+```json
+{
+  "name": "Enrico Piovesan",
+  "url": "https://enricopiovesan.github.io/youaskm3/",
+  "search_index_url": "https://enricopiovesan.github.io/youaskm3/search-index.json",
+  "description": "Author instance covering WASM, UMA, distributed systems, and architecture writing.",
+  "topics": ["WASM", "UMA", "distributed systems", "architecture"],
+  "since": "2026-04-01"
+}
+```

--- a/openspec/specs/federation/spec.md
+++ b/openspec/specs/federation/spec.md
@@ -8,13 +8,33 @@ The federation capability defines how independent youaskm3 instances become disc
 
 ### Requirement: Register public instances through git workflows
 
-The system SHALL let an instance join the federation through a pull-request-driven registry process instead of a centralized runtime service.
+The system SHALL let an instance join the federation through a pull-request-driven registry process against the public `youaskm3/registry` repository instead of a centralized runtime service.
 
 #### Scenario: Add an instance to the registry
 
 - GIVEN an instance is publicly accessible and ready to join the network
-- WHEN its maintainer submits the required registry metadata by pull request
+- WHEN its maintainer submits the required registry metadata to `instances.json` by pull request
 - THEN the registry can review and include that instance without direct database writes
+
+### Requirement: Capture minimum federation metadata
+
+The registry SHALL require enough metadata to identify an instance, explain what it covers, and discover its published search surface.
+
+#### Scenario: Review a registration entry
+
+- GIVEN a maintainer prepares a new federation registration
+- WHEN the registry validates the entry
+- THEN the entry includes the instance name, published URL, description, topics, join date, and search index location
+
+### Requirement: Document registry participation rules
+
+The system SHALL document the join workflow, review expectations, and removal conditions for federation participation.
+
+#### Scenario: Prepare a compliant join request
+
+- GIVEN a contributor wants to join the federation for the first time
+- WHEN they read the registry guidance
+- THEN they can prepare a valid `instances.json` entry and understand how approval happens
 
 ### Requirement: Build a shared discoverability index
 


### PR DESCRIPTION
## Summary
- tighten the federation OpenSpec around registry participation and minimum metadata
- add the canonical `instances.json` schema and a compliant example entry
- validate the join contract with a deterministic frontend test and maintainer docs

## Spec Reference
- openspec/specs/federation/spec.md
- SPEC.md section 8 (M5 - Federation)
- SPEC.md section 11

## Validation
- npm test -- federation-registry-contract
- npm run typecheck
- bash scripts/smoke.sh

Closes #23