### PR TITLE
Generate MVP knowledge graph artifact

### DIFF
--- a/app/site/build-manifest.json
+++ b/app/site/build-manifest.json
@@ -6,6 +6,7 @@
   "pendingInputCount": 0,
   "artifacts": [
     "app/site/search-index.json",
+    "app/site/knowledge-graph.json",
     "app/site/build-manifest.json",
     "app/site/sync-state.json",
     "app/site/author-instance.json",

--- a/app/site/knowledge-graph.json
+++ b/app/site/knowledge-graph.json
@@ -1,0 +1,148 @@
+{
+  "schema_version": "0.1.0",
+  "graph_id": "youaskm3-author.knowledge-graph",
+  "generated_from": [
+    "knowledge--blog--mvp-fixture-article--index",
+    "knowledge--books--mvp-fixture-handbook--index",
+    "knowledge--papers--mvp-fixture-note--index"
+  ],
+  "nodes": [
+    {
+      "node_id": "document:knowledge--blog--mvp-fixture-article--index",
+      "label": "Portable Knowledge Article",
+      "type": "document",
+      "source_artifact_ids": [
+        "knowledge--blog--mvp-fixture-article--index"
+      ],
+      "source_chunk_ids": [
+
+      ],
+      "source_paths": [
+        "knowledge/blog/mvp-fixture-article/index.md"
+      ]
+    },
+    {
+      "node_id": "chunk:knowledge--blog--mvp-fixture-article--index:chunk:0",
+      "label": "Portable Knowledge Article source chunk",
+      "type": "chunk",
+      "source_artifact_ids": [
+        "knowledge--blog--mvp-fixture-article--index"
+      ],
+      "source_chunk_ids": [
+        "knowledge--blog--mvp-fixture-article--index:chunk:0"
+      ],
+      "source_paths": [
+        "knowledge/blog/mvp-fixture-article/index.md"
+      ]
+    },
+    {
+      "node_id": "document:knowledge--books--mvp-fixture-handbook--index",
+      "label": "MVP Architecture Handbook",
+      "type": "document",
+      "source_artifact_ids": [
+        "knowledge--books--mvp-fixture-handbook--index"
+      ],
+      "source_chunk_ids": [
+
+      ],
+      "source_paths": [
+        "knowledge/books/mvp-fixture-handbook/index.md"
+      ]
+    },
+    {
+      "node_id": "chunk:knowledge--books--mvp-fixture-handbook--index:chunk:0",
+      "label": "MVP Architecture Handbook source chunk",
+      "type": "chunk",
+      "source_artifact_ids": [
+        "knowledge--books--mvp-fixture-handbook--index"
+      ],
+      "source_chunk_ids": [
+        "knowledge--books--mvp-fixture-handbook--index:chunk:0"
+      ],
+      "source_paths": [
+        "knowledge/books/mvp-fixture-handbook/index.md"
+      ]
+    },
+    {
+      "node_id": "document:knowledge--papers--mvp-fixture-note--index",
+      "label": "Source Grounding Note",
+      "type": "document",
+      "source_artifact_ids": [
+        "knowledge--papers--mvp-fixture-note--index"
+      ],
+      "source_chunk_ids": [
+
+      ],
+      "source_paths": [
+        "knowledge/papers/mvp-fixture-note/index.md"
+      ]
+    },
+    {
+      "node_id": "chunk:knowledge--papers--mvp-fixture-note--index:chunk:0",
+      "label": "Source Grounding Note source chunk",
+      "type": "chunk",
+      "source_artifact_ids": [
+        "knowledge--papers--mvp-fixture-note--index"
+      ],
+      "source_chunk_ids": [
+        "knowledge--papers--mvp-fixture-note--index:chunk:0"
+      ],
+      "source_paths": [
+        "knowledge/papers/mvp-fixture-note/index.md"
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "edge_id": "edge:knowledge--blog--mvp-fixture-article--index:document-source-chunk",
+      "from_node_id": "document:knowledge--blog--mvp-fixture-article--index",
+      "to_node_id": "chunk:knowledge--blog--mvp-fixture-article--index:chunk:0",
+      "relationship": "has_source_chunk",
+      "source_artifact_ids": [
+        "knowledge--blog--mvp-fixture-article--index"
+      ],
+      "source_chunk_ids": [
+        "knowledge--blog--mvp-fixture-article--index:chunk:0"
+      ],
+      "source_paths": [
+        "knowledge/blog/mvp-fixture-article/index.md"
+      ],
+      "extraction_method": "deterministic-site-artifact-generator",
+      "confidence": 1.0
+    },
+    {
+      "edge_id": "edge:knowledge--books--mvp-fixture-handbook--index:document-source-chunk",
+      "from_node_id": "document:knowledge--books--mvp-fixture-handbook--index",
+      "to_node_id": "chunk:knowledge--books--mvp-fixture-handbook--index:chunk:0",
+      "relationship": "has_source_chunk",
+      "source_artifact_ids": [
+        "knowledge--books--mvp-fixture-handbook--index"
+      ],
+      "source_chunk_ids": [
+        "knowledge--books--mvp-fixture-handbook--index:chunk:0"
+      ],
+      "source_paths": [
+        "knowledge/books/mvp-fixture-handbook/index.md"
+      ],
+      "extraction_method": "deterministic-site-artifact-generator",
+      "confidence": 1.0
+    },
+    {
+      "edge_id": "edge:knowledge--papers--mvp-fixture-note--index:document-source-chunk",
+      "from_node_id": "document:knowledge--papers--mvp-fixture-note--index",
+      "to_node_id": "chunk:knowledge--papers--mvp-fixture-note--index:chunk:0",
+      "relationship": "has_source_chunk",
+      "source_artifact_ids": [
+        "knowledge--papers--mvp-fixture-note--index"
+      ],
+      "source_chunk_ids": [
+        "knowledge--papers--mvp-fixture-note--index:chunk:0"
+      ],
+      "source_paths": [
+        "knowledge/papers/mvp-fixture-note/index.md"
+      ],
+      "extraction_method": "deterministic-site-artifact-generator",
+      "confidence": 1.0
+    }
+  ]
+}

--- a/contracts/examples/knowledge-graph.example.json
+++ b/contracts/examples/knowledge-graph.example.json
@@ -8,14 +8,16 @@
       "label": "Traverse",
       "type": "runtime",
       "source_artifact_ids": ["artifact.portable-runtime-note"],
-      "source_chunk_ids": ["chunk.runtime.001"]
+      "source_chunk_ids": ["chunk.runtime.001"],
+      "source_paths": ["knowledge/blog/portable-runtime-note.md"]
     },
     {
       "node_id": "node.wasm-capability",
       "label": "WASM capability",
       "type": "execution_unit",
       "source_artifact_ids": ["artifact.portable-runtime-note"],
-      "source_chunk_ids": ["chunk.runtime.001"]
+      "source_chunk_ids": ["chunk.runtime.001"],
+      "source_paths": ["knowledge/blog/portable-runtime-note.md"]
     }
   ],
   "edges": [
@@ -26,6 +28,7 @@
       "relationship": "runs",
       "source_artifact_ids": ["artifact.portable-runtime-note"],
       "source_chunk_ids": ["chunk.runtime.001"],
+      "source_paths": ["knowledge/blog/portable-runtime-note.md"],
       "extraction_method": "fixture",
       "confidence": 1
     }

