### PR TITLE
Add lean agent workflow guidance

### DIFF
--- a/.codex/skills/youaskm3-ops/SKILL.md
+++ b/.codex/skills/youaskm3-ops/SKILL.md
@@ -52,6 +52,43 @@ YOUASKM3 OPS
 - Keep the PWA UI-only and the CLI artifact/build-focused.
 - Temporary harnesses are allowed only when they mirror the future Traverse contract and are clearly replaceable.
 
+## Token Discipline
+
+Default to lean, filtered operations. Preserve autonomy and correctness by fetching enough evidence to decide, but do not paste large raw outputs into chat.
+
+- Issue/PR discovery: prefer filtered `gh issue list` / `gh pr list` queries for the active lane before any full board export. Pull a single issue, PR, or project item in detail only after it becomes actionable.
+- Project boards: use `--jq` or `jq` filters that return only issue number, title, labels, status, agent/owner, blocker, and item id. Avoid full Project item JSON unless debugging schema drift.
+- PR checks: prefer `gh pr checks --json name,state,conclusion,workflow,detailsUrl --jq ...` or a one-shot status query. Avoid repeated `gh pr checks --watch` transcripts; report only status changes and failing check names.
+- CI logs: start with check/run summaries. Fetch logs only for failed jobs, and quote only actionable failure lines plus a small amount of surrounding context.
+- Tests and coverage: run the normal commands, but summarize pass/fail counts, failing test names, coverage gate result, and first actionable error. Do not paste full passing test, clippy, coverage, or build logs.
+- Diffs: inspect `git diff --stat` and `git diff --name-only` before any larger diff. Read narrow hunks for files under review instead of dumping full diffs.
+- File reads: use focused `rg` queries and exact `sed -n` ranges. Avoid broad recursive reads, full generated JSON, full lockfiles, and full build artifacts unless the whole file is the artifact being edited.
+- Progress updates: keep updates to current action, blocker if any, and next action. Do not restate unchanged CI, board, or test state.
+- Final reports: include merged/open PR, validation results, current branch/status, and the next recommended action. Keep detailed logs out of the final answer unless the user explicitly asks.
+
+Useful lean command shapes:
+
+```bash
+git diff --stat
+git diff --name-only
+gh pr checks <pr> --json name,state,conclusion,workflow,detailsUrl --jq '.[] | {name,state,conclusion,workflow,detailsUrl}'
+gh run view <run-id> --log-failed
+gh project item-list 3 --owner enricopiovesan --format json --limit 100 --jq '[.items[] | {content:.content.title,status:.status,labels:.labels,item:.id}]'
+```
+
+## Minimality Ladder
+
+Before adding code, apply this ladder in order:
+
+1. Does this change need to exist for the active issue or user request?
+2. Can existing project code, contracts, docs, configs, or tests already satisfy it?
+3. Can the standard library, platform feature, or existing dependency do it?
+4. Can a schema, config, test, or doc change solve it without a new abstraction?
+5. Can one focused function, command branch, or validation rule solve it?
+6. Only then add the minimum new structure needed.
+
+Minimality must never weaken correctness, security, accessibility, stable errors, validation, traceability, required tests, or project governance. If the smallest change would weaken any of those, choose the next-smallest correct change and explain the tradeoff briefly.
+
 ## Validation
 
 Default validation for implementation work:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,5 +10,8 @@ openspec/specs/[capability]/spec.md - [requirement name]
 ## Test coverage
 [confirm: 100% maintained / new tests added for new behaviour]
 
+## Lean ops / minimality
+[confirm: used focused evidence, avoided broad dumps/logs, and applied the Minimality Ladder before adding code]
+
 ## Breaking changes
 [none / describe]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Agent Workflow
+
+This repository uses the youaskm3 ops model for agent and dev coordination.
+
+Start here before implementation work:
+
+1. Read `SPEC.md`.
+2. Read `docs/youaskm3-ops.md` for workflow, guardrails, Token Discipline, and the Minimality Ladder.
+3. If running Codex, use `.codex/skills/youaskm3-ops/SKILL.md` when the user says `YOUASKM3 OPS` or asks for ready-ticket, PR-finisher, backlog-gardener, or spec/contracts work.
+
+## Lean Ops Default
+
+Agents should stay autonomous and evidence-driven, but keep command output bounded:
+
+- Prefer filtered issue, PR, and Project 3 queries before full board exports.
+- Use `git diff --stat` and `git diff --name-only` before reading large diffs.
+- Read focused file ranges with `rg` and `sed -n`; avoid full generated files, lockfiles, and logs unless they are the artifact under review.
+- Summarize passing tests, lint, clippy, coverage, and CI as statuses and counts.
+- Fetch failed CI logs only for failed jobs, and quote only actionable failing lines.
+- Poll CI by reporting status changes, not repeated unchanged watch output.
+- Keep final reports focused on PR state, validation, branch/status, residual risk, and next recommendation.
+
+## Minimality Ladder
+
+Before adding code, apply this ladder:
+
+1. Does this change need to exist for the active issue or request?
+2. Can existing project code, contracts, docs, configs, or tests already satisfy it?
+3. Can the standard library, platform feature, or existing dependency do it?
+4. Can a schema, config, test, or doc change solve it without a new abstraction?
+5. Can one focused function, command branch, or validation rule solve it?
+6. Only then add the minimum new structure needed.
+
+Minimality must never weaken correctness, security, accessibility, stable errors, validation, traceability, required tests, or project governance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,9 +72,26 @@ openspec/specs/[capability]/spec.md — [requirement name]
 ## Test coverage
 [confirm: 100% maintained / new tests added for new behaviour]
 
