### PR TITLE
Add MVP fixture corpus

### DIFF
--- a/app/site/build-manifest.json
+++ b/app/site/build-manifest.json
@@ -1,8 +1,8 @@
 {
   "instanceId": "youaskm3-author",
   "shellUrl": "https://enricopiovesan.github.io/youaskm3/",
-  "sourceFingerprint": "8049373a1a474a63d5d48700ba4ae23fff1fc6fe40ed96b30df11feed3ad8238",
-  "knowledgeDocumentCount": 0,
+  "sourceFingerprint": "ca954af000101d3b1fc170b193fa54e7f6f63ddeb7f8b18c759c5b1a4db8321e",
+  "knowledgeDocumentCount": 3,
   "pendingInputCount": 0,
   "artifacts": [
     "app/site/search-index.json",
@@ -16,6 +16,21 @@
       "path": "app/site/author-instance.json",
       "kind": "instance-manifest",
       "sha256": "d2651ae376fbcd980d521b1da60930b92d9cfa7f325796595c916bdda03fd483"
+    },
+    {
+      "path": "knowledge/blog/mvp-fixture-article/index.md",
+      "kind": "processed-knowledge",
+      "sha256": "c27763a2440c75c45de9d9181de4506878fc790c6b7a0ba547263e2add2caea2"
+    },
+    {
+      "path": "knowledge/books/mvp-fixture-handbook/index.md",
+      "kind": "processed-knowledge",
+      "sha256": "28038fb843628893b8136a3713db321e9d65ccce38e7f80494ca45a9a3d5d89c"
+    },
+    {
+      "path": "knowledge/papers/mvp-fixture-note/index.md",
+      "kind": "processed-knowledge",
+      "sha256": "638e3f6c7f232743fc2e55a7e3e08f195f0d36acf09477561800ac4e00b956ae"
     }
   ]
 }

--- a/app/site/search-index.json
+++ b/app/site/search-index.json
@@ -2,8 +2,31 @@
   "instanceId": "youaskm3-author",
   "title": "youaskm3 author instance",
   "shellUrl": "https://enricopiovesan.github.io/youaskm3/",
-  "sourceFingerprint": "8049373a1a474a63d5d48700ba4ae23fff1fc6fe40ed96b30df11feed3ad8238",
+  "sourceFingerprint": "ca954af000101d3b1fc170b193fa54e7f6f63ddeb7f8b18c759c5b1a4db8321e",
   "documents": [
-
+    {
+      "id": "knowledge--blog--mvp-fixture-article--index",
+      "title": "Portable Knowledge Article",
+      "source_path": "knowledge/blog/mvp-fixture-article/index.md",
+      "category": "blog",
+      "excerpt": "Portable knowledge keeps useful context in files that a person can inspect, version, and move between tools. A local-first chat product should answer from those files without hidin",
+      "content_sha256": "c27763a2440c75c45de9d9181de4506878fc790c6b7a0ba547263e2add2caea2"
+    },
+    {
+      "id": "knowledge--books--mvp-fixture-handbook--index",
+      "title": "MVP Architecture Handbook",
+      "source_path": "knowledge/books/mvp-fixture-handbook/index.md",
+      "category": "books",
+      "excerpt": "Architecture decisions for the first MVP are easiest to test when the repository contains a small handbook-style document. This fixture explains that artifact preparation and runti",
+      "content_sha256": "28038fb843628893b8136a3713db321e9d65ccce38e7f80494ca45a9a3d5d89c"
+    },
+    {
+      "id": "knowledge--papers--mvp-fixture-note--index",
+      "title": "Source Grounding Note",
+      "source_path": "knowledge/papers/mvp-fixture-note/index.md",
+      "category": "papers",
+      "excerpt": "Source grounding means every answer should carry evidence that a user can trace back to a markdown artifact, a chunk identifier, and eventually a graph relationship. The first MVP ",
+      "content_sha256": "638e3f6c7f232743fc2e55a7e3e08f195f0d36acf09477561800ac4e00b956ae"
+    }
   ]
 }

