### PR TITLE
feat: automate federation index generation

### DIFF
--- a/.github/workflows/index.yml
+++ b/.github/workflows/index.yml
@@ -7,10 +7,28 @@ on:
 
 jobs:
   rebuild-index:
-    name: Rebuild Knowledge Index
+    name: Build Federation Index
     runs-on: ubuntu-latest
+    env:
+      FEDERATION_REGISTRY_URL: https://raw.githubusercontent.com/youaskm3/registry/main/instances.json
 
     steps:
-      - name: Echo stub index rebuild
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Generate federation index artifacts
         shell: bash
-        run: echo "index rebuild"
+        run: ruby scripts/generate-federation-index.rb "$FEDERATION_REGISTRY_URL" app/site
+
+      - name: Upload federation index artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: federation-index
+          path: |
+            app/site/federation-search-index.json
+            app/site/federation-index-manifest.json

--- a/docs/federation-index-generation.md
+++ b/docs/federation-index-generation.md
@@ -1,0 +1,44 @@
+# Federation Index Generation
+
+This document defines the first deterministic crawl flow for the federation registry. It turns approved registry entries into a shared static index that later `/explore` and cross-instance search work can consume.
+
+## Inputs
+
+The crawl consumes:
+
+| Input | Purpose |
+|---|---|
+| Registry JSON | Source of approved instance metadata and search index URLs. |
+| Instance `search-index.json` files | Source-backed searchable summaries published by each participating instance. |
+
+The canonical registry contract is defined in [`contracts/federation-instances.schema.json`](../contracts/federation-instances.schema.json). Each instance entry must expose a `search_index_url` that resolves to a valid `search-index.json`.
+
+## Outputs
+
+The generator writes these static artifacts:
+
+| Artifact | Purpose |
+|---|---|
+| `app/site/federation-search-index.json` | Aggregated list of registered instances and their published searchable documents. |
+| `app/site/federation-index-manifest.json` | Deterministic crawl manifest, artifact list, and source URLs for debugging. |
+
+Both outputs include a `sourceFingerprint` so maintainers can confirm exactly which registry and instance inputs produced the crawl result.
+
+## Workflow
+
+Use the crawl flow in one of two modes:
+
+1. Local deterministic validation with `bash scripts/federation-index-smoke.sh`
+2. Nightly or on-demand generation through `.github/workflows/index.yml`
+
+The scheduled workflow reads the registry URL from `FEDERATION_REGISTRY_URL`. When not overridden, it targets the public `youaskm3/registry` raw `instances.json` path.
+
+## Failure handling
+
+The crawl fails fast when:
+
+- the registry JSON is missing required fields
+- an instance search index cannot be fetched
+- an instance search index is malformed or missing required searchable metadata
+
+Those failures are intentional. They keep the shared index deterministic and make broken registry entries visible before publish or commit automation runs.

