### PR TITLE
Define MVP roadmap and capability contracts

### DIFF
--- a/.codex/skills/youaskm3-ops/SKILL.md
+++ b/.codex/skills/youaskm3-ops/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: youaskm3-ops
+description: Start or resume the standard youaskm3 operating model when the user says YOUASKM3 OPS, asks to start youaskm3 ops/dev work, asks for the ready-ticket worker, PR finisher, backlog gardener, spec/contracts gardener, or wants Codex to pick ready GitHub Project 3 MVP work and run the youaskm3 coordination process.
+---
+
+# youaskm3 Ops
+
+Use this skill when the user wants Codex to start or resume the standard youaskm3 operating model.
+
+Canonical trigger:
+
+```text
+YOUASKM3 OPS
+```
+
+## Workflow
+
+1. Read `SPEC.md` before implementation work.
+2. Read `README.md`, `CONTRIBUTING.md`, `docs/mvp-ticket-backlog.md`, and `docs/traverse-mvp-requirements.md` when they are relevant to the requested lane.
+3. Inspect current GitHub issues, PRs, and Project 3 state.
+4. Prefer finishing existing open PRs before claiming new Ready work.
+5. If no active PR needs attention, pick one Ready Project 3 issue.
+6. Before work on an issue, run ownership pre-flight checks:
+   - issue must not have `agent:claude`
+   - no remote `claude/issue-NNN-*` branch may exist
+   - issue must not already be owned by another active agent
+7. If pre-flight passes, claim the issue:
+   - add `agent:codex`
+   - set Project 3 Agent to `Codex` when project write access is available
+   - set Project 3 Status to `In Progress` when project write access is available
+   - if project write access is unavailable, report the limitation before coding
+8. Use a dedicated `codex/issue-NNN-*` branch.
+9. Keep work scoped to the claimed issue, governing OpenSpec spec, and MVP contract boundary.
+10. Open a dedicated PR with validation evidence.
+
+## Operating Lanes
+
+- **Ready-ticket worker:** claim one Ready Project 3 issue and implement it end to end.
+- **PR finisher:** inspect open PRs, fix CI/review issues, update stale branches, and merge when green if allowed.
+- **Backlog gardener:** audit Project 3 statuses, labels, blockers, notes, missing tickets, and ticket/spec mismatches.
+- **Spec/contracts gardener:** align `README.md`, `SPEC.md`, `openspec/specs/`, `contracts/`, and smoke validation with the approved MVP direction.
+- **Traverse dependency checker:** verify whether blocked youaskm3 tickets depend on Traverse runtime requirements in `docs/traverse-mvp-requirements.md`.
+
+## Project Guardrails
+
+- Do not mark work `In Progress` unless a real dev thread has started it.
+- Do not use labels as status; Project 3 status is the actionability source of truth.
+- Do not claim work already owned by Claude Code or another active agent.
+- Do not broaden scope beyond the issue and governing spec.
+- Create future tickets for non-blocking improvements instead of expanding an active slice.
+- Keep all product/business logic portable and Traverse/WASM-bound.
+- Keep the PWA UI-only and the CLI artifact/build-focused.
+- Temporary harnesses are allowed only when they mirror the future Traverse contract and are clearly replaceable.
+
+## Validation
+
+Default validation for implementation work:
+
+```bash
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+For docs/spec-only changes, at minimum run the relevant focused smoke script and explain why full smoke was skipped.
+
+For the full operating model, see `docs/youaskm3-ops.md`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **your knowledge, queryable**
 
-youaskm3 is an open source, WASM-native, MCP-powered personal knowledge project for turning your books, papers, notes, and source material into something you can query, inspect, fork, and evolve in the open.
+youaskm3 is an open source, WASM-native, MCP-powered personal knowledge product for turning your books, papers, notes, and source material into a local-first chat experience you can query, inspect, fork, and evolve in the open.
 
 It is designed on top of [Traverse](https://github.com/enricopiovesan/Traverse) and the broader [Universal Microservices Architecture](https://github.com/enricopiovesan/UMA-code-examples) direction: portable capability contracts, governed specs, and runtime surfaces that stay usable across tools and hosts.
 
@@ -29,8 +29,8 @@ Most personal knowledge tooling locks your context inside closed products, hoste
 
 youaskm3 is for people who want to:
 
-- ingest source material like PDFs into a git-tracked knowledge base
-- prepare knowledge artifacts that can later be queried through MCP-capable clients
+- ingest source material like PDFs, DOCX files, slides, notes, and articles into a git-tracked knowledge base
+- prepare markdown, chunk, search, and graph artifacts that can be queried by the chat product
 - run a strict, deterministic development workflow with CI, coverage, and spec gates
 - build an agent-friendly repo where humans and coding agents can work from the same source of truth
 
@@ -44,6 +44,8 @@ If you clone this repository right now, you can:
 - ingest a PDF or URL into the knowledge structure with `./scripts/m3.sh add`
 - generate static knowledge artifacts and WASM builds with `./scripts/m3.sh build`
 - refresh generated artifacts incrementally with `./scripts/m3.sh sync`
+- query the generated local search index with `./scripts/m3.sh search <query>`
+- serve the static PWA shell locally with `./scripts/m3.sh serve [port]`
 - inspect and extend the current Rust crates for `core`, `ingest`, `search`, and `mcp`
 - work against real OpenSpec contracts and CI gates instead of placeholders
 
@@ -51,8 +53,9 @@ If you clone this repository right now, you can:
 
 This repository is not yet a finished end-user product. The main gaps today are:
 
-- no polished end-user query workflow in the README yet
-- no stable `m3 search` or `m3 serve` command in the repo command surface
+- no finished end-user chat loop over Traverse-run WASM capabilities
+- no production graph artifact generator yet
+- no finished local LLM/inference capability delegated through Traverse yet
 - no finished fork-and-run onboarding path for a brand-new user in under 15 minutes
 - no complete federation explore experience
 - no full cross-instance search fan-out flow
@@ -108,6 +111,8 @@ This repo is intentionally structured so humans and agents can navigate the same
 | Learn contribution rules | [CONTRIBUTING.md](CONTRIBUTING.md) |
 | Review active capability specs | [openspec/specs/](openspec/specs/) |
 | Review current MCP contracts | [contracts/mcp-tools.json](contracts/mcp-tools.json) |
+| Review MVP capability contracts | [contracts/capabilities/](contracts/capabilities/) |
+| Start or resume ops workflow | [docs/youaskm3-ops.md](docs/youaskm3-ops.md) |
 | Inspect the repo command surface | [scripts/m3.sh](scripts/m3.sh) |
 | Run the full validation path | [scripts/smoke.sh](scripts/smoke.sh) |
 | Review current knowledge layout | [knowledge/index.md](knowledge/index.md) |
@@ -117,7 +122,7 @@ This repo is intentionally structured so humans and agents can navigate the same
 The current repo-level command entrypoint is:
 
 ```bash