--- a/app/site/sync-state.json
+++ b/app/site/sync-state.json
@@ -1,16 +1,34 @@
 {
   "instanceId": "youaskm3-author",
-  "sourceFingerprint": "8049373a1a474a63d5d48700ba4ae23fff1fc6fe40ed96b30df11feed3ad8238",
-  "knowledgeDocumentCount": 0,
+  "sourceFingerprint": "ca954af000101d3b1fc170b193fa54e7f6f63ddeb7f8b18c759c5b1a4db8321e",
+  "knowledgeDocumentCount": 3,
   "pendingInputCount": 0,
   "trackedSourcePaths": [
-    "app/site/author-instance.json"
+    "app/site/author-instance.json",
+    "knowledge/blog/mvp-fixture-article/index.md",
+    "knowledge/books/mvp-fixture-handbook/index.md",
+    "knowledge/papers/mvp-fixture-note/index.md"
   ],
   "sources": [
     {
       "path": "app/site/author-instance.json",
       "kind": "instance-manifest",
       "sha256": "d2651ae376fbcd980d521b1da60930b92d9cfa7f325796595c916bdda03fd483"
+    },
+    {
+      "path": "knowledge/blog/mvp-fixture-article/index.md",
+      "kind": "processed-knowledge",
+      "sha256": "c27763a2440c75c45de9d9181de4506878fc790c6b7a0ba547263e2add2caea2"
+    },
+    {
+      "path": "knowledge/books/mvp-fixture-handbook/index.md",
+      "kind": "processed-knowledge",
+      "sha256": "28038fb843628893b8136a3713db321e9d65ccce38e7f80494ca45a9a3d5d89c"
+    },
+    {
+      "path": "knowledge/papers/mvp-fixture-note/index.md",
+      "kind": "processed-knowledge",
+      "sha256": "638e3f6c7f232743fc2e55a7e3e08f195f0d36acf09477561800ac4e00b956ae"
     }
   ]
 }

--- a/knowledge/blog/mvp-fixture-article/index.md
+++ b/knowledge/blog/mvp-fixture-article/index.md
@@ -1,0 +1,18 @@
+# Portable Knowledge Article
+
+<!--
+youaskm3:fixture
+source_type: article
+source_label: original MVP fixture
+artifact_id: fixture.article.portable-knowledge
+-->
+
+Portable knowledge keeps useful context in files that a person can inspect, version, and move between tools. A local-first chat product should answer from those files without hiding the source path or the chunk that supported the response.
+
+## Runtime Boundary
+
+The article fixture describes the boundary between the UI, the CLI, and Traverse. The UI renders the conversation, the CLI prepares artifacts, and Traverse runs portable WASM business capabilities.
+
+## Source Notes
+
+This is original repository fixture content created for MVP validation. It is intentionally short, source-attributed, and suitable for deterministic search tests.

--- a/knowledge/books/mvp-fixture-handbook/index.md
+++ b/knowledge/books/mvp-fixture-handbook/index.md
@@ -1,0 +1,18 @@
+# MVP Architecture Handbook
+
+<!--
+youaskm3:fixture
+source_type: book
+source_label: original MVP fixture
+artifact_id: fixture.book.mvp-architecture-handbook
+-->
+
+Architecture decisions for the first MVP are easiest to test when the repository contains a small handbook-style document. This fixture explains that artifact preparation and runtime execution are separate responsibilities.
+
+## Chapter 1: Artifact Pipeline
+
+The artifact pipeline converts source material into normalized markdown, search records, and graph-ready evidence. Build steps should be deterministic so the same repository state produces the same local index.
+
+## Chapter 2: Runtime Execution
+
+Runtime execution belongs behind Traverse-compatible contracts. Retrieval ranking, graph expansion, context packing, inference, validation, and formatting are business capabilities, not browser shortcuts.

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -22,10 +22,14 @@ The generated portion of this file is managed by the M1 knowledge index flow doc
 <!-- youaskm3:index:start -->
 | Category | Processed entries | Pending inputs |
 |---|---:|---:|
-| `books/` | 0 | 0 |
-| `papers/` | 0 | 0 |
-| `blog/` | 0 | 0 |
+| `books/` | 1 | 0 |
+| `papers/` | 1 | 0 |
+| `blog/` | 1 | 0 |
 | `inputs/` | 0 | 0 |
 
-No processed knowledge artifacts have been committed yet.
+Processed fixture artifacts:
+
+- `knowledge/books/mvp-fixture-handbook/index.md`
+- `knowledge/papers/mvp-fixture-note/index.md`
+- `knowledge/blog/mvp-fixture-article/index.md`
 <!-- youaskm3:index:end -->