+## Lean ops / minimality
+[confirm: used focused evidence, avoided broad dumps/logs, and applied the Minimality Ladder before adding code]
+
 ## Breaking changes
 [none / describe]
 ```
+
+## Agent and dev workflow discipline
+
+Agent-led work should follow [AGENTS.md](AGENTS.md) and
+[docs/youaskm3-ops.md](docs/youaskm3-ops.md). The short version:
+
+- use filtered issue, PR, Project 3, CI, and log queries before broad dumps
+- summarize passing validation as statuses and counts
+- quote only actionable failure lines when something fails
+- inspect `git diff --stat` and `git diff --name-only` before larger diffs
+- apply the Minimality Ladder before adding code or abstractions
+
+This discipline reduces review cost and token churn without weakening specs,
+contracts, validation, traceability, or governance.
 
 ## Coverage
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -264,6 +264,9 @@ openspec/specs/[capability]/spec.md — [requirement name]
 ## Test coverage
 [confirm: 100% maintained / new tests added for new behaviour]
 
+## Lean ops / minimality
+[confirm: used focused evidence, avoided broad dumps/logs, and applied the Minimality Ladder before adding code]
+
 ## Breaking changes
 [none / describe]
 ```

--- a/docs/youaskm3-ops.md
+++ b/docs/youaskm3-ops.md
@@ -89,6 +89,109 @@ Use this lane when a ticket needs application bundle registration, real Traverse
 - Temporary harnesses are allowed only when they mirror the future Traverse contract and are clearly replaceable.
 - If GitHub Project write scope is unavailable, report that clearly and avoid pretending the board was updated.
 