--- a/contracts/knowledge-graph.schema.json
+++ b/contracts/knowledge-graph.schema.json
@@ -19,9 +19,10 @@
           "label": { "type": "string", "minLength": 1 },
           "type": { "type": "string" },
           "source_artifact_ids": { "type": "array", "items": { "type": "string" } },
-          "source_chunk_ids": { "type": "array", "items": { "type": "string" } }
+          "source_chunk_ids": { "type": "array", "items": { "type": "string" } },
+          "source_paths": { "type": "array", "items": { "type": "string" } }
         },
-        "required": ["node_id", "label", "type", "source_artifact_ids", "source_chunk_ids"],
+        "required": ["node_id", "label", "type", "source_artifact_ids", "source_chunk_ids", "source_paths"],
         "additionalProperties": false
       }
     },
@@ -36,10 +37,11 @@
           "relationship": { "type": "string", "minLength": 1 },
           "source_artifact_ids": { "type": "array", "items": { "type": "string" } },
           "source_chunk_ids": { "type": "array", "items": { "type": "string" } },
+          "source_paths": { "type": "array", "items": { "type": "string" } },
           "extraction_method": { "type": "string" },
           "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
         },
-        "required": ["edge_id", "from_node_id", "to_node_id", "relationship", "source_artifact_ids", "source_chunk_ids", "extraction_method", "confidence"],
+        "required": ["edge_id", "from_node_id", "to_node_id", "relationship", "source_artifact_ids", "source_chunk_ids", "source_paths", "extraction_method", "confidence"],
         "additionalProperties": false
       }
     }