--- a/knowledge/papers/mvp-fixture-note/index.md
+++ b/knowledge/papers/mvp-fixture-note/index.md
@@ -1,0 +1,14 @@
+# Source Grounding Note
+
+<!--
+youaskm3:fixture
+source_type: note
+source_label: original MVP fixture
+artifact_id: fixture.note.source-grounding
+-->
+
+Source grounding means every answer should carry evidence that a user can trace back to a markdown artifact, a chunk identifier, and eventually a graph relationship. The first MVP should make that evidence visible even before advanced inference exists.
+
+## Validation Claim
+
+The fixture note gives the search and chat harness a compact source for citation-oriented queries. It also gives graph generation a simple relationship between answers, evidence, and source paths.

--- a/scripts/generate-site-artifacts.rb
+++ b/scripts/generate-site-artifacts.rb
@@ -13,9 +13,22 @@ author_instance_path = File.join(root, "app/site/author-instance.json")
 abort("Missing required file: app/site/author-instance.json") unless File.file?(author_instance_path)
 
 def trimmed_excerpt(markdown)
+  inside_html_comment = false
+
   markdown
     .each_line
     .map(&:strip)
+    .reject do |line|
+      if inside_html_comment
+        inside_html_comment = false if line.include?("-->")
+        true
+      elsif line.start_with?("<!--")
+        inside_html_comment = true unless line.include?("-->")
+        true
+      else
+        false
+      end
+    end
     .reject(&:empty?)
     .reject { |line| line.start_with?("#", "-", "|", "<!--") }
     .first

--- a/scripts/mvp-fixture-corpus-smoke.sh
+++ b/scripts/mvp-fixture-corpus-smoke.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+ruby ./scripts/generate-site-artifacts.rb app/site
+
+ruby <<'RUBY'
+require "json"
+
+index = JSON.parse(File.read("app/site/search-index.json"))
+documents = index.fetch("documents")
+fixture_documents = documents.select { |document| document.fetch("source_path").include?("mvp-fixture") }
+
+abort "Expected at least 3 MVP fixture documents, found #{fixture_documents.length}" if fixture_documents.length < 3
+if fixture_documents.any? { |document| document.fetch("excerpt").include?("youaskm3:fixture") }
+  abort "Fixture metadata leaked into generated search excerpts"
+end
+
+required_queries = {
+  "portable" => "Portable Knowledge Article",
+  "architecture" => "MVP Architecture Handbook",
+  "grounding" => "Source Grounding Note"
+}
+
+required_queries.each do |query, expected_title|
+  matches = fixture_documents.select do |document|
+    [document.fetch("title"), document.fetch("excerpt"), document.fetch("source_path")].any? do |value|
+      value.downcase.include?(query)
+    end
+  end
+
+  unless matches.any? { |document| document.fetch("title") == expected_title }
+    abort "Expected query #{query.inspect} to match #{expected_title.inspect}"
+  end
+end
+RUBY
+
+portable_output="$(./scripts/m3.sh search portable)"
+architecture_output="$(./scripts/m3.sh search architecture)"
+
+grep -q "Portable Knowledge Article" <<<"$portable_output"
+grep -q "MVP Architecture Handbook" <<<"$architecture_output"
+
+echo "MVP fixture corpus smoke passed."

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -70,6 +70,9 @@ bash ./scripts/m3-command-surface-smoke.sh
 echo "Validating MVP contracts..."
 bash ./scripts/mvp-contracts-smoke.sh
 
+echo "Validating MVP fixture corpus..."
+bash ./scripts/mvp-fixture-corpus-smoke.sh
+
 echo "Validating federation index generation..."
 bash ./scripts/federation-index-smoke.sh
 


### PR DESCRIPTION
## What this changes
Adds a small original MVP fixture corpus with one article-like document, one handbook/book-like document, and one note/paper-like document. The generated local search index now contains three processed knowledge documents, and the search excerpts skip HTML metadata blocks so fixture metadata does not leak into user-facing results.

## Spec reference
- SPEC.md section 8 - MVP-2 Artifact Pipeline
- openspec/specs/knowledge-ingest/spec.md - normalized markdown artifacts
- openspec/specs/knowledge-search/spec.md - deterministic local search artifacts
- docs/mvp-ticket-backlog.md - MVP-004

## Spec delta (if spec changed)
None.

## Test coverage
Validated locally with:

```bash
./scripts/m3.sh sync
./scripts/m3.sh search portable
./scripts/m3.sh search architecture
PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh
```

Added `scripts/mvp-fixture-corpus-smoke.sh`, which verifies:

- at least three MVP fixture documents exist in `app/site/search-index.json`
- fixture metadata does not leak into excerpts
- fixture queries match `portable`, `architecture`, and `grounding`
- CLI search returns the expected fixture results

## Breaking changes
None.

Closes #63.
