### PR TITLE
feat: add MarkItDown multi-format ingest path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /ref/
 /target
 /node_modules
+/.cache
 /coverage
 /dist
 *.wasm

--- a/crates/youaskm3-ingest/examples/markitdown2m3.rs
+++ b/crates/youaskm3-ingest/examples/markitdown2m3.rs
@@ -1,0 +1,82 @@
+use std::{env, error::Error, fs, path::Path};
+
+use youaskm3_ingest::{
+    MarkItDownMarkdownInput, derive_title_from_file_path, render_markitdown_markdown,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("markitdown2m3 example failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut arguments = env::args().skip(1);
+    let input_path = arguments
+        .next()
+        .ok_or("usage: cargo run -p youaskm3-ingest --example markitdown2m3 -- <input.md> <output.md> <source-path> <source-format> [title]")?;
+    let output_path = arguments
+        .next()
+        .ok_or("usage: cargo run -p youaskm3-ingest --example markitdown2m3 -- <input.md> <output.md> <source-path> <source-format> [title]")?;
+    let source_path = arguments
+        .next()
+        .ok_or("usage: cargo run -p youaskm3-ingest --example markitdown2m3 -- <input.md> <output.md> <source-path> <source-format> [title]")?;
+    let source_format = arguments
+        .next()
+        .ok_or("usage: cargo run -p youaskm3-ingest --example markitdown2m3 -- <input.md> <output.md> <source-path> <source-format> [title]")?;
+    let title = arguments
+        .next()
+        .unwrap_or_else(|| derive_title_from_file_path(&source_path));
+
+    let captured_markdown = fs::read_to_string(&input_path)?;
+    let markdown = render_markitdown_markdown(&MarkItDownMarkdownInput {
+        title,
+        source_path,
+        source_format,
+        captured_markdown,
+    })?;
+
+    ensure_output_directory(Path::new(&output_path))?;
+
+    fs::write(output_path, markdown)?;
+    Ok(())
+}
+
+fn ensure_output_directory(output_path: &Path) -> Result<(), Box<dyn Error>> {
+    if let Some(parent) = output_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_output_directory;
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    #[test]
+    fn output_in_current_directory_does_not_require_parent_creation() {
+        assert!(ensure_output_directory(PathBuf::from("out.md").as_path()).is_ok());
+    }
+
+    #[test]
+    fn nested_output_path_creates_missing_parent_directory() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |duration| duration.as_nanos());
+        let root = std::env::temp_dir().join(format!("youaskm3-markitdown2m3-{unique}"));
+        let output_path = root.join("nested").join("out.md");
+
+        assert!(ensure_output_directory(&output_path).is_ok());
+        assert!(root.join("nested").is_dir());
+        assert!(fs::remove_dir_all(root).is_ok());
+    }
+}

--- a/crates/youaskm3-ingest/src/lib.rs
+++ b/crates/youaskm3-ingest/src/lib.rs
@@ -31,6 +31,19 @@ pub struct UrlMarkdownInput {
     pub captured_text: String,
 }
 
+/// Metadata and captured markdown needed to render a MarkItDown-backed artifact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkItDownMarkdownInput {
+    /// Human-readable title for the generated document.
+    pub title: String,
+    /// Source file path used for traceability.
+    pub source_path: String,
+    /// Source format handled by `MarkItDown`.
+    pub source_format: String,
+    /// Markdown content produced by `MarkItDown`.
+    pub captured_markdown: String,
+}
+
 /// Errors returned when PDF ingest input is incomplete.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PdfMarkdownError {
@@ -76,6 +89,32 @@ impl fmt::Display for UrlMarkdownError {
 }
 
 impl std::error::Error for UrlMarkdownError {}
+
+/// Errors returned when `MarkItDown` ingest input is incomplete.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MarkItDownMarkdownError {
+    /// The title was empty after trimming.
+    MissingTitle,
+    /// The source path was empty after trimming.
+    MissingSourcePath,
+    /// The source format was empty after trimming.
+    MissingSourceFormat,
+    /// The captured markdown was empty after trimming.
+    MissingCapturedMarkdown,
+}
+
+impl fmt::Display for MarkItDownMarkdownError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingTitle => f.write_str("missing MarkItDown title"),
+            Self::MissingSourcePath => f.write_str("missing MarkItDown source path"),
+            Self::MissingSourceFormat => f.write_str("missing MarkItDown source format"),
+            Self::MissingCapturedMarkdown => f.write_str("missing MarkItDown markdown"),
+        }
+    }
+}
+
+impl std::error::Error for MarkItDownMarkdownError {}
 
 /// Markdown content ready to be split into index-friendly chunks.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -205,6 +244,41 @@ pub fn render_url_markdown(input: &UrlMarkdownInput) -> Result<String, UrlMarkdo
     ))
 }
 