+## Token Discipline
+
+The operating model should stay autonomous without making the transcript carry every byte of evidence. Agents should fetch enough data to decide, patch, and validate, then report concise summaries with links, file paths, or check names that let a human drill in.
+
+### Default Rules
+
+- Start broad with counts and names, then narrow only where something is actionable.
+- Prefer filtered issue, PR, and Project 3 queries for the active lane before full board dumps or full issue exports.
+- Prefer structured filters over raw dumps: `--json`, `--jq`, `jq`, `rg`, exact line ranges, and summary flags.
+- Bound command output whenever the tool supports it. Increase the bound only after a specific failure requires more context.
+- Never paste full passing logs, full generated JSON, full lockfiles, full board exports, or full CI transcripts into chat.
+- Use `git diff --stat` and `git diff --name-only` before reading hunks. Read full diffs only for the files and ranges being reviewed.
+- Progress updates should say: current action, blocker if any, next action. Skip updates that merely restate unchanged state.
+- Final answers should cover PR/branch state, validation results, merged or open PR links, residual risks, and the next recommended action.
+
+### Lean Command Patterns
+
+Use these shapes as the default for common ops work:
+
+```bash
+git status --short --branch
+git diff --stat
+git diff --name-only
+git diff -- path/to/file
+rg -n "pattern" path/to/focused/tree
+sed -n '120,190p' path/to/file
+gh pr checks <pr> --json name,state,conclusion,workflow,detailsUrl --jq '.[] | {name,state,conclusion,workflow,detailsUrl}'
+gh run view <run-id> --json status,conclusion,url,jobs --jq '{status,conclusion,url,jobs:[.jobs[] | {name,status,conclusion}]}'
+gh run view <run-id> --log-failed
+gh project item-list 3 --owner enricopiovesan --format json --limit 100 --jq '[.items[] | {content:.content.title,status:.status,labels:.labels,item:.id}]'
+```
+
+### What To Report
+
+- Project board audits: number of Ready/In Progress/Blocked items, stale ownership conflicts, and the exact issue numbers that need action.
+- PR checks: count by status, failing check names, and the next failing line or URL. Do not paste watch output loops.
+- CI/test failures: failing command, failing test/check name, first actionable error line, and affected file if known.
+- Coverage: package/crate, measured status, threshold, and any uncovered file/function names if the gate fails.
+- Diffs: changed files, risk level, and narrow references to the hunks that matter.
+
+### Exceptions
+
+Large output is acceptable when the output itself is the deliverable, when a schema/log format is being debugged, or when the user explicitly asks for raw logs. Even then, prefer a saved artifact or a focused excerpt first.
+
+## Minimality Ladder
+
+Before adding code or creating a new abstraction, agents must apply this ladder in order:
+
+1. Does this change need to exist for the active issue or request?
+2. Can existing project code, contracts, docs, configs, or tests already satisfy it?
+3. Can the standard library, platform feature, or existing dependency do it?
+4. Can a schema, config, test, or doc change solve it without a new abstraction?
+5. Can one focused function, command branch, or validation rule solve it?
+6. Only then add the minimum new structure needed.
+
+Minimality is a cost-control tool, not permission to cut corners. It must never weaken:
+
+- correctness
+- security
+- accessibility
+- stable errors and failure modes
+- validation and test coverage
+- traceability and source evidence
+- OpenSpec, contract, PR, issue, or Project 3 governance
+
+When the smallest visible change would weaken any of those, choose the next-smallest correct change and call out the tradeoff in the PR.
+
+## Future-Agent Checklist
+
+### Before
+
+- Identify the active issue or request and the governing spec or contract.
+- Check open PRs before claiming new work.
+- Use lean issue/PR/project queries to find only actionable work.
+- Run ownership pre-flight before marking work In Progress.
+- Apply the Minimality Ladder before adding code.
+
+### During
+
+- Read focused file ranges and narrow diffs.
+- Keep status updates to current action, blocker, and next action.
+- Add tests or validation at the smallest level that proves the behavior.
+- Create future tickets for adjacent improvements instead of widening the active slice.
+
+### After
+
+- Report validation as pass/fail counts and named gates.
+- Include PR link/state, issue/project state, branch/status, and residual risk.
+- Quote only actionable failing lines if something failed.
+- Recommend the next Ready issue or PR-finisher action.
+
+## Output Reduction Risks
+
+Lean output can hide important information if used carelessly. Do not reduce output when:
+
+- a failure line is ambiguous without nearby context
+- a schema or generated artifact shape is the thing being reviewed
+- a security, privacy, accessibility, or data-loss risk is present
+- a Project field or GitHub API shape appears to have drifted
+- the user explicitly asks for raw logs, full diffs, or complete generated output
+
+In those cases, fetch the larger evidence, but summarize it first and keep raw excerpts focused.
+
 ## Current MVP Boundary
 
 The first MVP is:


### PR DESCRIPTION
## What this changes
Adds lean agent/dev workflow guidance across the project instruction surfaces: root `AGENTS.md`, the Codex ops skill, the full ops doc, contributor guidance, SPEC PR template copy, and the GitHub PR template.

Closes #80

## Spec reference
openspec/specs/pwa-shell/spec.md - agent/dev workflow supports governed PWA shell work without adding product behavior

## Spec delta (if spec changed)
None. This is documentation/instructions only.

## Updated files
- `AGENTS.md`
- `.codex/skills/youaskm3-ops/SKILL.md`
- `docs/youaskm3-ops.md`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `CONTRIBUTING.md`
- `SPEC.md`

## Before/after operating checklist
Before:
- identify active issue/request and governing spec
- check open PRs before new work
- use lean issue/PR/project queries
- run ownership pre-flight before In Progress
- apply the Minimality Ladder before adding code

During:
- read focused file ranges and narrow diffs
- keep updates to current action, blocker, and next action
- validate at the smallest level that proves behavior
- create future tickets for adjacent improvements

After:
- report validation as pass/fail counts and named gates
- include PR/issue/project state and branch/status
- quote only actionable failure lines
- recommend next Ready issue or PR-finisher action

## Risks
Lean output can hide useful context when failures are ambiguous, schema/generated artifact shape is under review, security/accessibility/data-loss risks are present, GitHub Project/API shape drifts, or the user asks for raw logs/full diffs. The docs now call out those exceptions.

## Test coverage
- `git diff --cached --check`
- targeted `rg` verification for Token Discipline, Minimality Ladder, Output Reduction Risks, and PR template prompts
- Full smoke not run: docs/instructions-only change; no executable code or OpenSpec files changed.

## Lean ops / minimality
Used focused file reads, `git diff --stat`, `git diff --name-only`, bounded command output, and no external dependencies or plugins.

## Breaking changes
None.