--- a/scripts/generate-site-artifacts.rb
+++ b/scripts/generate-site-artifacts.rb
@@ -88,6 +88,57 @@ knowledge_documents = processed_document_paths.map do |path|
   }
 end
 
+graph_nodes = knowledge_documents.flat_map do |document|
+  artifact_id = document.fetch("id")
+  chunk_id = "#{artifact_id}:chunk:0"
+  source_path = document.fetch("source_path")
+
+  [
+    {
+      "node_id" => "document:#{artifact_id}",
+      "label" => document.fetch("title"),
+      "type" => "document",
+      "source_artifact_ids" => [artifact_id],
+      "source_chunk_ids" => [],
+      "source_paths" => [source_path]
+    },
+    {
+      "node_id" => "chunk:#{chunk_id}",
+      "label" => "#{document.fetch("title")} source chunk",
+      "type" => "chunk",
+      "source_artifact_ids" => [artifact_id],
+      "source_chunk_ids" => [chunk_id],
+      "source_paths" => [source_path]
+    }
+  ]
+end
+
+graph_edges = knowledge_documents.map do |document|
+  artifact_id = document.fetch("id")
+  chunk_id = "#{artifact_id}:chunk:0"
+  source_path = document.fetch("source_path")
+
+  {
+    "edge_id" => "edge:#{artifact_id}:document-source-chunk",
+    "from_node_id" => "document:#{artifact_id}",
+    "to_node_id" => "chunk:#{chunk_id}",
+    "relationship" => "has_source_chunk",
+    "source_artifact_ids" => [artifact_id],
+    "source_chunk_ids" => [chunk_id],
+    "source_paths" => [source_path],
+    "extraction_method" => "deterministic-site-artifact-generator",
+    "confidence" => 1.0
+  }
+end
+
+knowledge_graph = {
+  "schema_version" => "0.1.0",
+  "graph_id" => "#{author_instance.fetch("instanceId")}.knowledge-graph",
+  "generated_from" => knowledge_documents.map { |document| document.fetch("id") },
+  "nodes" => graph_nodes,
+  "edges" => graph_edges
+}
+
 search_index = {
   "instanceId" => author_instance.fetch("instanceId"),
   "title" => author_instance.fetch("title"),
@@ -104,6 +155,7 @@ build_manifest = {
   "pendingInputCount" => pending_input_paths.length,
   "artifacts" => [
     "app/site/search-index.json",
+    "app/site/knowledge-graph.json",
     "app/site/build-manifest.json",
     "app/site/sync-state.json",
     "app/site/author-instance.json",
@@ -123,5 +175,6 @@ sync_state = {
 
 FileUtils.mkdir_p(output_dir)
 File.write(File.join(output_dir, "search-index.json"), JSON.pretty_generate(search_index) + "\n")
+File.write(File.join(output_dir, "knowledge-graph.json"), JSON.pretty_generate(knowledge_graph) + "\n")
 File.write(File.join(output_dir, "build-manifest.json"), JSON.pretty_generate(build_manifest) + "\n")
 File.write(File.join(output_dir, "sync-state.json"), JSON.pretty_generate(sync_state) + "\n")

--- a/scripts/m3-sync.sh
+++ b/scripts/m3-sync.sh
@@ -33,10 +33,12 @@ if [[ -f "$SYNC_STATE_FILE" ]] && cmp -s "$temp_dir/sync-state.json" "$SYNC_STAT
 fi
 
 cp "$temp_dir/search-index.json" "$SITE_DIR/search-index.json"
+cp "$temp_dir/knowledge-graph.json" "$SITE_DIR/knowledge-graph.json"
 cp "$temp_dir/build-manifest.json" "$SITE_DIR/build-manifest.json"
 cp "$temp_dir/sync-state.json" "$SITE_DIR/sync-state.json"
 
 echo "Detected source changes; refreshed static artifacts."
 echo "- app/site/search-index.json"
+echo "- app/site/knowledge-graph.json"
 echo "- app/site/build-manifest.json"
 echo "- app/site/sync-state.json"

--- a/scripts/mvp-graph-artifact-smoke.sh
+++ b/scripts/mvp-graph-artifact-smoke.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+ruby ./scripts/generate-site-artifacts.rb app/site
+
+ruby <<'RUBY'
+require "json"
+
+search_index = JSON.parse(File.read("app/site/search-index.json"))
+graph = JSON.parse(File.read("app/site/knowledge-graph.json"))
+
+documents = search_index.fetch("documents")
+source_paths = documents.map { |document| document.fetch("source_path") }.sort
+
+abort "Graph artifact must include a schema version" unless graph.fetch("schema_version") == "0.1.0"
+abort "Graph generated_from must match indexed documents" unless graph.fetch("generated_from").sort == documents.map { |document| document.fetch("id") }.sort
+
+nodes = graph.fetch("nodes")
+edges = graph.fetch("edges")
+
+expected_node_count = documents.length * 2
+abort "Expected #{expected_node_count} graph nodes, found #{nodes.length}" unless nodes.length == expected_node_count
+abort "Expected #{documents.length} graph edges, found #{edges.length}" unless edges.length == documents.length
+
+graph_source_paths = (nodes + edges).flat_map { |entry| entry.fetch("source_paths") }.uniq.sort
+abort "Graph source paths do not match search index source paths" unless graph_source_paths == source_paths
+
+node_ids = nodes.map { |node| node.fetch("node_id") }
+abort "Graph node ids must be unique" unless node_ids.uniq.length == node_ids.length
+
+edges.each do |edge|
+  abort "Graph edge references missing source node: #{edge.fetch("edge_id")}" unless node_ids.include?(edge.fetch("from_node_id"))
+  abort "Graph edge references missing target node: #{edge.fetch("edge_id")}" unless node_ids.include?(edge.fetch("to_node_id"))
+  abort "Graph edge must use deterministic extraction" unless edge.fetch("extraction_method") == "deterministic-site-artifact-generator"
+end
+RUBY
+
+echo "MVP graph artifact smoke passed."

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -73,6 +73,9 @@ bash ./scripts/mvp-contracts-smoke.sh
 echo "Validating MVP fixture corpus..."
 bash ./scripts/mvp-fixture-corpus-smoke.sh
 
+echo "Validating MVP graph artifact..."
+bash ./scripts/mvp-graph-artifact-smoke.sh
+
 echo "Validating federation index generation..."
 bash ./scripts/federation-index-smoke.sh
 


### PR DESCRIPTION
## What this changes
Generates the first deterministic `app/site/knowledge-graph.json` artifact from processed markdown documents. Each indexed document now produces one document node, one chunk/source node, and one `has_source_chunk` edge with source artifact ids, chunk ids, and source paths.

## Spec reference
- SPEC.md section 8 - MVP-3 Search and Graph Evidence
- openspec/specs/knowledge-graph/spec.md - deterministic graph artifact
- contracts/knowledge-graph.schema.json
- docs/mvp-ticket-backlog.md - MVP-006

## Spec delta (if spec changed)
- Tightened `contracts/knowledge-graph.schema.json` so graph nodes and edges include `source_paths`.
- Updated the graph example fixture to include source paths.

## Test coverage
Validated locally with:

```bash
./scripts/m3.sh sync
test -f app/site/knowledge-graph.json
PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh
```

Added `scripts/mvp-graph-artifact-smoke.sh`, which verifies:

- generated graph references the indexed documents
- node and edge counts match the fixture corpus
- graph source paths match `search-index.json`
- edge endpoints reference existing nodes
- extraction method is deterministic

## Breaking changes
None.

Closes #65.