+/// Builds a stable markdown artifact from MarkItDown-generated markdown.
+///
+/// # Errors
+///
+/// Returns an error if the title, source path, source format, or captured markdown
+/// is empty after trimming.
+pub fn render_markitdown_markdown(
+    input: &MarkItDownMarkdownInput,
+) -> Result<String, MarkItDownMarkdownError> {
+    let title = input.title.trim();
+    let source_path = input.source_path.trim();
+    let source_format = input.source_format.trim();
+    let captured_markdown = input.captured_markdown.trim();
+
+    if title.is_empty() {
+        return Err(MarkItDownMarkdownError::MissingTitle);
+    }
+
+    if source_path.is_empty() {
+        return Err(MarkItDownMarkdownError::MissingSourcePath);
+    }
+
+    if source_format.is_empty() {
+        return Err(MarkItDownMarkdownError::MissingSourceFormat);
+    }
+
+    if captured_markdown.is_empty() {
+        return Err(MarkItDownMarkdownError::MissingCapturedMarkdown);
+    }
+
+    Ok(format!(
+        "# {title}\n\n## Source\n\n- type: file\n- format: {source_format}\n- path: {source_path}\n- ingested_by: `markitdown2m3`\n\n## Captured Markdown\n\n{captured_markdown}\n"
+    ))
+}
+
 /// Derives a human-readable title from a PDF file path or file name.
 #[must_use]
 pub fn derive_title_from_path(path: &str) -> String {
@@ -246,6 +320,29 @@ pub fn derive_title_from_url(url: &str) -> String {
         .unwrap_or("url capture");
 
     let normalized = last_segment
+        .chars()
+        .map(|character| {
+            if matches!(character, '-' | '_' | '.') {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>();
+
+    normalized.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Derives a human-readable title from a local file path by stripping the final extension.
+#[must_use]
+pub fn derive_title_from_file_path(path: &str) -> String {
+    let trimmed = path.trim();
+    let file_name = trimmed.rsplit(['/', '\\']).next().unwrap_or(trimmed);
+    let stem = file_name
+        .rsplit_once('.')
+        .map_or(file_name, |(prefix, _)| prefix);
+
+    let normalized = stem
         .chars()
         .map(|character| {
             if matches!(character, '-' | '_' | '.') {
@@ -399,10 +496,11 @@ fn render_source_line(source_path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        ChunkingOptions, MarkdownChunk, MarkdownChunkError, MarkdownChunkInput, PdfMarkdownError,
-        PdfMarkdownInput, UrlMarkdownError, UrlMarkdownInput, chunk_markdown, crate_name,
-        derive_title_from_path, derive_title_from_url, normalize_pdf_text, render_pdf_markdown,
-        render_url_markdown,
+        ChunkingOptions, MarkItDownMarkdownError, MarkItDownMarkdownInput, MarkdownChunk,
+        MarkdownChunkError, MarkdownChunkInput, PdfMarkdownError, PdfMarkdownInput,
+        UrlMarkdownError, UrlMarkdownInput, chunk_markdown, crate_name,
+        derive_title_from_file_path, derive_title_from_path, derive_title_from_url,
+        normalize_pdf_text, render_markitdown_markdown, render_pdf_markdown, render_url_markdown,
     };
 
     #[test]
@@ -425,6 +523,18 @@ mod tests {
             "portable knowledge html"
         );
         assert_eq!(derive_title_from_url("https://example.com/"), "example com");
+    }
+
+    #[test]
+    fn derive_title_from_file_path_strips_the_last_extension() {
+        assert_eq!(
+            derive_title_from_file_path("ref/Portable_Knowledge.html"),
+            "Portable Knowledge"
+        );
+        assert_eq!(
+            derive_title_from_file_path("notes/meeting-notes.docx"),
+            "meeting notes"
+        );
     }
 
     #[test]
@@ -480,6 +590,19 @@ mod tests {
         let expected = "# Portable Knowledge\n\n## Source\n\n- type: url\n- url: https://example.com/portable-knowledge\n- ingested_by: `url2m3`\n\n## Captured Text\n\nFirst paragraph. Still first paragraph.\n\nSecond paragraph.\n";
 
         assert_eq!(render_url_markdown(&input), Ok(expected.to_string()));
+    }
+
+    #[test]
+    fn render_markitdown_markdown_includes_traceability_metadata() {
+        let input = MarkItDownMarkdownInput {
+            title: "Portable Knowledge".to_string(),
+            source_path: "ref/portable-knowledge.html".to_string(),
+            source_format: "html".to_string(),
+            captured_markdown: "## Portable Knowledge\n\nHello **world**.".to_string(),
+        };
+        let expected = "# Portable Knowledge\n\n## Source\n\n- type: file\n- format: html\n- path: ref/portable-knowledge.html\n- ingested_by: `markitdown2m3`\n\n## Captured Markdown\n\n## Portable Knowledge\n\nHello **world**.\n";
+
+        assert_eq!(render_markitdown_markdown(&input), Ok(expected.to_string()));
     }
 
     #[test]
@@ -580,6 +703,61 @@ mod tests {
         assert_eq!(
             UrlMarkdownError::MissingCapturedText.to_string(),
             "missing captured URL text"
+        );
+    }
+
+    #[test]
+    fn render_markitdown_markdown_rejects_incomplete_input() {
+        let valid = MarkItDownMarkdownInput {
+            title: "Example".to_string(),
+            source_path: "ref/example.html".to_string(),
+            source_format: "html".to_string(),
+            captured_markdown: "Body.".to_string(),
+        };
+
+        assert_eq!(
+            render_markitdown_markdown(&MarkItDownMarkdownInput {
+                title: " ".to_string(),
+                ..valid.clone()
+            }),
+            Err(MarkItDownMarkdownError::MissingTitle)
+        );
+        assert_eq!(
+            MarkItDownMarkdownError::MissingTitle.to_string(),
+            "missing MarkItDown title"
+        );
+        assert_eq!(
+            render_markitdown_markdown(&MarkItDownMarkdownInput {
+                source_path: " ".to_string(),
+                ..valid.clone()
+            }),
+            Err(MarkItDownMarkdownError::MissingSourcePath)
+        );
+        assert_eq!(
+            MarkItDownMarkdownError::MissingSourcePath.to_string(),
+            "missing MarkItDown source path"
+        );
+        assert_eq!(
+            render_markitdown_markdown(&MarkItDownMarkdownInput {
+                source_format: " ".to_string(),
+                ..valid.clone()
+            }),
+            Err(MarkItDownMarkdownError::MissingSourceFormat)
+        );
+        assert_eq!(
+            MarkItDownMarkdownError::MissingSourceFormat.to_string(),
+            "missing MarkItDown source format"
+        );
+        assert_eq!(
+            render_markitdown_markdown(&MarkItDownMarkdownInput {
+                captured_markdown: " ".to_string(),
+                ..valid
+            }),
+            Err(MarkItDownMarkdownError::MissingCapturedMarkdown)
+        );
+        assert_eq!(
+            MarkItDownMarkdownError::MissingCapturedMarkdown.to_string(),
+            "missing MarkItDown markdown"
         );
     }
 

--- a/scripts/m3-markitdown-smoke.sh
+++ b/scripts/m3-markitdown-smoke.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+INPUT_HTML="$TMP_DIR/portable-knowledge.html"
+EXPECTED_OUTPUT="$ROOT_DIR/knowledge/inputs/notes/portable-knowledge.md"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+  rm -f "$EXPECTED_OUTPUT"
+}
+
+trap cleanup EXIT
+
+cat >"$INPUT_HTML" <<'EOF'
+<!doctype html>
+<html lang="en">
+  <body>
+    <h1>Portable Knowledge</h1>
+    <p>Hello <strong>world</strong>.</p>
+  </body>
+</html>
+EOF
+
+bash "$ROOT_DIR/scripts/m3.sh" add "$INPUT_HTML"
+
+[[ -f "$EXPECTED_OUTPUT" ]]
+grep -q '^# portable knowledge$' "$EXPECTED_OUTPUT"
+grep -q '^- type: file$' "$EXPECTED_OUTPUT"
+grep -q '^- format: html$' "$EXPECTED_OUTPUT"
+grep -q '^- ingested_by: `markitdown2m3`$' "$EXPECTED_OUTPUT"
+grep -q 'Portable Knowledge' "$EXPECTED_OUTPUT"
+grep -q 'Hello' "$EXPECTED_OUTPUT"
+
+echo "m3 MarkItDown smoke passed."

--- a/scripts/m3.sh
+++ b/scripts/m3.sh
@@ -45,18 +45,30 @@ run_add() {
       case "$source_name" in
         *.pdf|*.PDF)
           source_stem="${source_name%.*}"
+          bash "$ROOT_DIR/tools/pdf2m3/pdf2m3.sh" \
+            "$source_path" \
+            "knowledge/papers/${source_stem}/index.md" \
+            "$source_path"
+          ;;
+        *.html|*.HTML|*.htm|*.HTM|*.docx|*.DOCX|*.pptx|*.PPTX|*.xlsx|*.XLSX|*.xls|*.XLS|*.csv|*.CSV|*.json|*.JSON|*.xml|*.XML|*.epub|*.EPUB|*.zip|*.ZIP)
+          source_stem="${source_name%.*}"
+          if [[ -n "$title" ]]; then
+            bash "$ROOT_DIR/tools/markitdown2m3/markitdown2m3.sh" \
+              "$source_path" \
+              "knowledge/inputs/notes/${source_stem}.md" \
+              "$title"
+          else
+            bash "$ROOT_DIR/tools/markitdown2m3/markitdown2m3.sh" \
+              "$source_path" \
+              "knowledge/inputs/notes/${source_stem}.md"
+          fi
           ;;
         *)
-          echo "m3 add currently routes PDF files and HTTP(S) URLs." >&2
-          echo "Use a .pdf input or URL for this M1 slice." >&2
+          echo "m3 add currently routes PDF files, selected local document formats, and HTTP(S) URLs." >&2
+          echo "Use a supported file extension or URL for this M1 slice." >&2
           exit 1
           ;;
       esac
-
-      bash "$ROOT_DIR/tools/pdf2m3/pdf2m3.sh" \
-        "$source_path" \
-        "knowledge/papers/${source_stem}/index.md" \
-        "$source_path"
       ;;
   esac
 }

--- a/scripts/setup-markitdown.sh
+++ b/scripts/setup-markitdown.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_DIR="$ROOT_DIR/.cache/markitdown-venv"
+PYTHON_BIN="${PYTHON:-python3}"
+MARKITDOWN_VERSION="0.1.6"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd "$PYTHON_BIN"
+
+if ! "$PYTHON_BIN" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)'; then
+  echo "MarkItDown requires Python 3.10 or higher." >&2
+  exit 1
+fi
+
+mkdir -p "$ROOT_DIR/.cache"
+
+if [[ ! -x "$VENV_DIR/bin/python" ]]; then
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+
+INSTALLED_VERSION="$("$VENV_DIR/bin/python" -c 'import importlib.metadata as metadata; import sys
+try:
+    print(metadata.version("markitdown"))
+except metadata.PackageNotFoundError:
+    sys.exit(1)' 2>/dev/null || true)"
+
+if [[ "$INSTALLED_VERSION" != "$MARKITDOWN_VERSION" ]]; then
+  echo "Installing markitdown==${MARKITDOWN_VERSION} into ${VENV_DIR}..." >&2
+  "$VENV_DIR/bin/python" -m pip install --upgrade pip >/dev/null
+  "$VENV_DIR/bin/python" -m pip install "markitdown==${MARKITDOWN_VERSION}" >/dev/null
+fi
+
+echo "$VENV_DIR/bin/markitdown"

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -47,6 +47,9 @@ bash ./scripts/m3-init-smoke.sh
 echo "Validating m3 add ingest routing..."
 bash ./scripts/m3-add-smoke.sh
 
+echo "Validating MarkItDown ingest routing..."
+bash ./scripts/m3-markitdown-smoke.sh
+
 echo "Validating PWA shell assets..."
 bash ./scripts/pwa-shell-smoke.sh
 

--- a/tools/markitdown2m3/README.md
+++ b/tools/markitdown2m3/README.md
@@ -1,0 +1,47 @@
+# markitdown2m3
+
+`markitdown2m3` uses [Microsoft MarkItDown](https://github.com/microsoft/markitdown) as a repo-local ingest adapter for supported file types beyond the existing PDF and URL paths.
+
+The first integration slice is intentionally narrow:
+
+- it keeps `youaskm3`'s own markdown structure and source traceability rules
+- it pins MarkItDown through a repo-local setup script
+- it routes supported local files into `knowledge/inputs/notes/`
+
+## Supported file types in this slice
+
+The MarkItDown-backed path is intended for local files such as:
+
+- `.html`
+- `.htm`
+- `.docx`
+- `.pptx`
+- `.xlsx`
+- `.xls`
+- `.csv`
+- `.json`
+- `.xml`
+- `.epub`
+- `.zip`
+
+Support depends on the installed MarkItDown package and any optional dependencies it requires. The first smoke path validates HTML ingest explicitly.
+
+## Usage
+
+```bash
+tools/markitdown2m3/markitdown2m3.sh <input-file> <output.md> [title]
+```
+
+Example:
+
+```bash
+tools/markitdown2m3/markitdown2m3.sh ref/example.html knowledge/inputs/notes/example.md
+./scripts/m3.sh add ref/example.html
+```
+
+The generated markdown includes:
+
+- a document title derived from the file name or supplied title
+- source traceability metadata
+- the original file format handled by MarkItDown
+- the Markdown body produced by MarkItDown

--- a/tools/markitdown2m3/markitdown2m3.sh
+++ b/tools/markitdown2m3/markitdown2m3.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+if [[ "$#" -lt 2 || "$#" -gt 3 ]]; then
+  echo "Usage: tools/markitdown2m3/markitdown2m3.sh <input-file> <output.md> [title]" >&2
+  exit 1
+fi
+
+require_cmd cargo
+require_cmd python3
+
+INPUT_FILE="$1"
+OUTPUT_MD="$2"
+TITLE="${3:-}"
+SOURCE_NAME="${INPUT_FILE##*/}"
+SOURCE_FORMAT="${SOURCE_NAME##*.}"
+TEMP_MARKDOWN="$(mktemp)"
+trap 'rm -f "$TEMP_MARKDOWN"' EXIT
+
+if [[ "$SOURCE_FORMAT" == "$SOURCE_NAME" ]]; then
+  echo "MarkItDown ingest requires a file with a supported extension." >&2
+  exit 1
+fi
+
+MARKITDOWN_BIN="$(bash "$ROOT_DIR/scripts/setup-markitdown.sh")"
+
+cd "$ROOT_DIR"
+
+"$MARKITDOWN_BIN" "$INPUT_FILE" -o "$TEMP_MARKDOWN"
+
+if [[ -n "$TITLE" ]]; then
+  cargo run --quiet -p youaskm3-ingest --example markitdown2m3 -- \
+    "$TEMP_MARKDOWN" \
+    "$OUTPUT_MD" \
+    "$INPUT_FILE" \
+    "$SOURCE_FORMAT" \
+    "$TITLE"
+else
+  cargo run --quiet -p youaskm3-ingest --example markitdown2m3 -- \
+    "$TEMP_MARKDOWN" \
+    "$OUTPUT_MD" \
+    "$INPUT_FILE" \
+    "$SOURCE_FORMAT"
+fi
+
+echo "Generated markdown artifact at ${OUTPUT_MD}"

--- a/tools/pdf2m3/README.md
+++ b/tools/pdf2m3/README.md
@@ -23,3 +23,5 @@ The generated markdown includes:
 - a document title derived from the PDF file name
 - source traceability metadata
 - normalized extracted text grouped into markdown paragraphs
+
+For additional local file types, see [../markitdown2m3/README.md](../markitdown2m3/README.md).

--- a/tools/url2m3/README.md
+++ b/tools/url2m3/README.md
@@ -22,3 +22,5 @@ The generated markdown includes:
 - a document title derived from the URL or supplied title
 - source URL traceability metadata
 - normalized captured text grouped into markdown paragraphs
+
+For local files beyond PDFs, see [../markitdown2m3/README.md](../markitdown2m3/README.md).


### PR DESCRIPTION
## Summary
- route supported local document formats through a pinned MarkItDown adapter
- add repo-local setup and smoke coverage for HTML-backed ingest into m3 artifacts
- document the new adapter alongside the existing PDF and URL ingest flows
- spec reference: openspec/specs/knowledge-ingest/spec.md

## Testing
- bash scripts/m3-markitdown-smoke.sh
- bash scripts/smoke.sh

Closes #55