-./scripts/m3.sh {init|add|build|sync|test|lint|smoke|status}
+./scripts/m3.sh {init|add|build|sync|search|serve|test|lint|smoke|status}
 ```
 
 Available now:
@@ -126,6 +131,8 @@ Available now:
 - `m3 add` routes PDF and URL ingest into the knowledge structure
 - `m3 build` generates static knowledge artifacts and validates native plus `wasm32-wasip1` builds
 - `m3 sync` refreshes generated artifacts without forcing a full rebuild every time
+- `m3 search <query>` queries the generated local search index from the CLI
+- `m3 serve [port]` serves the static PWA shell from `app/site` for local inspection
 - `m3 smoke` runs the full repository validation path
 
 ## Project Standards
@@ -148,15 +155,24 @@ youaskm3 is not an isolated experiment. It sits in a larger line of work:
 
 Traverse answers the runtime question. youaskm3 applies that model to personal knowledge.
 
+For the first MVP, the boundary is strict:
+
+- `youaskm3` CLI owns source discovery, MarkItDown-backed conversion, normalization, artifact writing, build/sync, and local serving.
+- `Traverse` owns runtime execution of product/business behavior as governed WASM capabilities or agents.
+- The PWA owns UI only: chat input, rendering answers, rendering sources, graph views, and execution status.
+- Query planning, retrieval ranking, graph traversal, context packing, inference selection, answer grounding, and response formatting are capability contracts, not browser or CLI shortcuts.
+
 ## Roadmap
 
 | Milestone | Focus |
 |---|---|
-| M1 | Knowledge ingest and indexing |
-| M2 | WASM MCP core and contracts |
-| M3 | PWA chat shell |
-| M4 | Fork-and-run workflow |
-| M5 | Federation and registry |
+| MVP-1 | Spec and contract reset around local-first chat, Traverse runtime boundaries, and artifact schemas |
+| MVP-2 | MarkItDown default conversion, normalized markdown artifacts, deterministic chunks, and fixture corpus |
+| MVP-3 | Search and graph artifact generation with source and chunk evidence |
+| MVP-4 | UI-only PWA chat shell wired to a temporary Traverse-compatible runtime harness |
+| MVP-5 | Traverse application bundle registration and real WASM capability execution |
+| MVP-6 | Local/server inference capability delegated through Traverse placement and dependency resolution |
+| Later | Fork-and-run polish, federation, cross-instance search, and registry workflows |
 
 Roadmap source: [SPEC.md](SPEC.md#8-milestones) and [GitHub Project 3](https://github.com/users/enricopiovesan/projects/3).
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -7,31 +7,33 @@
 **Born:** Golden, BC — Purcell Mountains  
 **Spec framework:** [OpenSpec](https://openspec.dev/)  
 **Spec version:** 0.1.0  
-**Status:** Foundation
+**Status:** MVP specification reset
 
 ---
 
 ## 1. Vision
 
-youaskm3 is an open source, WASM-native, MCP-powered personal knowledge layer. It ingests everything you write, read, and save — books, white papers, blog posts, YouTube transcripts, articles, notes — and makes it all queryable via any LLM or chat interface.
+youaskm3 is an open source, WASM-native, MCP-powered personal knowledge product. It ingests everything you write, read, and save — books, white papers, blog posts, YouTube transcripts, articles, notes — and turns those files into a local-first chat experience grounded in user-owned markdown, search, chunk, and graph artifacts.
 
 The system answers as *you*: in your voice, from your accumulated thinking.
 
-Anyone can fork it, fill it with their own knowledge, and run their own instance for free on GitHub Pages. Instances can optionally federate through a shared registry, making knowledge discoverable across the network.
+Anyone can fork it, fill it with their own knowledge, and run their own instance for free on GitHub Pages. Runtime business behavior is delegated to Traverse as governed WASM capabilities so the same application logic can run locally, on a server, or through MCP as Traverse placement improves. Instances can optionally federate through a shared registry, making knowledge discoverable across the network.
 
-**Core promise:** no server, no database, no cost, no lock-in. Git is the infrastructure.
+**Core promise:** no mandatory hosted service, no database, no lock-in. Git is the infrastructure, the browser is the product surface, and Traverse is the portable business-logic runtime.
 
 ---
 
 ## 2. Design Principles
 
 1. **Specs are the source of truth.** Code, tests, and PRs must align with approved specs. A PR that drifts from spec fails review.
-2. **WASM-first portability.** Business logic compiles to WASM and runs identically in browser, edge, cloud, and CLI. No host-specific shortcuts.
+2. **WASM-first portability.** Business logic compiles to WASM and runs through Traverse across browser, edge, cloud, CLI, and MCP hosts. No host-specific shortcuts.
 3. **Contracts before code.** Every capability is defined by an explicit contract before implementation begins.
 4. **100% business logic test coverage.** No exceptions. Coverage is enforced in CI — a PR that drops coverage below 100% does not merge.
 5. **Production quality from day one.** No prototype shortcuts in core paths. Quality standards apply from the first commit.
 6. **Open by default.** Apache-2.0 licensed. Designed to be forked, extended, and contributed to.
-7. **Git as infrastructure.** Knowledge store, registry, deployment, and history are all git-native. No external services required.
+7. **Git as infrastructure.** Knowledge store, registry, deployment, and history are all git-native. No mandatory external services required.
+8. **UI-only product shell.** The PWA renders chat, sources, graph context, and traces; it does not own retrieval, ranking, graph traversal, context packing, inference selection, answer validation, or response formatting.
+9. **CLI as artifact builder.** The CLI may convert files, normalize markdown, write artifacts, build, sync, serve, and register bundles; product semantics belong in Traverse-run capabilities.
 
 ---
 
@@ -42,8 +44,9 @@ Anyone can fork it, fill it with their own knowledge, and run their own instance
 |---|---|---|
 | Business logic | **Rust → WASM** | Portable, safe, fast. Runs anywhere. |
 | WASM runtime | **Wasmtime** (CLI/server) / **browser native** | Same module, different host |
-| Runtime model | **Traverse v0.1 / UMA** | Contract-driven, governed, explainable release surface |
+| Runtime model | **Traverse v0.3 baseline / UMA** | Contract-driven, governed, explainable release surface for portable capabilities |
 | MCP interface | **WASM MCP module** | Portable MCP server compiled to WASM |
+| Runtime integration | **Traverse app bundle** | Registers capability contracts, event contracts, workflows, WASM packages, and model dependencies |
 
 ### Frontend
 | Layer | Technology | Rationale |
@@ -57,9 +60,12 @@ Anyone can fork it, fill it with their own knowledge, and run their own instance
 | Layer | Technology | Rationale |
 |---|---|---|
 | Format | **Markdown** | Human-readable, LLM-native, git-diffable |
+| Conversion | **MarkItDown** | Default source-to-markdown conversion layer for supported office, PDF, and document formats |
+| Chunks | **Static JSON + markdown refs** | Deterministic context units with source and section evidence |
+| Graph | **Static JSON graph artifact** | Source-aware nodes and edges for graph-backed context |
 | Diagrams | **Mermaid** | Plain text, renders in GitHub, LLM-readable |
 | Index | **Static JSON** | Generated at build time, no DB needed |
-| Search | **WASM vector search** | Runs client-side, no server |
+| Search | **WASM retrieval capability** | Runs through Traverse locally or remotely based on placement |
 | Version control | **Git** | The only database you need |
 
 ### Tooling & infrastructure
@@ -89,6 +95,10 @@ youaskm3/
 │   │   │   └── spec.md
 │   │   ├── knowledge-search/
 │   │   │   └── spec.md
+│   │   ├── knowledge-graph/
+│   │   │   └── spec.md
+│   │   ├── traverse-integration/
+│   │   │   └── spec.md
 │   │   ├── mcp-interface/
 │   │   │   └── spec.md
 │   │   ├── federation/
@@ -106,10 +116,14 @@ youaskm3/
 │   └── youaskm3-mcp/           ← WASM MCP server module
 │
 ├── contracts/
+│   ├── capabilities/           ← MVP product capability contracts
+│   ├── markdown-artifact.schema.json
+│   ├── knowledge-graph.schema.json
 │   └── mcp-tools.json          ← MCP tool definitions as UMA contracts
 │
 ├── tools/
-│   ├── pdf2m3/                 ← PDF → structured markdown converter
+│   ├── markitdown2m3/          ← MarkItDown → normalized markdown wrapper
+│   ├── pdf2m3/                 ← legacy PDF → structured markdown converter
 │   └── url2m3/                 ← URL/transcript → markdown ingester
 │
 ├── app/
@@ -169,14 +183,17 @@ idea → /openspec:proposal → proposal.md + design.md + tasks.md + spec delta
 
 ### Traverse integration baseline
 
-youaskm3 integrates with Traverse through documented public release surfaces instead of private Traverse internals. The current baseline is the Traverse v0.1 app-consumable release path:
+youaskm3 integrates with Traverse through documented public release surfaces instead of private Traverse internals. The current working baseline is the Traverse v0.3 readiness path described in [docs/traverse-mvp-requirements.md](docs/traverse-mvp-requirements.md):
 
-- versioned consumer bundle: Traverse `docs/app-consumable-consumer-bundle.md`
-- browser-hosted path: Traverse browser consumer package and browser adapter docs
-- MCP-facing path: Traverse `traverse-mcp` stdio server and MCP library surface
-- validation path: Traverse `youaskm3` integration, compatibility conformance, published artifact, and real shell validation scripts
+- governed application bundle registration
+- WASM business capability execution
+- evented workflow composition
+- app-facing HTTP/JSON execution path
+- MCP-facing execution path
+- public traces for answer grounding
+- local/server placement and model dependency resolution
 
-Roadmap work that touches runtime, MCP, browser hosting, or fork-and-run setup must pin an approved Traverse release pairing and include the relevant Traverse validation path.
+Roadmap work that touches runtime, MCP, browser hosting, model inference, or fork-and-run setup must pin an approved Traverse release pairing and include the relevant Traverse validation path.
 
 ### Spec format (OpenSpec)
 
@@ -280,71 +297,54 @@ Dual-licensed: **MIT** and **Apache-2.0**. Users choose.
 
 ## 8. Milestones
 
-### M0 — Foundation *(now)*
-- [ ] Repo created: `github.com/youaskm3/youaskm3`
-- [ ] This SPEC.md committed as the root document
-- [ ] OpenSpec installed and configured
-- [ ] `openspec/specs/` directory seeded with initial capability specs
-- [ ] CI skeleton: lint, test, coverage, WASM build
-- [ ] LICENSE-MIT, LICENSE-APACHE, README, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY
-- [ ] Cargo workspace with `youaskm3-core` stub
-- [ ] rust-toolchain.toml pinned
-- [ ] youaskm3.com domain connected to GitHub Pages
+### MVP-1 — Spec and Contract Reset *(now)*
+- [ ] README and SPEC describe the chat-first MVP.
+- [ ] OpenSpec capabilities cover ingest, search, graph, PWA shell, MCP, and Traverse integration.
+- [ ] MVP capability contracts exist for query, retrieval, graph expansion, context packing, inference, answer validation, and answer formatting.
+- [ ] Markdown and graph artifact schemas are machine-checkable.
+- [ ] Smoke validation checks the new specs and contracts.
 
-### M1 — Knowledge layer *(v0.1)*
-- [ ] Spec: `openspec/specs/knowledge-ingest/spec.md`
-- [ ] `pdf2m3` tool: PDF → structured markdown with chapter chunking
-- [ ] Mermaid diagram generation from visual PDF pages (via Claude API)
-- [ ] `url2m3` tool: URL/transcript → markdown
-- [ ] `knowledge/index.md` auto-generated from content
-- [ ] `youaskm3-ingest` crate: 100% coverage
-- [ ] Author's books, white papers, blog posts ingested as first content
+### MVP-2 — Artifact Pipeline
+- [ ] MarkItDown is the default source-to-markdown converter.
+- [ ] Normalized markdown artifacts include stable ids, source metadata, conversion metadata, sections, chunks, and graph hints.
+- [ ] Deterministic chunks are generated from processed markdown, not raw captures.
+- [ ] A small fixture corpus validates search, graph, and chat flows without private content.
+- [ ] `m3 build` and `m3 sync` produce the full static artifact set.
 
-### M2 — WASM MCP core *(v0.2)*
-- [ ] Spec: `openspec/specs/mcp-interface/spec.md`
-- [ ] `contracts/mcp-tools.json` — UMA contracts for all MCP tools
-- [ ] `youaskm3-search` crate: WASM vector search
-- [ ] Traverse v0.1 release pairing pinned for runtime, browser consumer, and MCP surfaces
-- [ ] `youaskm3-mcp` crate acts as a thin integration adapter over the supported Traverse MCP/library surface where possible
-- [ ] MCP tools: `search`, `remember`, `recall`, `connect` mapped to contract-defined Traverse-compatible tool semantics
-- [ ] Runs through documented Traverse MCP/CLI validation paths before claiming browser, CLI, or edge compatibility
-- [ ] Built on the Traverse v0.1 app-consumable runtime model, not a bespoke runtime fork
-- [ ] 100% test coverage on all crates
+### MVP-3 — Search and Graph Evidence
+- [ ] Search artifacts include source paths, chunk ids, excerpts, and deterministic scoring inputs.
+- [ ] Graph artifacts include nodes, edges, source artifact ids, source chunk ids, labels, extraction method, confidence, and deterministic ordering.
+- [ ] Retrieval and graph expansion run behind Traverse-compatible capability contracts.
+- [ ] Empty, stale, and invalid artifact states return machine-readable failures.
 
-### M3 — Chat interface *(v0.3)*
-- [ ] Spec: `openspec/specs/pwa-shell/spec.md`
-- [ ] PWA shell: installable, offline-capable
-- [ ] Web Components: `<m3-chat>`, `<m3-result>`, `<m3-source>`
-- [ ] Browser-hosted runtime path consumes the Traverse browser consumer package/adapter or its approved release successor
-- [ ] WASM/MCP behavior is validated through the Traverse `youaskm3` real shell validation path
-- [ ] youaskm3.com serves author's instance
-- [ ] Claude API integration (configurable key)
-- [ ] Works with any MCP-compatible LLM
+### MVP-4 — UI-Only PWA Chat
+- [ ] The PWA provides the first user-facing product: a local-first chat interface.
+- [ ] Web Components render chat messages, source cards, graph evidence, and execution status.
+- [ ] The PWA can call a temporary local harness that exactly mirrors the Traverse app-facing contract.
+- [ ] The PWA contains no retrieval, ranking, graph traversal, prompt construction, inference selection, or answer validation logic.
 
-### M4 — Fork and run your own *(v0.4)*
-- [ ] `m3 init` — interactive setup for new instances
-- [ ] `m3 build` — generates index, compiles WASM, prepares site
-- [ ] `m3 sync` — incremental re-index on content changes
-- [ ] GitHub Actions template included in repo
-- [ ] Traverse release pairing and compatibility conformance commands documented for forked instances
-- [ ] One-command setup documented in README
-- [ ] Setup time target: under 15 minutes
+### MVP-5 — Traverse Runtime Integration
+- [ ] The CLI registers a Traverse application bundle through public APIs.
+- [ ] The bundle includes capability contracts, event contracts, workflows, WASM package manifests, binary digests, runtime constraints, and model dependencies.
+- [ ] Traverse executes the same product workflow through app-facing HTTP/JSON and MCP surfaces.
+- [ ] Execution traces include capability versions, placement, source evidence, graph evidence, inference dependency, validation outcome, and failure reasons.
 
-### M5 — Federation *(v1.0)*
-- [ ] Spec: `openspec/specs/federation/spec.md`
-- [ ] `github.com/youaskm3/registry` repo created
-- [ ] `instances.json` format defined
-- [ ] PR-based join process documented
-- [ ] Explore page at youaskm3.com (`/explore`)
-- [ ] Browse by topic across registered instances
-- [ ] Nightly GitHub Action: crawl registered instances, build cross-instance index
-- [ ] Cross-instance search (client-side fan-out)
+### MVP-6 — Local-First Inference Through Traverse
+- [ ] `knowledge.infer` declares inference needs by contract instead of hardcoding a provider.
+- [ ] Traverse can run a compatible local WASM inference capability when available.
+- [ ] Traverse can choose a server-side inference capability when allowed and available.
+- [ ] Missing inference capability fails clearly before user-facing execution begins.
+
+### Later — Fork, Federation, and Network Effects
+- [ ] One-command setup documented in README with a target under 15 minutes.
+- [ ] `youaskm3.com` serves the author's public instance.
+- [ ] Federation registry and cross-instance search remain separate from the first MVP.
 
 ---
 
 ## 9. MCP Tools (initial set)
 
-Defined as UMA contracts in `contracts/mcp-tools.json`.
+Defined as UMA contracts in `contracts/mcp-tools.json`; MVP product capabilities are defined separately under `contracts/capabilities/` and exposed through Traverse app-facing and MCP surfaces.
 
 | Tool | Description |
 |---|---|
@@ -355,9 +355,25 @@ Defined as UMA contracts in `contracts/mcp-tools.json`.
 | `list_sources` | List all indexed sources with metadata |
 | `status` | Report index status, last sync, coverage |
 
+## 10. MVP Product Capabilities
+
+The first chat workflow is composed from these product-level capability contracts:
+
+| Capability | Description |
+|---|---|
+| `knowledge.query.answer` | User-facing workflow entrypoint that returns a grounded answer envelope |
+| `knowledge.retrieve` | Source-aware retrieval over prepared search and chunk artifacts |
+| `knowledge.graph.expand` | Graph context expansion from retrieved chunks, topics, or cited nodes |
+| `knowledge.context.pack` | Deterministic context construction within model limits |
+| `knowledge.infer` | Model inference dependency resolved and placed by Traverse |
+| `knowledge.answer.validate` | Grounding, citation, and failure validation |
+| `knowledge.answer.format` | Final response shaping for chat and MCP clients |
+
+All seven capabilities must run as governed WASM capabilities or agents through Traverse for the production MVP. Temporary local harnesses are allowed only when they implement the same contract envelopes and are marked as replaceable.
+
 ---
 
-## 10. Knowledge Structure
+## 11. Knowledge Structure
 
 ```
 knowledge/
@@ -388,7 +404,7 @@ knowledge/
 
 ---
 
-## 11. Federation Protocol
+## 12. Federation Protocol
 
 ### Instance registration
 An instance joins the federation by opening a PR to `youaskm3/registry` adding one JSON entry to `instances.json`:
@@ -418,7 +434,7 @@ A nightly GitHub Action in `youaskm3/registry`:
 
 ---
 