--- a/scripts/federation-index-smoke.sh
+++ b/scripts/federation-index-smoke.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+mkdir -p "$TEMP_DIR/instance-a" "$TEMP_DIR/instance-b" "$TEMP_DIR/out"
+
+cat <<EOF > "$TEMP_DIR/instance-a/search-index.json"
+{
+  "instanceId": "instance-a",
+  "title": "Instance A",
+  "shellUrl": "https://instance-a.example/",
+  "documents": [
+    {
+      "id": "paper-a",
+      "title": "Paper A",
+      "source_path": "knowledge/papers/paper-a/index.md",
+      "category": "papers",
+      "excerpt": "Distributed systems notes."
+    }
+  ]
+}
+EOF
+
+cat <<EOF > "$TEMP_DIR/instance-b/search-index.json"
+{
+  "instanceId": "instance-b",
+  "title": "Instance B",
+  "shellUrl": "https://instance-b.example/",
+  "documents": [
+    {
+      "id": "blog-b",
+      "title": "Blog B",
+      "source_path": "knowledge/blog/blog-b.md",
+      "category": "blog",
+      "excerpt": "WASM field notes."
+    }
+  ]
+}
+EOF
+
+cat <<EOF > "$TEMP_DIR/instances.json"
+{
+  "registry_repository": "https://github.com/youaskm3/registry",
+  "instances": [
+    {
+      "name": "Instance A",
+      "url": "https://instance-a.example/",
+      "search_index_url": "file://$TEMP_DIR/instance-a/search-index.json",
+      "description": "Systems writing.",
+      "topics": ["systems"],
+      "since": "2026-04-01"
+    },
+    {
+      "name": "Instance B",
+      "url": "https://instance-b.example/",
+      "search_index_url": "file://$TEMP_DIR/instance-b/search-index.json",
+      "description": "WASM writing.",
+      "topics": ["wasm"],
+      "since": "2026-04-02"
+    }
+  ]
+}
+EOF
+
+ruby "$ROOT_DIR/scripts/generate-federation-index.rb" \
+  "$TEMP_DIR/instances.json" \
+  "$TEMP_DIR/out"
+
+[[ -f "$TEMP_DIR/out/federation-search-index.json" ]]
+[[ -f "$TEMP_DIR/out/federation-index-manifest.json" ]]
+
+grep -q '"instanceCount": 2' "$TEMP_DIR/out/federation-search-index.json"
+grep -q '"documentCount": 2' "$TEMP_DIR/out/federation-search-index.json"
+grep -q '"instanceName": "Instance A"' "$TEMP_DIR/out/federation-search-index.json"
+grep -q '"instanceName": "Instance B"' "$TEMP_DIR/out/federation-search-index.json"
+grep -q '"searchIndexUrl": "file://' "$TEMP_DIR/out/federation-index-manifest.json"
+
+echo "Federation index smoke passed."