-## 12. CLI Reference (`m3`)
+## 13. CLI Reference (`m3`)
 
 ```bash
 m3 init                  # interactive setup for new instance
@@ -432,7 +448,7 @@ m3 serve                 # local dev server
 
 ---
 
-## 13. Non-Goals
+## 14. Non-Goals
 
 The following are explicitly out of scope for v1.0:
 

--- a/contracts/capabilities/knowledge.answer.format.json
+++ b/contracts/capabilities/knowledge.answer.format.json
@@ -1,0 +1,43 @@
+{
+  "kind": "youaskm3.capability_contract",
+  "schema_version": "1.0.0",
+  "id": "knowledge.answer.format",
+  "version": "0.1.0",
+  "lifecycle": "mvp",
+  "summary": "Format validated answer envelopes for chat and MCP clients.",
+  "description": "Shapes final answer text, citations, source cards, graph evidence, and trace references without changing business meaning.",
+  "execution": {
+    "runtime": "traverse",
+    "business_logic": "wasm",
+    "permitted_targets": ["local", "server", "mcp"],
+    "requires_trace": true
+  },
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "raw_answer": { "type": "string" },
+        "citations": { "type": "array", "items": { "type": "object" } },
+        "graph_evidence": { "type": "array", "items": { "type": "object" } },
+        "validation": { "type": "object" },
+        "target": { "type": "string", "enum": ["chat", "mcp"] }
+      },
+      "required": ["raw_answer", "citations", "graph_evidence", "validation", "target"],
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "answer": { "type": "string" },
+        "source_cards": { "type": "array", "items": { "type": "object" } },
+        "graph_cards": { "type": "array", "items": { "type": "object" } },
+        "trace_id": { "type": "string" },
+        "display_status": { "type": "string", "enum": ["grounded", "needs_review", "failed"] }
+      },
+      "required": ["answer", "source_cards", "graph_cards", "trace_id", "display_status"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/contracts/capabilities/knowledge.answer.validate.json
+++ b/contracts/capabilities/knowledge.answer.validate.json
@@ -1,0 +1,52 @@
+{
+  "kind": "youaskm3.capability_contract",
+  "schema_version": "1.0.0",
+  "id": "knowledge.answer.validate",
+  "version": "0.1.0",
+  "lifecycle": "mvp",
+  "summary": "Validate answer grounding, citations, and graph evidence.",
+  "description": "Checks that an answer is supported by source chunks and graph evidence before the product renders it as grounded.",
+  "execution": {
+    "runtime": "traverse",
+    "business_logic": "wasm",
+    "permitted_targets": ["local", "server", "mcp"],
+    "requires_trace": true
+  },
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "answer": { "type": "string" },
+        "citations": { "type": "array", "items": { "type": "object" } },
+        "retrieved_chunks": { "type": "array", "items": { "type": "object" } },
+        "graph_evidence": { "type": "array", "items": { "type": "object" } }
+      },
+      "required": ["answer", "citations", "retrieved_chunks", "graph_evidence"],
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "status": { "type": "string", "enum": ["valid", "invalid", "partial"] },
+        "checks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "status": { "type": "string", "enum": ["pass", "fail", "warn"] },
+              "message": { "type": "string" }
+            },
+            "required": ["name", "status", "message"],
+            "additionalProperties": false
+          }
+        },
+        "trace_id": { "type": "string" }
+      },
+      "required": ["status", "checks", "trace_id"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/contracts/capabilities/knowledge.context.pack.json
+++ b/contracts/capabilities/knowledge.context.pack.json
@@ -1,0 +1,42 @@
+{
+  "kind": "youaskm3.capability_contract",
+  "schema_version": "1.0.0",
+  "id": "knowledge.context.pack",
+  "version": "0.1.0",
+  "lifecycle": "mvp",
+  "summary": "Build bounded prompt context from retrieved chunks and graph evidence.",
+  "description": "Constructs deterministic context packages inside model limits while preserving source and graph references.",
+  "execution": {
+    "runtime": "traverse",
+    "business_logic": "wasm",
+    "permitted_targets": ["local", "server", "mcp"],
+    "requires_trace": true
+  },
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "query": { "type": "string", "minLength": 1 },
+        "retrieved_chunks": { "type": "array", "items": { "type": "object" } },
+        "graph_evidence": { "type": "array", "items": { "type": "object" } },
+        "token_budget": { "type": "integer", "minimum": 256, "maximum": 32768 }
+      },
+      "required": ["query", "retrieved_chunks", "graph_evidence", "token_budget"],
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "context": { "type": "string" },
+        "included_chunk_ids": { "type": "array", "items": { "type": "string" } },
+        "included_edge_ids": { "type": "array", "items": { "type": "string" } },
+        "omitted_reasons": { "type": "array", "items": { "type": "string" } },
+        "trace_id": { "type": "string" }
+      },
+      "required": ["context", "included_chunk_ids", "included_edge_ids", "omitted_reasons", "trace_id"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/contracts/capabilities/knowledge.graph.expand.json
+++ b/contracts/capabilities/knowledge.graph.expand.json
@@ -1,0 +1,53 @@
+{
+  "kind": "youaskm3.capability_contract",
+  "schema_version": "1.0.0",
+  "id": "knowledge.graph.expand",
+  "version": "0.1.0",
+  "lifecycle": "mvp",
+  "summary": "Expand source-backed graph context around retrieved evidence.",
+  "description": "Consumes graph artifacts and retrieved chunks to return bounded graph evidence for answer context.",
+  "execution": {
+    "runtime": "traverse",
+    "business_logic": "wasm",
+    "permitted_targets": ["local", "server", "mcp"],
+    "requires_trace": true
+  },
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "graph_path": { "type": "string" },
+        "seed_chunk_ids": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+        "max_hops": { "type": "integer", "minimum": 0, "maximum": 3 },
+        "max_edges": { "type": "integer", "minimum": 1, "maximum": 100 }
+      },
+      "required": ["graph_path", "seed_chunk_ids"],
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "nodes": { "$ref": "knowledge-graph.schema.json#/properties/nodes" },
+        "edges": { "$ref": "knowledge-graph.schema.json#/properties/edges" },
+        "trace_id": { "type": "string" },
+        "failure": { "$ref": "#/$defs/failure" }
+      },
+      "required": ["nodes", "edges", "trace_id"],
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "failure": {
+      "type": "object",
+      "properties": {
+        "code": { "type": "string" },
+        "message": { "type": "string" },
+        "recoverable": { "type": "boolean" }
+      },
+      "required": ["code", "message", "recoverable"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/contracts/capabilities/knowledge.infer.json
+++ b/contracts/capabilities/knowledge.infer.json
@@ -1,0 +1,62 @@
+{
+  "kind": "youaskm3.capability_contract",
+  "schema_version": "1.0.0",
+  "id": "knowledge.infer",
+  "version": "0.1.0",
+  "lifecycle": "mvp",
+  "summary": "Inference dependency resolved and placed by Traverse.",
+  "description": "Declares model inference as a governed capability so youaskm3 does not hardcode local, server, or external providers.",
+  "execution": {
+    "runtime": "traverse",
+    "business_logic": "wasm_or_agent",
+    "permitted_targets": ["local", "server"],
+    "requires_trace": true
+  },
+  "model_dependencies": [
+    {
+      "interface_id": "knowledge.inference.text.generate",
+      "version": "0.1.0",
+      "required": true,
+      "placement": ["local", "server"],
+      "notes": "Traverse resolves this dependency. youaskm3 does not select Ollama, WebLLM, llama.cpp, or cloud APIs directly."
+    }
+  ],
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "prompt": { "type": "string", "minLength": 1 },
+        "context": { "type": "string" },
+        "max_output_tokens": { "type": "integer", "minimum": 1, "maximum": 8192 }
+      },
+      "required": ["prompt", "context"],
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "text": { "type": "string" },
+        "selected_inference_capability": { "type": "string" },
+        "placement": { "type": "string", "enum": ["local", "server"] },
+        "trace_id": { "type": "string" },
+        "failure": { "$ref": "#/$defs/failure" }
+      },
+      "required": ["text", "selected_inference_capability", "placement", "trace_id"],
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "failure": {
+      "type": "object",
+      "properties": {
+        "code": { "type": "string" },
+        "message": { "type": "string" },
+        "recoverable": { "type": "boolean" }
+      },
+      "required": ["code", "message", "recoverable"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/contracts/capabilities/knowledge.query.answer.json
+++ b/contracts/capabilities/knowledge.query.answer.json
@@ -1,0 +1,92 @@
+{
+  "kind": "youaskm3.capability_contract",
+  "schema_version": "1.0.0",
+  "id": "knowledge.query.answer",
+  "version": "0.1.0",
+  "lifecycle": "mvp",
+  "summary": "User-facing chat answer workflow entrypoint.",
+  "description": "Coordinates retrieval, graph expansion, context packing, inference, validation, and formatting behind the Traverse runtime boundary.",
+  "execution": {
+    "runtime": "traverse",
+    "business_logic": "wasm",
+    "permitted_targets": ["local", "server", "mcp"],
+    "requires_trace": true
+  },
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "query": { "type": "string", "minLength": 1 },
+        "conversation_id": { "type": "string" },
+        "artifact_scope": { "type": "array", "items": { "type": "string" } },
+        "max_sources": { "type": "integer", "minimum": 1, "maximum": 20 }
+      },
+      "required": ["query"],
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "answer": { "type": "string" },
+        "citations": { "$ref": "#/$defs/citations" },
+        "graph_evidence": { "$ref": "#/$defs/graphEvidence" },
+        "trace_id": { "type": "string" },
+        "validation": { "$ref": "#/$defs/validation" },
+        "failure": { "$ref": "#/$defs/failure" }
+      },
+      "required": ["answer", "citations", "graph_evidence", "trace_id", "validation"],
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "citations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "citation_id": { "type": "string" },
+          "artifact_id": { "type": "string" },
+          "chunk_id": { "type": "string" },
+          "source_path": { "type": "string" },
+          "excerpt": { "type": "string" }
+        },
+        "required": ["citation_id", "artifact_id", "chunk_id", "source_path", "excerpt"],
+        "additionalProperties": false
+      }
+    },
+    "graphEvidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "node_ids": { "type": "array", "items": { "type": "string" } },
+          "edge_ids": { "type": "array", "items": { "type": "string" } },
+          "supporting_chunk_ids": { "type": "array", "items": { "type": "string" } }
+        },
+        "required": ["node_ids", "edge_ids", "supporting_chunk_ids"],
+        "additionalProperties": false
+      }
+    },
+    "validation": {
+      "type": "object",
+      "properties": {
+        "status": { "type": "string", "enum": ["valid", "invalid", "partial"] },
+        "checks": { "type": "array", "items": { "type": "string" } }
+      },
+      "required": ["status", "checks"],
+      "additionalProperties": false
+    },
+    "failure": {
+      "type": "object",
+      "properties": {
+        "code": { "type": "string" },
+        "message": { "type": "string" },
+        "recoverable": { "type": "boolean" }
+      },
+      "required": ["code", "message", "recoverable"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/contracts/capabilities/knowledge.retrieve.json
+++ b/contracts/capabilities/knowledge.retrieve.json
@@ -1,0 +1,67 @@
+{
+  "kind": "youaskm3.capability_contract",
+  "schema_version": "1.0.0",
+  "id": "knowledge.retrieve",
+  "version": "0.1.0",
+  "lifecycle": "mvp",
+  "summary": "Source-aware retrieval over prepared knowledge artifacts.",
+  "description": "Returns ranked chunks from generated search and markdown artifacts without embedding retrieval behavior in the PWA.",
+  "execution": {
+    "runtime": "traverse",
+    "business_logic": "wasm",
+    "permitted_targets": ["local", "server", "mcp"],
+    "requires_trace": true
+  },
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "query": { "type": "string", "minLength": 1 },
+        "artifact_index_path": { "type": "string" },
+        "limit": { "type": "integer", "minimum": 1, "maximum": 50 }
+      },
+      "required": ["query", "artifact_index_path"],
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "results": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "artifact_id": { "type": "string" },
+              "chunk_id": { "type": "string" },
+              "title": { "type": "string" },
+              "source_path": { "type": "string" },
+              "excerpt": { "type": "string" },
+              "score": { "type": "number" },
+              "score_basis": { "type": "array", "items": { "type": "string" } }
+            },
+            "required": ["artifact_id", "chunk_id", "title", "source_path", "excerpt", "score", "score_basis"],
+            "additionalProperties": false
+          }
+        },
+        "trace_id": { "type": "string" },
+        "failure": { "$ref": "#/$defs/failure" }
+      },
+      "required": ["results", "trace_id"],
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "failure": {
+      "type": "object",
+      "properties": {
+        "code": { "type": "string" },
+        "message": { "type": "string" },
+        "recoverable": { "type": "boolean" }
+      },
+      "required": ["code", "message", "recoverable"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/contracts/examples/knowledge-graph.example.json
+++ b/contracts/examples/knowledge-graph.example.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "0.1.0",
+  "graph_id": "graph.mvp-fixture",
+  "generated_from": ["artifact.portable-runtime-note"],
+  "nodes": [
+    {
+      "node_id": "node.traverse",
+      "label": "Traverse",
+      "type": "runtime",
+      "source_artifact_ids": ["artifact.portable-runtime-note"],
+      "source_chunk_ids": ["chunk.runtime.001"]
+    },
+    {
+      "node_id": "node.wasm-capability",
+      "label": "WASM capability",
+      "type": "execution_unit",
+      "source_artifact_ids": ["artifact.portable-runtime-note"],
+      "source_chunk_ids": ["chunk.runtime.001"]
+    }
+  ],
+  "edges": [
+    {
+      "edge_id": "edge.traverse.runs.wasm",
+      "from_node_id": "node.traverse",
+      "to_node_id": "node.wasm-capability",
+      "relationship": "runs",
+      "source_artifact_ids": ["artifact.portable-runtime-note"],
+      "source_chunk_ids": ["chunk.runtime.001"],
+      "extraction_method": "fixture",
+      "confidence": 1
+    }
+  ]
+}

--- a/contracts/examples/markdown-artifact.example.json
+++ b/contracts/examples/markdown-artifact.example.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "0.1.0",
+  "artifact_id": "artifact.portable-runtime-note",
+  "title": "Portable Runtime Note",
+  "source": {
+    "type": "markdown",
+    "path": "knowledge/blog/portable-runtime-note.md",
+    "original_name": "portable-runtime-note.md"
+  },
+  "conversion": {
+    "tool": "markitdown",
+    "tool_version": "mvp-fixture",
+    "converted_at": "2026-06-13T00:00:00Z"
+  },
+  "sections": [
+    {
+      "section_id": "section.runtime",
+      "heading": "Runtime Boundary",
+      "markdown": "Business logic runs as governed WASM capabilities through Traverse.",
+      "source_locator": "line:1"
+    }
+  ],
+  "chunks": [
+    {
+      "chunk_id": "chunk.runtime.001",
+      "section_id": "section.runtime",
+      "token_estimate": 12,
+      "markdown": "Business logic runs as governed WASM capabilities through Traverse."
+    }
+  ],
+  "graph_hints": [
+    {
+      "hint_id": "hint.runtime.001",
+      "chunk_id": "chunk.runtime.001",
+      "label": "runtime_boundary",
+      "text": "Business logic runs through Traverse."
+    }
+  ]
+}

--- a/contracts/knowledge-graph.schema.json
+++ b/contracts/knowledge-graph.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://youaskm3.dev/contracts/knowledge-graph.schema.json",
+  "title": "youaskm3 knowledge graph artifact",
+  "type": "object",
+  "properties": {
+    "schema_version": { "type": "string" },
+    "graph_id": { "type": "string", "minLength": 1 },
+    "generated_from": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "nodes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "node_id": { "type": "string", "minLength": 1 },
+          "label": { "type": "string", "minLength": 1 },
+          "type": { "type": "string" },
+          "source_artifact_ids": { "type": "array", "items": { "type": "string" } },
+          "source_chunk_ids": { "type": "array", "items": { "type": "string" } }
+        },
+        "required": ["node_id", "label", "type", "source_artifact_ids", "source_chunk_ids"],
+        "additionalProperties": false
+      }
+    },
+    "edges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "edge_id": { "type": "string", "minLength": 1 },
+          "from_node_id": { "type": "string", "minLength": 1 },
+          "to_node_id": { "type": "string", "minLength": 1 },
+          "relationship": { "type": "string", "minLength": 1 },
+          "source_artifact_ids": { "type": "array", "items": { "type": "string" } },
+          "source_chunk_ids": { "type": "array", "items": { "type": "string" } },
+          "extraction_method": { "type": "string" },
+          "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+        },
+        "required": ["edge_id", "from_node_id", "to_node_id", "relationship", "source_artifact_ids", "source_chunk_ids", "extraction_method", "confidence"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["schema_version", "graph_id", "generated_from", "nodes", "edges"],
+  "additionalProperties": false
+}

--- a/contracts/markdown-artifact.schema.json
+++ b/contracts/markdown-artifact.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://youaskm3.dev/contracts/markdown-artifact.schema.json",
+  "title": "youaskm3 normalized markdown artifact",
+  "type": "object",
+  "properties": {
+    "schema_version": { "type": "string" },
+    "artifact_id": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 },
+    "source": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["pdf", "docx", "pptx", "html", "url", "text", "markdown", "other"] },
+        "path": { "type": "string" },
+        "url": { "type": "string" },
+        "original_name": { "type": "string" }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
+    "conversion": {
+      "type": "object",
+      "properties": {
+        "tool": { "type": "string", "minLength": 1 },
+        "tool_version": { "type": "string" },
+        "converted_at": { "type": "string" },
+        "command": { "type": "string" }
+      },
+      "required": ["tool"],
+      "additionalProperties": false
+    },
+    "sections": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "section_id": { "type": "string", "minLength": 1 },
+          "heading": { "type": "string" },
+          "markdown": { "type": "string" },
+          "source_locator": { "type": "string" }
+        },
+        "required": ["section_id", "heading", "markdown"],
+        "additionalProperties": false
+      }
+    },
+    "chunks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "chunk_id": { "type": "string", "minLength": 1 },
+          "section_id": { "type": "string" },
+          "token_estimate": { "type": "integer", "minimum": 1 },
+          "markdown": { "type": "string" }
+        },
+        "required": ["chunk_id", "section_id", "token_estimate", "markdown"],
+        "additionalProperties": false
+      }
+    },
+    "graph_hints": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "hint_id": { "type": "string" },
+          "chunk_id": { "type": "string" },
+          "label": { "type": "string" },
+          "text": { "type": "string" }
+        },
+        "required": ["hint_id", "chunk_id", "label", "text"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["schema_version", "artifact_id", "title", "source", "conversion", "sections", "chunks"],
+  "additionalProperties": false
+}

--- a/docs/graph-artifact-contract.md
+++ b/docs/graph-artifact-contract.md
@@ -1,0 +1,22 @@
+# Knowledge Graph Artifact Contract
+
+Status: MVP contract
+
+Knowledge graph artifacts are the source-backed graph representation used by the chat workflow.
+
+The artifact shape is owned by youaskm3. Graph generation tools can be swapped as long as they produce this contract. Graph traversal and graph expansion are runtime behavior and must run behind the `knowledge.graph.expand` capability.
+
+Required properties:
+
+- stable `graph_id`
+- deterministic `nodes`
+- deterministic `edges`
+- source artifact references
+- source chunk references
+- relationship labels
+- extraction method
+- confidence
+
+Validation source: `contracts/knowledge-graph.schema.json`.
+
+Example: `contracts/examples/knowledge-graph.example.json`.

--- a/docs/markdown-artifact-contract.md
+++ b/docs/markdown-artifact-contract.md
@@ -1,0 +1,21 @@
+# Normalized Markdown Artifact Contract
+
+Status: MVP contract
+
+Normalized markdown artifacts are the CLI-owned handoff between source conversion and runtime knowledge capabilities.
+
+The CLI may discover files, call MarkItDown, normalize text, write artifacts, and build indexes. Runtime product behavior starts after these artifacts exist.
+
+Required properties:
+
+- stable `artifact_id`
+- human-readable `title`
+- source type and source path or URL
+- conversion tool metadata
+- one or more sections
+- chunk ids suitable for retrieval and citation
+- optional graph extraction hints
+
+Validation source: `contracts/markdown-artifact.schema.json`.
+
+Example: `contracts/examples/markdown-artifact.example.json`.

--- a/docs/mvp-ticket-backlog.md
+++ b/docs/mvp-ticket-backlog.md
@@ -1,0 +1,785 @@
+# youaskm3 MVP Ticket Backlog
+
+Status: Draft implementation backlog
+Last updated: 2026-06-12
+
+## Goal
+
+This backlog breaks the first youaskm3 MVP into independent tickets that can be picked up by separate contributors or agents.
+
+The MVP target is:
+
+> A local-first PWA chat experience that answers from user-owned knowledge artifacts, with source attribution and graph context, while preparing the product to hand runtime business logic to Traverse as governed WASM capabilities.
+
+## Operating Rules
+
+- Each ticket must be independently understandable.
+- Each ticket must include a clear definition of done.
+- Each ticket must keep `bash scripts/smoke.sh` green.
+- Runtime/product business logic must move toward Traverse-compatible contracts and WASM capability boundaries.
+- Temporary harnesses are allowed only when they mimic the future Traverse boundary and are clearly marked as replaceable.
+- The CLI may own mechanical build/setup tasks.
+- The PWA may own rendering and interaction only.
+
+## Ticket MVP-001: Rewrite Roadmap Around the New MVP
+
+### Objective
+
+Update the public roadmap so it reflects the new product and architecture decisions:
+
+- MarkItDown is the default conversion layer.
+- The first MVP includes graph-backed chat.
+- The PWA chat is the user-facing product.
+- Traverse owns runtime/business capability execution.
+- youaskm3 owns artifact preparation and product contracts.
+
+### Scope
+
+Update:
+
+- `README.md`
+- `SPEC.md`
+- relevant `openspec/specs/*/spec.md` files if they conflict with the new direction
+
+### Out of Scope
+
+- Implementing graph generation
+- Implementing Traverse integration
+- Changing command behavior
+
+### Definition of Done
+
+- README roadmap matches the new milestone sequence.
+- SPEC milestones no longer describe stale M0-M5 assumptions as the current plan.
+- The first MVP is explicitly described as local-first PWA chat backed by markdown, graph, search, and Traverse-run capabilities.
+- The document distinguishes build-time CLI responsibilities from Traverse runtime responsibilities.
+- All changed docs are internally consistent.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-002: Define MVP Capability Contracts
+
+### Objective
+
+Create product-level contracts for the first chat workflow capabilities.
+
+These contracts are the target interface for Traverse and for any temporary local harness.
+
+### Required Capabilities
+
+- `knowledge.query.answer`
+- `knowledge.retrieve`
+- `knowledge.graph.expand`
+- `knowledge.context.pack`
+- `knowledge.infer`
+- `knowledge.answer.validate`
+- `knowledge.answer.format`
+
+### Scope
+
+Add contract files under a clear repo path, for example:
+
+- `contracts/capabilities/knowledge.query.answer.json`
+- `contracts/capabilities/knowledge.retrieve.json`
+- `contracts/capabilities/knowledge.graph.expand.json`
+- `contracts/capabilities/knowledge.context.pack.json`
+- `contracts/capabilities/knowledge.infer.json`
+- `contracts/capabilities/knowledge.answer.validate.json`
+- `contracts/capabilities/knowledge.answer.format.json`
+
+Each contract must include:
+
+- stable id
+- version
+- purpose
+- input schema
+- output schema
+- source/citation fields where relevant
+- trace/evidence fields where relevant
+- explicit notes about Traverse execution expectations
+
+### Out of Scope
+
+- Implementing the capabilities
+- Registering them with Traverse
+- Selecting a real LLM/model
+
+### Definition of Done
+
+- All seven contracts exist.
+- Each contract has a JSON schema for inputs and outputs.
+- Contracts are strict enough to prevent arbitrary unstructured blobs.
+- Contracts include source attribution requirements where relevant.
+- Contracts include graph evidence requirements where relevant.
+- Contracts include validation/failure output shapes.
+- A new contract smoke test validates that the files are parseable JSON and contain required fields.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+node -e "for (const f of require('fs').readdirSync('contracts/capabilities')) JSON.parse(require('fs').readFileSync('contracts/capabilities/' + f, 'utf8'))"
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-003: Define the Normalized Markdown Artifact Contract
+
+### Objective
+
+Define the canonical markdown format produced after MarkItDown/raw conversion.
+
+The goal is to make every source artifact traceable, chunkable, graph-ready, and indexable.
+
+### Scope
+
+Add documentation and validation for normalized markdown artifacts.
+
+Suggested files:
+
+- `docs/markdown-artifact-contract.md`
+- `contracts/markdown-artifact.schema.json`
+- smoke test script for sample artifacts
+
+The contract must define:
+
+- required metadata
+- source path or URL
+- source type
+- title
+- stable artifact id
+- ingestion/conversion tool metadata
+- content section requirements
+- source attribution rules
+- graph extraction hints if applicable
+
+### Out of Scope
+
+- Implementing graph generation
+- Implementing semantic cleanup
+- Replacing MarkItDown
+
+### Definition of Done
+
+- A clear markdown artifact contract exists.
+- At least one sample artifact validates against the contract.
+- Existing `markitdown2m3` output either conforms or has a documented follow-up gap.
+- Validation is added to smoke or a focused script called by smoke.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-004: Add a Real MVP Fixture Corpus
+
+### Objective
+
+Add a small, real-enough fixture corpus so the product loop can be tested without empty indexes or placeholder sample documents.
+
+### Scope
+
+Create a minimal corpus with:
+
+- one note
+- one article-like document
+- one paper/book-like document
+- metadata/source attribution
+- at least three chunks total
+
+Suggested location:
+
+- `knowledge/fixtures/` for source fixtures, or
+- `knowledge/books/`, `knowledge/papers/`, `knowledge/blog/` if intended to be part of the visible default instance
+
+### Out of Scope
+
+- Large author corpus ingestion
+- Real private/personal content
+- Federation
+
+### Definition of Done
+
+- `app/site/search-index.json` generated from the fixture corpus contains at least three documents.
+- `m3 search` returns results for at least two fixture queries.
+- Fixtures are small enough for repo use.
+- Fixtures do not include copyrighted long-form content.
+- Smoke or a focused test checks that the search index is non-empty.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+./scripts/m3.sh sync
+./scripts/m3.sh search portable
+./scripts/m3.sh search architecture
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-005: Define Graph Artifact Contract
+
+### Objective
+
+Define the graph artifact shape before choosing or integrating Graphy.
+
+The graph contract must be owned by youaskm3. Graphy can be evaluated against it later.
+
+### Scope
+
+Add:
+
+- `docs/graph-artifact-contract.md`
+- `contracts/knowledge-graph.schema.json`
+- sample graph artifact
+
+The graph artifact must support:
+
+- nodes
+- edges
+- source artifact references
+- source chunk references
+- labels/types
+- confidence or extraction method
+- stable ids
+- deterministic ordering
+
+### Out of Scope
+
+- Graphy integration
+- graph visualization
+- graph traversal implementation
+
+### Definition of Done
+
+- Graph artifact schema exists.
+- Sample graph artifact validates.
+- Contract explains how graph nodes/edges link back to source markdown.
+- Contract explains what must be deterministic.
+- Contract explains what may be generated heuristically later.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('contracts/knowledge-graph.schema.json','utf8'))"
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-006: Generate Initial Graph Artifacts from Markdown Fixtures
+
+### Objective
+
+Generate a deterministic first graph artifact from the fixture corpus.
+
+This does not need to be smart. It needs to create valid, source-linked graph data that the UI and Traverse contracts can target.
+
+### Scope
+
+Add a build/sync step that produces:
+
+- `app/site/knowledge-graph.json`
+
+Minimum generation rules:
+
+- one document node per processed markdown artifact
+- one chunk/source node per indexed document
+- edges from document to chunk/source
+- optional topic nodes from headings or metadata
+
+### Out of Scope
+
+- Graphy integration
+- semantic entity extraction
+- LLM-generated graph extraction
+- graph ranking
+
+### Definition of Done
+
+- `m3 sync` generates `app/site/knowledge-graph.json`.
+- Graph artifact conforms to `contracts/knowledge-graph.schema.json`.
+- Graph references source paths already present in `search-index.json`.
+- Graph generation is deterministic.
+- Smoke validates that graph artifact exists and is valid.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+./scripts/m3.sh sync
+test -f app/site/knowledge-graph.json
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-007: Replace Browser Sample Documents with Artifact Loading
+
+### Objective
+
+Move the PWA away from hardcoded sample documents and toward real generated artifacts.
+
+### Scope
+
+Update browser runtime/component code so it can load:
+
+- `app/site/search-index.json`
+- `app/site/knowledge-graph.json` if present
+- `app/site/author-instance.json`
+- `app/site/provider-config.json`
+
+The UI can still use a temporary local adapter response, but source/result data must come from generated artifacts.
+
+### Out of Scope
+
+- Real Traverse runtime calls
+- LLM chat
+- graph visualization beyond simple source evidence
+
+### Definition of Done
+
+- No primary user-facing search/result display depends on `SAMPLE_BROWSER_DOCUMENTS`.
+- PWA can render at least one real search result from `search-index.json`.
+- Missing or empty artifacts produce a clear UI state.
+- Tests cover successful artifact loading and empty artifact handling.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+npm test
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-008: Define Temporary Traverse-Compatible Chat Harness
+
+### Objective
+
+Create a strict local test harness that mimics the future Traverse response shape.
+
+This allows the PWA chat UI to be developed while Traverse implements missing runtime/model dependency features.
+
+### Scope
+
+Add a harness module that accepts the future `knowledge.query.answer` input and returns the future output shape.
+
+The harness may be deterministic:
+
+- retrieve top matching source entries
+- produce a simple templated answer
+- include citations
+- include graph evidence if available
+- include a fake-but-structured trace summary marked as `harness`
+
+### Out of Scope
+
+- Real LLM inference
+- Hidden alternative runtime
+- Business logic that will remain permanently in TypeScript
+
+### Definition of Done
+
+- Harness input/output matches the capability contract from MVP-002.
+- Harness is clearly named and documented as temporary.
+- Harness response includes answer, citations, graph evidence, validation status, and trace summary.
+- Tests ensure the harness output conforms to the contract.
+- UI can call the harness through the same adapter interface intended for Traverse.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+npm test
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-009: Build the First PWA Chat Interaction
+
+### Objective
+
+Turn the PWA shell into an actual chat interface backed by the temporary Traverse-compatible harness.
+
+### Scope
+
+Implement:
+
+- prompt input
+- submit action
+- answer rendering
+- citation rendering
+- source cards
+- graph evidence summary
+- loading state
+- error state
+- empty corpus state
+
+### Out of Scope
+
+- Real Traverse integration
+- real LLM inference
+- polished graph explorer
+- account/auth
+
+### Definition of Done
+
+- User can type a question.
+- User can submit the question.
+- UI renders an answer from the harness.
+- UI renders citations and source paths.
+- UI renders graph evidence when available.
+- UI handles no-result and error states.
+- Existing PWA install/offline smoke still passes.
+- Tests cover the chat rendering states.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+npm test
+bash scripts/pwa-shell-smoke.sh
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-010: Create Traverse Application Bundle Skeleton
+
+### Objective
+
+Create the repo structure for the future Traverse application bundle without requiring Traverse to support all missing features yet.
+
+### Scope
+
+Add:
+
+- bundle manifest placeholder
+- capability contract references
+- workflow references
+- README explaining how it maps to Traverse
+- TODO markers for fields blocked by Traverse requirements
+
+Suggested path:
+
+- `traverse/youaskm3-app/manifest.json`
+- `traverse/youaskm3-app/README.md`
+- `traverse/youaskm3-app/workflows/`
+
+### Out of Scope
+
+- Executable WASM capabilities
+- real Traverse registration
+- model dependency resolution
+
+### Definition of Done
+
+- Bundle skeleton exists.
+- Bundle references the capability contracts from MVP-002.
+- README explains which Traverse requirements block full registration.
+- Manifest avoids pretending unsupported Traverse features already exist.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-011: Add Traverse Readiness Check Command
+
+### Objective
+
+Add a youaskm3 command or script that checks whether the local Traverse environment is ready for integration.
+
+### Scope
+
+Add a script such as:
+
+- `scripts/traverse-readiness.sh`
+
+It should check:
+
+- Traverse checkout location is configured or discoverable
+- Traverse commit/tag
+- Cargo available
+- required Traverse conformance script can run
+- HTTP app path available
+- MCP path available
+
+### Out of Scope
+
+- Installing Traverse
+- modifying Traverse
+- starting long-running services by default
+
+### Definition of Done
+
+- Readiness script exists.
+- It produces clear pass/fail output.
+- It does not require private Traverse internals beyond documented scripts.
+- It can be skipped in normal smoke if Traverse is not present.
+- Documentation explains how to run it.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+bash scripts/traverse-readiness.sh
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-012: Add Product-Level MVP Acceptance Test
+
+### Objective
+
+Add a single smoke test that proves the local MVP loop works without Traverse runtime dependency.
+
+This test validates our side while Traverse works on runtime gaps.
+
+### Scope
+
+Add a script such as:
+
+- `scripts/mvp-local-loop-smoke.sh`
+
+It should:
+
+1. initialize temp instance
+2. add/prepare fixture content
+3. sync artifacts
+4. verify non-empty search index
+5. verify graph artifact exists
+6. invoke chat harness
+7. assert answer includes citations
+
+### Out of Scope
+
+- Real LLM inference
+- real Traverse execution
+- browser screenshot testing
+
+### Definition of Done
+
+- Script exists and is called by `scripts/smoke.sh`.
+- Script uses temp directories and leaves no repo pollution.
+- Script fails if search index is empty.
+- Script fails if graph artifact is missing.
+- Script fails if harness answer has no citations.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+bash scripts/mvp-local-loop-smoke.sh
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-013: Prepare First WASM Capability Implementation
+
+### Objective
+
+Implement the first youaskm3 business capability as Rust that can compile to `wasm32-wasip1`.
+
+Best first candidate:
+
+- `knowledge.retrieve`
+
+Reason:
+
+- deterministic
+- no model dependency
+- easy to test
+- immediately useful for chat and MCP
+
+### Scope
+
+Add Rust code for retrieval capability with:
+
+- contract-shaped input
+- contract-shaped output
+- source-aware ranked results
+- no filesystem access in runtime function
+- pure logic callable from tests
+- WASM-compatible crate target
+
+### Out of Scope
+
+- Traverse registration
+- model inference
+- graph traversal
+
+### Definition of Done
+
+- Capability logic exists in Rust.
+- Unit tests cover ranking, empty input, no results, and source attribution.
+- It builds for native target.
+- It builds for `wasm32-wasip1`.
+- It can be wrapped later as a Traverse stdin/stdout JSON agent.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+cargo test --locked --workspace
+cargo build --locked --workspace --target wasm32-wasip1
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-014: Add Source/Citation Validation Logic
+
+### Objective
+
+Create deterministic answer validation logic that checks whether a response includes source-backed citations.
+
+This will become part of `knowledge.answer.validate`.
+
+### Scope
+
+Implement pure Rust validation logic:
+
+- input answer text
+- citation list
+- available source ids
+- output pass/warn/fail
+- missing citation reasons
+- unsupported citation reasons
+
+### Out of Scope
+
+- semantic claim verification
+- LLM calls
+- UI rendering
+
+### Definition of Done
+
+- Validation logic exists in Rust.
+- Tests cover valid citations, missing citations, unknown citations, duplicate citations, and empty answer.
+- Output matches the contract from MVP-002.
+- Builds for `wasm32-wasip1`.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+cargo test --locked --workspace
+cargo build --locked --workspace --target wasm32-wasip1
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-015: Document Current Local Development Toolchain
+
+### Objective
+
+Document the toolchain needed to run the full local smoke path.
+
+### Scope
+
+Update developer docs with:
+
+- Rustup requirement
+- pinned Rust `1.94.0`
+- `wasm32-wasip1` target
+- `cargo-llvm-cov`
+- Python 3.10+ requirement for MarkItDown
+- recommended Python path on this machine
+- npm install
+- exact smoke command
+
+### Out of Scope
+
+- Installing tools automatically
+- CI changes
+
+### Definition of Done
+
+- README or docs page explains setup.
+- Exact passing smoke command is documented:
+
+```bash
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+- Common failures are documented:
+  - missing `cargo`
+  - missing `wasm32-wasip1`
+  - Python 3.9 too old for MarkItDown
+  - missing `eslint`
+  - missing `cargo-llvm-cov`
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+## Recommended Parallelization
+
+These tickets can start immediately and independently:
+
+- MVP-001 roadmap rewrite
+- MVP-002 capability contracts
+- MVP-003 markdown artifact contract
+- MVP-005 graph artifact contract
+- MVP-011 Traverse readiness script
+- MVP-015 toolchain docs
+
+These become easier after the contracts exist:
+
+- MVP-006 graph generation
+- MVP-008 chat harness
+- MVP-010 Traverse bundle skeleton
+- MVP-013 first WASM capability
+- MVP-014 citation validation
+
+These become most useful after fixture artifacts exist:
+
+- MVP-004 fixture corpus
+- MVP-007 artifact-backed PWA
+- MVP-009 PWA chat interaction
+- MVP-012 product-level MVP acceptance test
+
+## First Ticket to Start
+
+Recommended first implementation ticket:
+
+> MVP-002: Define MVP Capability Contracts
+
+Reason:
+
+- It unblocks Traverse alignment.
+- It unblocks the harness.
+- It unblocks WASM capability implementation.
+- It forces the product shape to become explicit.

--- a/docs/traverse-mvp-requirements.md
+++ b/docs/traverse-mvp-requirements.md
@@ -1,0 +1,590 @@
+# Traverse Requirements for the First Knowledge-App MVP
+
+Status: Draft for Traverse team review
+Owner: youaskm3 downstream integration
+Last updated: 2026-06-12
+
+## Purpose
+
+This document describes what a downstream local-first knowledge application needs from Traverse for its first MVP.
+
+The Traverse team should be able to read this without knowing the product roadmap. The downstream application can be summarized as:
+
+- a browser/PWA user interface
+- a local CLI that prepares static knowledge artifacts from user-owned files
+- a chat experience that answers from those artifacts with source attribution
+- all product/business behavior executed as governed WASM capabilities through Traverse
+
+The core requirement is not "make a chat app." The core requirement is:
+
+> Traverse must be able to run, compose, trace, and expose portable WASM business capabilities for a downstream application whose UI is only a UI and whose CLI is only a build/setup caller.
+
+## Non-Negotiable Architecture Rule
+
+All downstream product/business logic must run through Traverse as governed WASM capabilities or agents.
+
+The UI may render screens, collect input, and display results. The CLI may convert files, write artifacts, start local services, and register bundles. Neither the UI nor the CLI should own core business decisions such as retrieval ranking, graph traversal, context construction, answer grounding, citation validation, or model selection.
+
+Traverse is expected to own the runtime boundary:
+
+- capability registration
+- capability execution
+- WASM execution
+- capability contracts
+- event contracts
+- workflow composition
+- runtime placement
+- execution traces
+- MCP exposure
+- app-facing HTTP/JSON exposure
+- model/capability dependency resolution
+- local/server placement decisions where applicable
+
+The downstream app should only depend on Traverse public surfaces, not private crate internals.
+
+## Current Baseline Confirmed
+
+As of 2026-06-12, the local Traverse checkout and public GitHub `main` matched commit `b30ff93` (`docs: add youaskm3 v0.3.0 readiness index`).
+
+The following validation passed locally after installing the required Rust toolchain:
+
+```bash
+bash scripts/ci/youaskm3_compatibility_conformance.sh
+```
+
+The current Traverse baseline appears sufficient for a narrow claim:
+
+- source-build runtime surface exists
+- HTTP/JSON app path exists
+- MCP stdio path exists
+- WASM execution via Wasmtime exists
+- stdin/stdout JSON contract exists
+- capability and agent package manifests exist
+- execution traces exist
+- programmatic registration exists
+- browser adapter validation exists
+
+The main MVP gap is model/capability dependency handling: current docs say `model_dependencies` are documentation-only and are not resolved or injected by the runtime.
+
+## MVP Runtime Flow
+
+The downstream app needs this end-to-end runtime flow:
+
+1. CLI prepares local artifacts from user-owned source files.
+2. CLI registers a Traverse application bundle into a workspace.
+3. Browser/PWA discovers the local Traverse app endpoint.
+4. Browser/PWA sends a user prompt to Traverse.
+5. Traverse executes a governed workflow composed of WASM capabilities.
+6. Capabilities retrieve relevant artifacts, traverse graph context, construct prompt/context, call model inference, validate grounding, and return an answer.
+7. Traverse returns a structured result and public trace.
+8. UI renders answer, citations, graph/source evidence, and execution status.
+9. MCP clients can discover and call the same governed capabilities through Traverse MCP.
+
+## Boundaries
+
+### Downstream CLI Owns
+
+The CLI may own build/setup tooling:
+
+- file discovery
+- file-to-markdown conversion using external tools such as MarkItDown
+- writing static artifacts to disk
+- invoking build/sync
+- starting local Traverse where appropriate
+- registering Traverse bundles through public APIs
+
+Important boundary: conversion tooling is allowed outside Traverse when it is mechanical source conversion. If transformation becomes product semantics, it should move into a Traverse capability.
+
+Examples:
+
+- Allowed outside Traverse: "convert this DOCX/PDF/PPTX to raw markdown."
+- Should be inside Traverse: "decide which chunks are relevant to a user question."
+- Should be inside Traverse: "validate that an answer is grounded in sources."
+- Should be inside Traverse: "choose graph paths to include in context."
+
+### Downstream UI Owns
+
+The UI may own:
+
+- visual layout
+- chat input
+- rendering messages
+- rendering source cards
+- rendering graph views
+- rendering trace/status details
+- local browser storage for UI preferences
+
+The UI must not own:
+
+- retrieval logic
+- ranking logic
+- graph traversal logic
+- prompt construction
+- answer validation
+- citation enforcement
+- model placement decisions
+- hidden alternate runtime behavior
+
+### Traverse Owns
+
+Traverse must own:
+
+- validated capability execution
+- WASM capability sandboxing
+- capability placement
+- workflow orchestration
+- evented capability coordination
+- dependency resolution
+- trace generation
+- app-facing APIs
+- MCP-facing APIs
+- model/inference capability abstraction
+- local/server execution policy
+
+## Prioritized Requirements
+
+### P0 - Required for MVP
+
+#### TRV-P0-001: Governed Application Bundle Registration
+
+Traverse must support registering a complete downstream application bundle into a workspace through public APIs.
+
+The bundle must include:
+
+- capability contracts
+- event contracts
+- workflow definitions
+- WASM agent/capability package manifests
+- binary paths and digests
+- model dependency declarations
+- runtime constraints
+- permitted targets
+
+Acceptance criteria:
+
+- A CLI can register the bundle without depending on private Traverse internals.
+- Bundle registration is idempotent.
+- Bundle registration is atomic.
+- Invalid bundles fail before partial registration.
+- Registration returns machine-readable artifact ids, versions, digests, and execution links.
+- Registration can be validated in CI.
+
+#### TRV-P0-002: WASM Business Capability Execution
+
+Traverse must execute downstream business capabilities compiled to WASM.
+
+Acceptance criteria:
+
+- WASM modules run through the governed Traverse executor.
+- Input is passed as JSON according to the capability contract.
+- Output is returned as JSON according to the capability contract.
+- Binary digest is verified before execution.
+- Unauthorized host imports are rejected.
+- No ambient filesystem, network, or environment access is granted.
+- Execution result and failure modes appear in traces.
+
+#### TRV-P0-003: Model Inference as a Governed Capability
+
+Traverse must model LLM inference as a governed capability or agent dependency, not as hidden downstream app code.
+
+The downstream app should declare that it needs an inference capability by contract. Traverse should decide how to satisfy and place that capability.
+
+Acceptance criteria:
+
+- A downstream capability can declare a model/inference dependency using a governed contract.
+- Traverse can resolve the dependency at registration or execution time.
+- Traverse can fail clearly if no compatible inference capability is available.
+- The downstream app does not hardcode Ollama, WebLLM, llama.cpp, a cloud API, or any provider.
+- The same downstream workflow can run against different inference implementations as Traverse improves.
+- The selected inference capability and placement appear in the trace.
+
+#### TRV-P0-004: Runtime Dependency Resolution for Model Dependencies
+
+Current agent docs describe `model_dependencies` as documentation-only. For this MVP, that is not enough.
+
+Traverse must turn model dependencies into runtime-governed dependencies.
+
+Acceptance criteria:
+
+- `model_dependencies` or a successor field has a schema.
+- Dependencies reference stable interface ids and versions.
+- Dependencies can be satisfied by registered capabilities, agents, connectors, or model providers.
+- Unsatisfied dependencies fail before user-facing execution begins.
+- Resolution result is visible in registration output or execution trace.
+- Dependency resolution does not require downstream app code changes when a new implementation is available.
+
+#### TRV-P0-005: Workflow Execution From App-Facing API
+
+The browser/PWA must be able to ask Traverse to execute a downstream workflow through a public app-facing API.
+
+Acceptance criteria:
+
+- UI can discover Traverse base URL through a documented public mechanism.
+- UI can submit a runtime request to a workspace.
+- UI can receive synchronous or async execution status.
+- UI can fetch public trace data.
+- Error envelopes are stable and machine-readable.
+- No private Traverse filesystem layout is required.
+
+#### TRV-P0-006: MCP Surface for the Same Capabilities
+
+The same downstream capabilities must be available through Traverse MCP.
+
+Acceptance criteria:
+
+- MCP clients can discover the downstream capabilities.
+- MCP clients can inspect capability contracts.
+- MCP clients can execute the relevant entrypoints.
+- MCP clients can render or fetch execution reports/traces.
+- MCP behavior is backed by the same registered capabilities, not a separate implementation.
+
+#### TRV-P0-007: Trace Evidence for Grounded Answers
+
+Traverse traces must provide enough public evidence for a UI and an auditor to understand how an answer was produced.
+
+Minimum trace evidence:
+
+- workflow id and version
+- capability ids and versions executed
+- placement target chosen for each capability
+- dependency/model capability selected
+- source artifact ids used
+- graph nodes/edges included in context
+- citation ids returned
+- validation outcome
+- failure reason if validation fails
+
+Acceptance criteria:
+
+- UI can show a useful "why this answer" view from public trace data.
+- Private sensitive inputs are not leaked into public traces.
+- Public traces are stable enough for downstream tests.
+
+#### TRV-P0-008: Deterministic Failure Modes
+
+The downstream app must be able to distinguish setup failure, dependency failure, execution failure, validation failure, and user-input failure.
+
+Acceptance criteria:
+
+- Missing model dependency has a stable error code.
+- Missing artifact bundle has a stable error code.
+- Invalid capability input has a stable error code.
+- Unsupported placement has a stable error code.
+- WASM execution failure has a stable error code.
+- Trace lookup failure has a stable error code.
+
+### P1 - Strongly Required for MVP Quality
+
+#### TRV-P1-001: Application Manifest Contract
+
+Traverse should support a first-class application manifest that declares the downstream app's runtime needs.
+
+The manifest should describe:
+
+- application id
+- workspace defaults
+- required bundles
+- required capabilities
+- required workflows
+- required MCP tools
+- required model interfaces
+- preferred placement policy
+- public app endpoint assumptions
+
+Acceptance criteria:
+
+- Manifest can be validated before runtime startup.
+- Manifest can be cited by downstream app docs.
+- Manifest can be used by CI/conformance tests.
+
+#### TRV-P1-002: Capability Interface Versioning
+
+Traverse must allow the downstream app to depend on stable capability interfaces while implementations evolve.
+
+Acceptance criteria:
+
+- Downstream app can request an interface/version or semver range.
+- Traverse resolves an implementation.
+- Breaking changes require explicit version movement.
+- Trace records resolved implementation.
+
+#### TRV-P1-003: Evented Capability Coordination
+
+The downstream workflow needs to coordinate several steps without hiding sequencing in UI code.
+
+Example capability sequence:
+
+- receive question
+- retrieve candidate sources
+- expand graph context
+- pack context
+- run inference
+- validate answer grounding
+- format response
+
+Acceptance criteria:
+
+- Workflow steps can be modeled as direct or event-triggered edges.
+- Event contracts can be registered with the bundle.
+- Event publication is validated against contracts.
+- Event-related failures are traceable.
+
+#### TRV-P1-004: Browser/PWA Consumption Without Private Internals
+
+The PWA must consume Traverse through public browser-safe surfaces.
+
+Acceptance criteria:
+
+- Browser/PWA can connect to local Traverse without importing private Traverse source.
+- Browser/PWA can subscribe to execution progress or poll status.
+- Browser/PWA can fetch public traces.
+- Browser adapter behavior is documented and tested.
+- CORS/local dev behavior is explicit.
+
+#### TRV-P1-005: Local-First Operation
+
+The first MVP must work without paid external services.
+
+Acceptance criteria:
+
+- A local Traverse execution path exists.
+- Missing server/cloud capability does not block local execution if a local compatible capability is installed.
+- Local execution path is documented.
+- The downstream app can state honestly whether the current setup is local-only, server-enabled, or mixed.
+
+#### TRV-P1-006: Placement Policy Visibility
+
+Traverse owns placement, but the downstream app needs visibility into the decision.
+
+Acceptance criteria:
+
+- Trace includes requested target, selected target, reason, and confidence.
+- If placement changes from local to server or server to local, the trace explains why.
+- Downstream app can display placement status without understanding Traverse internals.
+
+### P2 - Needed Soon After MVP
+
+#### TRV-P2-001: Server/Local Capability Equivalence
+
+Traverse should support the same capability contract running locally or on a server.
+
+Acceptance criteria:
+
+- Same workflow can run with local or server implementation.
+- Downstream app code does not change when placement changes.
+- Traces identify selected implementation and target.
+
+#### TRV-P2-002: Capability/Model Benchmark Evidence
+
+For model-heavy workflows, Traverse should expose enough benchmark or runtime performance evidence to support placement heuristics.
+
+Acceptance criteria:
+
+- Runtime snapshot can include model/capability latency or load.
+- Placement reasons can cite heuristic inputs.
+- Downstream app can avoid making its own model routing logic.
+
+#### TRV-P2-003: Connector or Dependency Path for Large Local Assets
+
+Some inference or graph capabilities may need large local artifacts such as model weights or indexes.
+
+Acceptance criteria:
+
+- Large artifacts are referenced by governed manifest fields.
+- Digests are verified.
+- Runtime can fail clearly when artifacts are missing.
+- Artifact access remains explicit and portable.
+
+#### TRV-P2-004: Better Distribution Than Source-Build Only
+
+Source-build is acceptable for early MVP validation, but not ideal for ordinary users.
+
+Acceptance criteria:
+
+- Traverse publishes installable or cacheable runtime artifacts.
+- Downstream app can pin a version without requiring users to build all of Traverse manually.
+- Supply-chain evidence remains available.
+
+## Downstream Capability Set Needed
+
+The downstream app expects to register capabilities similar to the following. Names are illustrative; Traverse does not need to know product details.
+
+### `knowledge.query.answer`
+
+Purpose: top-level chat/question workflow entrypoint.
+
+Input:
+
+- user question
+- optional conversation context
+- workspace/instance id
+- optional user-selected source filters
+
+Output:
+
+- answer text
+- citations
+- source ids
+- graph evidence
+- validation status
+- trace reference
+
+### `knowledge.retrieve`
+
+Purpose: retrieve candidate source chunks from local artifacts.
+
+Business logic:
+
+- parse query
+- rank chunks
+- return source-aware candidates
+
+### `knowledge.graph.expand`
+
+Purpose: expand context using graph nodes and edges.
+
+Business logic:
+
+- identify relevant nodes
+- follow bounded graph paths
+- return explainable graph context
+
+### `knowledge.context.pack`
+
+Purpose: create a bounded context package for model inference.
+
+Business logic:
+
+- deduplicate sources
+- fit token/context limits
+- preserve citation ids
+- include graph hints
+
+### `knowledge.infer`
+
+Purpose: invoke a governed inference capability.
+
+Business logic:
+
+- call/compose with the resolved model capability
+- enforce prompt/input contract
+- return structured model output
+
+### `knowledge.answer.validate`
+
+Purpose: verify answer grounding.
+
+Business logic:
+
+- ensure cited claims map to sources
+- identify unsupported claims
+- return pass/warn/fail result
+
+### `knowledge.answer.format`
+
+Purpose: produce final UI/MCP-ready response.
+
+Business logic:
+
+- final answer text
+- citations
+- graph summary
+- failure warnings
+- trace summary
+
+## Required Public APIs
+
+The downstream app needs stable public APIs for:
+
+- starting or discovering a local Traverse runtime
+- registering app bundles
+- registering capabilities
+- registering events
+- registering workflows
+- executing a workflow/capability
+- fetching execution status
+- fetching public traces
+- discovering MCP tools
+- executing MCP entrypoints
+
+Current v0.3.0 surfaces already cover much of this through HTTP/JSON and MCP. The main missing part is runtime-governed model dependency resolution and a clear application manifest story.
+
+## Required Validation Evidence
+
+Traverse should provide or extend validation scripts that prove:
+
+1. A downstream bundle can be registered from a clean checkout.
+2. A WASM capability can be executed through the HTTP/JSON app path.
+3. The same capability can be discovered or exercised through MCP.
+4. A workflow with multiple capabilities can execute and produce a public trace.
+5. A model dependency can be declared, resolved, selected, and traced.
+6. Failure to satisfy a model dependency fails deterministically.
+7. Browser/PWA consumption works without private Traverse internals.
+8. The conformance suite can run from a pinned release tag.
+
+Suggested validation command shape:
+
+```bash
+bash scripts/ci/downstream_app_bundle_registration_smoke.sh
+bash scripts/ci/downstream_wasm_workflow_smoke.sh
+bash scripts/ci/downstream_model_dependency_smoke.sh
+bash scripts/ci/downstream_browser_app_smoke.sh
+bash scripts/ci/downstream_mcp_smoke.sh
+```
+
+The exact names do not matter. The evidence does.
+
+## Non-Goals for Traverse
+
+Traverse does not need to own:
+
+- file conversion from PDF/DOCX/PPTX/etc. to raw markdown
+- product UI layout
+- product-specific visual design
+- source content authoring
+- downstream product release notes
+- downstream app smoke tests beyond public-surface compatibility
+- Graphy adoption decisions
+- MarkItDown adoption decisions
+
+Traverse should only care about these external tools if the downstream app wraps their outputs into governed capabilities or artifacts.
+
+## Open Questions for Traverse
+
+1. Should `model_dependencies` evolve into a first-class dependency resolver, or should model inference be represented as ordinary capability dependencies?
+2. Should model inference implementations be registered as capabilities, connectors, agents, or a new artifact type?
+3. How should large model weights or local indexes be referenced, digested, and placed?
+4. Can a workflow call another capability as a dependency without embedding provider-specific code inside a WASM module?
+5. What is the minimum local inference capability Traverse can prove first?
+6. Should application manifests live in Traverse, downstream apps, or both?
+7. What trace fields are safe for public UI display when inference and private source data are involved?
+
+## Recommended Traverse Work Order
+
+1. Promote model dependency declarations from documentation-only to governed runtime resolution.
+2. Define a minimal inference capability contract and trace shape.
+3. Add a smoke test proving one WASM workflow can depend on one inference capability.
+4. Add a downstream application manifest/bundle example with registration through public HTTP APIs.
+5. Extend MCP discovery/execution evidence to include the downstream workflow.
+6. Extend browser app validation to call the downstream workflow instead of only a demo fixture.
+7. Improve distribution beyond source-build once the contract is stable.
+
+## MVP Readiness Definition
+
+Traverse is ready for this downstream MVP when the downstream app can honestly say:
+
+> The UI sends a user request to Traverse. Traverse executes all product/business behavior as governed WASM capabilities, resolves the needed inference capability, selects placement, records a trace, and exposes the same behavior through HTTP/JSON and MCP. The downstream app does not contain alternate business logic paths.
+
+## Summary
+
+Traverse already has a strong foundation for the first integration:
+
+- public HTTP/JSON app path
+- public MCP path
+- WASM execution
+- programmatic registration
+- traces
+- browser adapter validation
+- source-build conformance evidence
+
+The critical missing piece for the MVP is not generic runtime execution. It is governed dependency/model resolution for LLM inference and the ability for a downstream app to register and execute its full business workflow as a Traverse application bundle.

--- a/docs/youaskm3-ops.md
+++ b/docs/youaskm3-ops.md
@@ -1,0 +1,127 @@
+# youaskm3 Ops
+
+Status: Active operating model
+
+## Metadata
+
+name: youaskm3-ops
+
+description: Start or resume the standard youaskm3 operating model when the user says YOUASKM3 OPS, asks to start youaskm3 ops/dev work, asks for the ready-ticket worker, PR finisher, backlog gardener, spec/contracts gardener, or wants Codex to pick ready GitHub Project 3 MVP work and run the youaskm3 coordination process.
+
+## Canonical Trigger
+
+```text
+YOUASKM3 OPS
+```
+
+## When To Use
+
+Use this operating model when the user wants Codex to:
+
+- resume youaskm3 project work
+- pick the next Ready MVP ticket
+- finish an open PR
+- audit Project 3
+- align tickets with specs and contracts
+- check whether a task is blocked by Traverse requirements
+
+## Workflow
+
+1. Read `SPEC.md` before implementation work.
+2. Read `README.md`, `CONTRIBUTING.md`, `docs/mvp-ticket-backlog.md`, and `docs/traverse-mvp-requirements.md` when they are relevant to the lane.
+3. Inspect current GitHub issues, PRs, and Project 3 state.
+4. Prefer finishing existing open PRs before claiming new Ready work.
+5. If no active PR needs attention, pick one Ready Project 3 issue.
+6. Before work on an issue, run ownership pre-flight checks:
+   - issue must not have `agent:claude`
+   - no remote `claude/issue-NNN-*` branch may exist
+   - issue must not already be owned by another active agent
+7. If pre-flight passes, claim the issue:
+   - add `agent:codex`
+   - set Project 3 Agent to `Codex` when project write access is available
+   - set Project 3 Status to `In Progress` when project write access is available
+   - if project write access is unavailable, report the limitation before coding
+8. Use a dedicated `codex/issue-NNN-*` branch.
+9. Keep work scoped to the claimed issue, governing OpenSpec spec, and MVP contract boundary.
+10. Open a dedicated PR with validation evidence.
+
+## Operating Lanes
+
+### Ready-ticket worker
+
+Claim one Ready Project 3 issue and implement it end to end.
+
+Use this lane when there is no open PR needing attention and Project 3 has Ready work.
+
+### PR finisher
+
+Inspect open PRs, fix CI or review issues, update stale branches, and merge when green if explicitly allowed.
+
+Use this lane before claiming new work.
+
+### Backlog gardener
+
+Audit Project 3 statuses, labels, blockers, notes, missing tickets, and stale ownership.
+
+Use this lane when the board may be out of sync with the repo.
+
+### Spec/contracts gardener
+
+Align `README.md`, `SPEC.md`, `openspec/specs/`, `contracts/`, and smoke validation with the approved MVP direction.
+
+Use this lane when tickets, specs, contracts, or roadmap disagree.
+
+### Traverse dependency checker
+
+Verify whether blocked youaskm3 tickets depend on Traverse runtime requirements in `docs/traverse-mvp-requirements.md`.
+
+Use this lane when a ticket needs application bundle registration, real Traverse execution, inference dependency resolution, MCP parity, runtime placement, or public traces.
+
+## Guardrails
+
+- Do not mark work `In Progress` unless a real dev thread has started it.
+- Do not use labels as status; Project 3 status is the actionability source of truth.
+- Do not claim work already owned by Claude Code or another active agent.
+- Do not broaden scope beyond the issue and governing spec.
+- Create future tickets for non-blocking improvements instead of expanding an active slice.
+- Keep all product/business logic portable and Traverse/WASM-bound.
+- Keep the PWA UI-only and the CLI artifact/build-focused.
+- Temporary harnesses are allowed only when they mirror the future Traverse contract and are clearly replaceable.
+- If GitHub Project write scope is unavailable, report that clearly and avoid pretending the board was updated.
+
+## Current MVP Boundary
+
+The first MVP is:
+
+> A local-first PWA chat experience that answers from user-owned knowledge artifacts, with source attribution and graph context, while preparing the product to hand runtime business logic to Traverse as governed WASM capabilities.
+
+youaskm3 owns:
+
+- MarkItDown-backed conversion
+- normalized markdown artifacts
+- chunk/search/graph artifacts
+- PWA UI
+- product contracts
+- temporary Traverse-compatible harnesses where needed
+
+Traverse owns:
+
+- governed WASM capability execution
+- app bundle registration
+- evented workflow composition
+- model/inference dependency resolution
+- local/server placement
+- MCP exposure
+- public traces
+
+## Validation
+
+Default validation for implementation work:
+
+```bash
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+Focused validation may be used for docs/spec-only work, but the final report must say exactly what did and did not run.

--- a/openspec/specs/knowledge-graph/spec.md
+++ b/openspec/specs/knowledge-graph/spec.md
@@ -1,0 +1,37 @@
+# knowledge-graph Specification
+
+## Purpose
+
+The knowledge-graph capability defines how youaskm3 represents graph context derived from normalized knowledge artifacts so chat answers can include source-backed relationships rather than isolated text snippets.
+
+## Requirements
+
+### Requirement: Produce a deterministic graph artifact
+
+The system SHALL define a static graph artifact with deterministic node and edge ordering, stable ids, labels, source artifact references, source chunk references, extraction method, and confidence metadata.
+
+#### Scenario: Build graph context from processed artifacts
+
+- GIVEN normalized markdown artifacts exist with chunk ids and graph hints
+- WHEN the graph artifact generation workflow runs
+- THEN it produces an artifact conforming to `contracts/knowledge-graph.schema.json`
+
+### Requirement: Preserve source evidence for graph relationships
+
+The system SHALL require every graph edge used for answer context to reference the source artifact and chunk evidence that supports the relationship.
+
+#### Scenario: Explain a relationship in chat
+
+- GIVEN an answer uses a relationship between two concepts
+- WHEN the graph evidence is rendered
+- THEN the relationship includes source artifact ids, source chunk ids, labels, and confidence metadata
+
+### Requirement: Expand graph context through a capability boundary
+
+The system SHALL expose graph expansion through the `knowledge.graph.expand` capability instead of embedding graph traversal in the PWA.
+
+#### Scenario: Expand context around retrieved chunks
+
+- GIVEN retrieval returned source chunks for a prompt
+- WHEN the answer workflow needs nearby graph context
+- THEN Traverse executes `knowledge.graph.expand` and returns bounded graph evidence to the workflow

--- a/openspec/specs/knowledge-ingest/spec.md
+++ b/openspec/specs/knowledge-ingest/spec.md
@@ -25,3 +25,33 @@ The system SHALL organize ingested content into markdown-oriented structures tha
 - GIVEN a book has been captured for ingestion
 - WHEN the ingest pipeline prepares its output
 - THEN the resulting structure is compatible with chapter maps, summaries, and derived diagram assets
+
+### Requirement: Use MarkItDown as the default source conversion layer
+
+The system SHALL route supported document conversion through MarkItDown before normalization unless a more specific approved converter is required for a source type.
+
+#### Scenario: Convert an office document into markdown
+
+- GIVEN a user provides a supported office document
+- WHEN the CLI add or build workflow converts the source
+- THEN the raw conversion output is produced through the MarkItDown-backed path and records the converter name and version in artifact metadata
+
+### Requirement: Produce normalized markdown artifacts
+
+The system SHALL normalize converted content into markdown artifacts that include stable ids, source metadata, conversion metadata, section boundaries, chunk hints, and graph extraction hints.
+
+#### Scenario: Normalize converted content for downstream capabilities
+
+- GIVEN raw converted markdown exists for a source file
+- WHEN the normalization workflow writes a processed artifact
+- THEN the artifact conforms to `contracts/markdown-artifact.schema.json` and can be chunked, searched, and used for graph extraction
+
+### Requirement: Keep product semantics out of conversion tooling
+
+The system SHALL keep source conversion, normalization, artifact writing, and build orchestration in the CLI while leaving retrieval ranking, graph traversal, context packing, answer validation, and inference selection to Traverse-run capabilities.
+
+#### Scenario: Build artifacts without answering a question
+
+- GIVEN the CLI is preparing a knowledge workspace
+- WHEN it converts and normalizes source files
+- THEN it writes deterministic artifacts without deciding which chunks answer a user prompt

--- a/openspec/specs/knowledge-search/spec.md
+++ b/openspec/specs/knowledge-search/spec.md
@@ -26,6 +26,26 @@ The system SHALL preserve enough source context in search responses to let downs
 - WHEN the search capability ranks and returns results
 - THEN each result can be associated with a source path or equivalent metadata
 
+### Requirement: Retrieve from prepared artifacts through a capability boundary
+
+The system SHALL define retrieval as a Traverse-compatible capability that consumes prepared search, chunk, and markdown artifacts instead of embedding product retrieval logic in the PWA.
+
+#### Scenario: Retrieve evidence for a chat request
+
+- GIVEN a user submits a chat prompt through the PWA
+- WHEN retrieval is needed for the answer workflow
+- THEN the PWA delegates retrieval to the `knowledge.retrieve` capability and receives source-aware result objects
+
+### Requirement: Preserve chunk-level evidence
+
+The system SHALL include chunk ids, source artifact ids, source paths, excerpts, and score information in retrieval responses.
+
+#### Scenario: Return a cited chunk
+
+- GIVEN an indexed chunk matches a query
+- WHEN the retrieval capability returns it
+- THEN the response includes the chunk id, artifact id, source path, excerpt, and score needed for citation and validation
+
 ### Requirement: Generate a deterministic knowledge index
 
 The system SHALL define a deterministic generation flow for `knowledge/index.md` that derives the master map from processed knowledge content rather than hand-maintained search metadata.

--- a/openspec/specs/mcp-interface/spec.md
+++ b/openspec/specs/mcp-interface/spec.md
@@ -25,3 +25,23 @@ The system SHALL keep the MCP interface compatible with a WASM-native execution 
 - GIVEN the MCP module is compiled to the target WASM format
 - WHEN a supported host loads it
 - THEN the host can expose the same tool contract surface without host-specific behavior changes
+
+### Requirement: Expose the same MVP capabilities through MCP
+
+The system SHALL expose the MVP knowledge capabilities through Traverse MCP using the same contracts used by the app-facing runtime path.
+
+#### Scenario: Call the answer workflow from an MCP client
+
+- GIVEN the application bundle is registered with Traverse
+- WHEN an MCP client discovers the available youaskm3 capabilities
+- THEN it can inspect and execute the same `knowledge.query.answer` contract used by the PWA
+
+### Requirement: Preserve trace and evidence references in MCP responses
+
+The system SHALL return machine-readable trace, source, and graph evidence references through MCP responses when a capability produces an answer.
+
+#### Scenario: Inspect answer evidence from MCP
+
+- GIVEN an MCP client calls the answer workflow
+- WHEN the workflow completes
+- THEN the response includes answer text, citations, validation status, and trace identifiers equivalent to the app-facing response

--- a/openspec/specs/pwa-shell/spec.md
+++ b/openspec/specs/pwa-shell/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The pwa-shell capability defines the installable, offline-capable browser shell that will host the chat experience, present sources, and run the WASM knowledge interface without requiring a bespoke native application.
+The pwa-shell capability defines the installable, offline-capable browser shell that hosts the user-facing chat experience, presents sources and graph evidence, and delegates product/business behavior to Traverse-run WASM capabilities.
 
 ## Requirements
 
@@ -25,3 +25,23 @@ The system SHALL reserve UI surfaces for chat responses and source attribution s
 - GIVEN the chat interface returns a knowledge answer with sources
 - WHEN the PWA shell renders the response
 - THEN the UI can display both the answer and its source references
+
+### Requirement: Keep the PWA as a UI-only application
+
+The system SHALL keep retrieval ranking, graph traversal, context packing, inference selection, answer validation, and answer formatting outside the PWA and behind Traverse-compatible capability contracts.
+
+#### Scenario: Submit a chat prompt
+
+- GIVEN a user enters a prompt in the PWA
+- WHEN the PWA starts the answer workflow
+- THEN it sends the request to the configured Traverse app-facing endpoint or compatible local harness instead of computing the answer in browser UI code
+
+### Requirement: Render graph and trace evidence
+
+The system SHALL provide UI surfaces for graph evidence and execution trace status returned by the runtime.
+
+#### Scenario: Inspect why an answer was produced
+
+- GIVEN a completed answer includes graph evidence and a trace reference
+- WHEN the user opens the evidence view
+- THEN the PWA can render cited sources, graph nodes or edges, and runtime status without needing private runtime internals

--- a/openspec/specs/traverse-integration/spec.md
+++ b/openspec/specs/traverse-integration/spec.md
@@ -1,0 +1,47 @@
+# traverse-integration Specification
+
+## Purpose
+
+The traverse-integration capability defines how youaskm3 hands product/business execution to Traverse while keeping the PWA as a UI-only application and the CLI as an artifact builder and bundle registrar.
+
+## Requirements
+
+### Requirement: Register an application bundle through public Traverse surfaces
+
+The system SHALL register the youaskm3 application bundle through documented Traverse public APIs, including capability contracts, event contracts, workflow definitions, WASM package manifests, binary digests, runtime constraints, permitted targets, and model dependency declarations.
+
+#### Scenario: Register the MVP bundle
+
+- GIVEN the CLI has built the MVP artifact and WASM package set
+- WHEN it registers the application with Traverse
+- THEN Traverse returns machine-readable bundle ids, versions, digests, and validation status without relying on private Traverse internals
+
+### Requirement: Execute the chat workflow through Traverse
+
+The system SHALL execute the first user-facing chat workflow through Traverse or a temporary harness that exactly mirrors the Traverse request and response contract.
+
+#### Scenario: Answer a user prompt
+
+- GIVEN a user submits a prompt in the PWA
+- WHEN the runtime workflow starts
+- THEN the workflow composes retrieval, graph expansion, context packing, inference, validation, and formatting capabilities behind the Traverse boundary
+
+### Requirement: Delegate inference selection and placement
+
+The system SHALL declare inference needs by contract and allow Traverse to choose a compatible local or server-side implementation based on availability, constraints, and placement policy.
+
+#### Scenario: Use a local inference capability when available
+
+- GIVEN a compatible local WASM inference capability is registered
+- WHEN the answer workflow requires inference
+- THEN Traverse may place the inference step locally and records the selected capability in the trace
+
+### Requirement: Return public evidence traces
+
+The system SHALL expose enough trace evidence for the UI, MCP clients, and auditors to understand how a grounded answer was produced.
+
+#### Scenario: Inspect a completed answer trace
+
+- GIVEN an answer workflow completed or failed validation
+- WHEN a client fetches the public trace reference
+- THEN the trace includes executed capability ids, versions, placement, source artifacts, graph evidence, inference dependency, validation outcome, and failure reasons where applicable

--- a/scripts/m3-command-surface-smoke.sh
+++ b/scripts/m3-command-surface-smoke.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+mkdir -p "$TEMP_DIR/app/site" "$TEMP_DIR/scripts"
+
+cp "$ROOT_DIR/scripts/m3.sh" "$TEMP_DIR/scripts/m3.sh"
+cp "$ROOT_DIR/scripts/m3-search.rb" "$TEMP_DIR/scripts/m3-search.rb"
+cp "$ROOT_DIR/scripts/m3-serve.sh" "$TEMP_DIR/scripts/m3-serve.sh"
+
+cat <<'EOF' > "$TEMP_DIR/app/site/index.html"
+<!doctype html>
+<title>youaskm3 smoke</title>
+EOF
+
+cat <<'EOF' > "$TEMP_DIR/app/site/search-index.json"
+{
+  "instanceId": "smoke",
+  "title": "Smoke instance",
+  "shellUrl": "https://example.com/",
+  "sourceFingerprint": "abc123",
+  "documents": [
+    {
+      "id": "portable-knowledge",
+      "title": "Portable Knowledge",
+      "category": "blog",
+      "excerpt": "Git-native context remains queryable from local commands.",
+      "source_path": "knowledge/blog/portable-knowledge.md"
+    },
+    {
+      "id": "other-note",
+      "title": "Other Note",
+      "category": "papers",
+      "excerpt": "Unrelated material.",
+      "source_path": "knowledge/papers/other-note/index.md"
+    }
+  ]
+}
+EOF
+
+search_output="$(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh search portable
+)"
+
+grep -q "Portable Knowledge" <<<"$search_output"
+grep -q "knowledge/blog/portable-knowledge.md" <<<"$search_output"
+
+empty_search_output="$(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh search nonexistent
+)"
+
+grep -q "No search results for: nonexistent" <<<"$empty_search_output"
+
+serve_help_output="$(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh serve --help
+)"
+
+grep -q "Usage: ./scripts/m3.sh serve \\[port\\]" <<<"$serve_help_output"
+
+echo "m3 command surface smoke passed."

--- a/scripts/m3-search.rb
+++ b/scripts/m3-search.rb
@@ -1,0 +1,66 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+
+ROOT_DIR = File.expand_path("..", __dir__)
+INDEX_PATH = File.join(ROOT_DIR, "app/site/search-index.json")
+
+def abort_with(message)
+  warn(message)
+  exit 1
+end
+
+def normalize_terms(query)
+  query.downcase.split.map do |term|
+    normalized = term.strip
+    normalized
+  end.reject(&:empty?)
+end
+
+def score_document(document, terms)
+  title = document.fetch("title", "").downcase
+  excerpt = document.fetch("excerpt", "").downcase
+  category = document.fetch("category", "").downcase
+  source_path = document.fetch("source_path", "").downcase
+
+  terms.sum do |term|
+    score = 0
+    score += 3 if title.include?(term)
+    score += 2 if category.include?(term)
+    score += 1 if excerpt.include?(term)
+    score += 1 if source_path.include?(term)
+    score
+  end
+end
+
+query = ARGV.join(" ").strip
+abort_with("Usage: ./scripts/m3.sh search <query>") if query.empty?
+abort_with("Search index is missing. Run ./scripts/m3.sh sync first.") unless File.file?(INDEX_PATH)
+
+index = JSON.parse(File.read(INDEX_PATH))
+documents = index.fetch("documents")
+terms = normalize_terms(query)
+
+results = documents.map do |document|
+  score = score_document(document, terms)
+  next if score.zero?
+
+  document.merge("score" => score)
+end.compact
+
+results.sort_by! do |document|
+  [-document.fetch("score"), document.fetch("title", ""), document.fetch("id", "")]
+end
+
+if results.empty?
+  puts "No search results for: #{query}"
+  exit 0
+end
+
+results.first(10).each_with_index do |document, index|
+  puts "#{index + 1}. #{document.fetch("title")} [score #{document.fetch("score")}]"
+  puts "   #{document.fetch("source_path")}"
+  excerpt = document.fetch("excerpt", "").strip
+  puts "   #{excerpt}" unless excerpt.empty?
+end

--- a/scripts/m3-serve.sh
+++ b/scripts/m3-serve.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PORT="${1:-4173}"
+SITE_DIR="$ROOT_DIR/app/site"
+
+if [[ "$PORT" == "--help" || "$PORT" == "-h" ]]; then
+  echo "Usage: ./scripts/m3.sh serve [port]"
+  exit 0
+fi
+
+if ! [[ "$PORT" =~ ^[0-9]+$ ]]; then
+  echo "m3 serve expects a numeric port." >&2
+  exit 1
+fi
+
+if [[ ! -f "$SITE_DIR/index.html" ]]; then
+  echo "PWA site assets are missing. Run ./scripts/m3.sh build first." >&2
+  exit 1
+fi
+
+echo "Serving youaskm3 from http://127.0.0.1:${PORT}/"
+cd "$SITE_DIR"
+exec ruby -run -e httpd . -p "$PORT" -b 127.0.0.1

--- a/scripts/m3.sh
+++ b/scripts/m3.sh
@@ -7,7 +7,7 @@ COMMAND="${1:-}"
 cd "$ROOT_DIR"
 
 usage() {
-  echo "Usage: ./scripts/m3.sh {init|add|build|sync|test|lint|smoke|status}" >&2
+  echo "Usage: ./scripts/m3.sh {init|add|build|sync|search|serve|test|lint|smoke|status}" >&2
 }
 
 slugify_url() {
@@ -88,6 +88,14 @@ case "$COMMAND" in
   sync)
     bash ./scripts/m3-sync.sh
     ;;
+  search)
+    shift
+    ruby ./scripts/m3-search.rb "$@"
+    ;;
+  serve)
+    shift
+    bash ./scripts/m3-serve.sh "$@"
+    ;;
   test)
     bash ./scripts/test.sh
     ;;
@@ -102,7 +110,7 @@ case "$COMMAND" in
     ;;
   *)
     usage
-    echo "Additional m3 commands arrive in later milestones." >&2
+    echo "Use one of the stable commands above." >&2
     exit 1
     ;;
 esac

--- a/scripts/mvp-contracts-smoke.sh
+++ b/scripts/mvp-contracts-smoke.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+ruby <<'RUBY'
+require "json"
+
+required_capabilities = [
+  "knowledge.query.answer",
+  "knowledge.retrieve",
+  "knowledge.graph.expand",
+  "knowledge.context.pack",
+  "knowledge.infer",
+  "knowledge.answer.validate",
+  "knowledge.answer.format"
+]
+
+def read_json(path)
+  JSON.parse(File.read(path))
+rescue JSON::ParserError => error
+  abort "Invalid JSON in #{path}: #{error.message}"
+end
+
+required_capabilities.each do |capability_id|
+  path = File.join("contracts", "capabilities", "#{capability_id}.json")
+  abort "Missing capability contract: #{path}" unless File.file?(path)
+
+  contract = read_json(path)
+  {
+    "kind" => "youaskm3.capability_contract",
+    "id" => capability_id
+  }.each do |key, expected|
+    actual = contract[key]
+    abort "#{path} has #{key}=#{actual.inspect}, expected #{expected.inspect}" unless actual == expected
+  end
+
+  ["schema_version", "version", "summary", "description", "execution", "inputs", "outputs"].each do |key|
+    abort "#{path} is missing #{key}" unless contract.key?(key)
+  end
+
+  ["runtime", "business_logic", "permitted_targets", "requires_trace"].each do |key|
+    abort "#{path} execution is missing #{key}" unless contract.fetch("execution").key?(key)
+  end
+
+  input_schema = contract.fetch("inputs").fetch("schema")
+  output_schema = contract.fetch("outputs").fetch("schema")
+  abort "#{path} input schema must be an object" unless input_schema["type"] == "object"
+  abort "#{path} output schema must be an object" unless output_schema["type"] == "object"
+end
+
+schema_expectations = {
+  "contracts/markdown-artifact.schema.json" => ["artifact_id", "title", "source", "conversion", "sections", "chunks"],
+  "contracts/knowledge-graph.schema.json" => ["graph_id", "generated_from", "nodes", "edges"]
+}
+
+schema_expectations.each do |path, required|
+  schema = read_json(path)
+  missing = required - schema.fetch("required")
+  abort "#{path} is missing required fields: #{missing.join(", ")}" unless missing.empty?
+end
+
+example_pairs = {
+  "contracts/examples/markdown-artifact.example.json" => ["artifact_id", "source", "conversion", "sections", "chunks"],
+  "contracts/examples/knowledge-graph.example.json" => ["graph_id", "nodes", "edges"]
+}
+
+example_pairs.each do |path, required|
+  example = read_json(path)
+  missing = required.reject { |key| example.key?(key) }
+  abort "#{path} is missing example fields: #{missing.join(", ")}" unless missing.empty?
+end
+RUBY
+
+echo "MVP contract smoke passed."

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -5,6 +5,8 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SPEC_FILES=(
   "openspec/specs/knowledge-ingest/spec.md"
   "openspec/specs/knowledge-search/spec.md"
+  "openspec/specs/knowledge-graph/spec.md"
+  "openspec/specs/traverse-integration/spec.md"
   "openspec/specs/mcp-interface/spec.md"
   "openspec/specs/federation/spec.md"
   "openspec/specs/pwa-shell/spec.md"
@@ -61,6 +63,12 @@ bash ./scripts/m3-build-smoke.sh
 
 echo "Validating incremental sync..."
 bash ./scripts/m3-sync-smoke.sh
+
+echo "Validating m3 search and serve commands..."
+bash ./scripts/m3-command-surface-smoke.sh
+
+echo "Validating MVP contracts..."
+bash ./scripts/mvp-contracts-smoke.sh
 
 echo "Validating federation index generation..."
 bash ./scripts/federation-index-smoke.sh


### PR DESCRIPTION
## What this changes
Defines the first youaskm3 MVP as a local-first PWA chat product backed by markdown/search/graph artifacts, with product/business execution delegated to Traverse-governed WASM capabilities. Adds the MVP ticket backlog, Traverse requirements, repo ops trigger, capability contracts, artifact schemas, OpenSpec updates, and smoke validation for the new contract pack.

## Spec reference
- SPEC.md section 8 - MVP milestones
- SPEC.md section 10 - MVP Product Capabilities
- openspec/specs/knowledge-ingest/spec.md - MarkItDown and normalized artifacts
- openspec/specs/knowledge-search/spec.md - Traverse-compatible retrieval
- openspec/specs/knowledge-graph/spec.md - graph artifact and expansion boundary
- openspec/specs/traverse-integration/spec.md - Traverse runtime boundary
- openspec/specs/pwa-shell/spec.md - UI-only PWA shell
- openspec/specs/mcp-interface/spec.md - same capabilities through MCP

## Spec delta (if spec changed)
- Replaced the old M0-M5 roadmap framing with MVP-1 through MVP-6.
- Added knowledge graph and Traverse integration specs.
- Added seven product capability contracts under contracts/capabilities/.
- Added markdown and graph artifact schemas plus examples.
- Added YOUASKM3 OPS operating model and repo-local skill.

## Test coverage
Validated locally with:

```bash
PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh
```

Also validated:

```bash
bash scripts/mvp-contracts-smoke.sh
ruby -e 'require "yaml"; text=File.read(".codex/skills/youaskm3-ops/SKILL.md"); fm=text.split(/^---\s*$/,3)[1]; data=YAML.safe_load(fm); abort "missing name" unless data["name"]=="youaskm3-ops"; abort "missing description" unless data["description"].to_s.include?("YOUASKM3 OPS")'
```

## Breaking changes
None. This is a spec, contract, docs, and validation reset for the first MVP.

Closes #60.
Closes #61.
Closes #62.
Closes #64.