--- a/scripts/generate-federation-index.rb
+++ b/scripts/generate-federation-index.rb
@@ -1,0 +1,143 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "digest"
+require "fileutils"
+require "json"
+require "open-uri"
+require "uri"
+
+def abort_with(message)
+  warn(message)
+  exit(1)
+end
+
+def fetch_json(source)
+  if source.start_with?("http://", "https://")
+    JSON.parse(URI.open(source, &:read))
+  elsif source.start_with?("file://")
+    file_path = URI.parse(source).path
+    JSON.parse(File.read(file_path))
+  else
+    JSON.parse(File.read(source))
+  end
+rescue Errno::ENOENT
+  abort_with("Federation crawl failed: missing file #{source}.")
+rescue OpenURI::HTTPError => error
+  abort_with("Federation crawl failed while fetching #{source}: #{error.message}.")
+rescue JSON::ParserError => error
+  abort_with("Federation crawl failed: invalid JSON at #{source}: #{error.message}.")
+end
+
+def required_string(hash, key, context)
+  value = hash[key]
+  abort_with("Federation crawl failed: #{context} is missing required field #{key}.") unless value.is_a?(String) && !value.empty?
+
+  value
+end
+
+def required_array(hash, key, context)
+  value = hash[key]
+  abort_with("Federation crawl failed: #{context} is missing required array #{key}.") unless value.is_a?(Array)
+
+  value
+end
+
+registry_source = ARGV[0]
+output_dir = ARGV[1]
+
+abort_with("Usage: ruby scripts/generate-federation-index.rb <registry-json> <output-dir>") if registry_source.nil? || output_dir.nil?
+
+registry = fetch_json(registry_source)
+registry_repository = required_string(registry, "registry_repository", "registry document")
+instances = required_array(registry, "instances", "registry document")
+
+aggregated_instances = []
+aggregated_documents = []
+fingerprint_inputs = [registry_repository]
+
+instances.each do |instance|
+  name = required_string(instance, "name", "registry instance")
+  url = required_string(instance, "url", "registry instance")
+  search_index_url = required_string(instance, "search_index_url", "registry instance")
+  description = required_string(instance, "description", "registry instance")
+  topics = required_array(instance, "topics", "registry instance")
+  since = required_string(instance, "since", "registry instance")
+
+  search_index = fetch_json(search_index_url)
+  instance_id = required_string(search_index, "instanceId", "search index")
+  title = required_string(search_index, "title", "search index")
+  shell_url = required_string(search_index, "shellUrl", "search index")
+  documents = required_array(search_index, "documents", "search index")
+
+  normalized_documents = documents.sort_by do |document|
+    source_path = required_string(document, "source_path", "search index document")
+    [source_path, required_string(document, "id", "search index document")]
+  end.map do |document|
+    document_id = required_string(document, "id", "search index document")
+    source_path = required_string(document, "source_path", "search index document")
+    fingerprint_inputs << "#{instance_id}:#{document_id}:#{source_path}"
+
+    {
+      "id" => "#{instance_id}--#{document_id}",
+      "instanceId" => instance_id,
+      "instanceName" => name,
+      "instanceUrl" => url,
+      "instanceShellUrl" => shell_url,
+      "title" => required_string(document, "title", "search index document"),
+      "source_path" => source_path,
+      "category" => required_string(document, "category", "search index document"),
+      "excerpt" => required_string(document, "excerpt", "search index document"),
+      "topics" => topics
+    }
+  end
+
+  aggregated_instances << {
+    "instanceId" => instance_id,
+    "name" => name,
+    "title" => title,
+    "url" => url,
+    "shellUrl" => shell_url,
+    "searchIndexUrl" => search_index_url,
+    "description" => description,
+    "topics" => topics,
+    "since" => since,
+    "documentCount" => normalized_documents.length
+  }
+
+  aggregated_documents.concat(normalized_documents)
+end
+
+aggregated_instances.sort_by! { |instance| [instance.fetch("name"), instance.fetch("instanceId")] }
+aggregated_documents.sort_by! { |document| [document.fetch("instanceName"), document.fetch("source_path"), document.fetch("id")] }
+
+source_fingerprint = Digest::SHA256.hexdigest(fingerprint_inputs.join("\n"))
+
+federation_search_index = {
+  "registryRepository" => registry_repository,
+  "sourceFingerprint" => source_fingerprint,
+  "instanceCount" => aggregated_instances.length,
+  "documentCount" => aggregated_documents.length,
+  "instances" => aggregated_instances,
+  "documents" => aggregated_documents
+}
+
+federation_manifest = {
+  "registryRepository" => registry_repository,
+  "sourceFingerprint" => source_fingerprint,
+  "artifacts" => [
+    "app/site/federation-search-index.json",
+    "app/site/federation-index-manifest.json"
+  ],
+  "instanceSources" => aggregated_instances.map do |instance|
+    {
+      "instanceId" => instance.fetch("instanceId"),
+      "searchIndexUrl" => instance.fetch("searchIndexUrl"),
+      "documentCount" => instance.fetch("documentCount")
+    }
+  end
+}
+
+FileUtils.mkdir_p(output_dir)
+File.write(File.join(output_dir, "federation-search-index.json"), JSON.pretty_generate(federation_search_index) + "\n")
+File.write(File.join(output_dir, "federation-index-manifest.json"), JSON.pretty_generate(federation_manifest) + "\n")

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -59,6 +59,9 @@ bash ./scripts/m3-build-smoke.sh
 echo "Validating incremental sync..."
 bash ./scripts/m3-sync-smoke.sh
 
+echo "Validating federation index generation..."
+bash ./scripts/federation-index-smoke.sh
+
 echo "Running Rust tests..."
 bash ./scripts/test.sh
 


### PR DESCRIPTION
## Summary
- add a deterministic federation crawl generator for registry and instance search indexes
- replace the nightly index workflow stub with a real artifact-building job
- cover the crawl path with dedicated smoke validation and maintainer docs

## Spec Reference
- openspec/specs/federation/spec.md
- SPEC.md section 8 (M5 - Federation)
- SPEC.md section 11

## Validation
- bash scripts/federation-index-smoke.sh
- bash scripts/smoke.sh

Closes #25