### PR TITLE
Pin Traverse v0.4.0 MVP baseline

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -44,7 +44,7 @@ Anyone can fork it, fill it with their own knowledge, and run their own instance
 |---|---|---|
 | Business logic | **Rust → WASM** | Portable, safe, fast. Runs anywhere. |
 | WASM runtime | **Wasmtime** (CLI/server) / **browser native** | Same module, different host |
-| Runtime model | **Traverse v0.3 baseline / UMA** | Contract-driven, governed, explainable release surface for portable capabilities |
+| Runtime model | **Traverse v0.4.0 baseline / UMA** | Contract-driven, governed, explainable release surface for portable capabilities |
 | MCP interface | **WASM MCP module** | Portable MCP server compiled to WASM |
 | Runtime integration | **Traverse app bundle** | Registers capability contracts, event contracts, workflows, WASM packages, and model dependencies |
 
@@ -183,15 +183,18 @@ idea → /openspec:proposal → proposal.md + design.md + tasks.md + spec delta
 
 ### Traverse integration baseline
 
-youaskm3 integrates with Traverse through documented public release surfaces instead of private Traverse internals. The current working baseline is the Traverse v0.3 readiness path described in [docs/traverse-mvp-requirements.md](docs/traverse-mvp-requirements.md):
+youaskm3 integrates with Traverse through documented public release surfaces instead of private Traverse internals. The minimum approved first-MVP integration baseline is Traverse `v0.4.0`, released on 2026-06-22, as described in [docs/traverse-mvp-requirements.md](docs/traverse-mvp-requirements.md):
 
 - governed application bundle registration
+- WASM component manifest validation
 - WASM business capability execution
+- atomic bundle registration
 - evented workflow composition
 - app-facing HTTP/JSON execution path
 - MCP-facing execution path
 - public traces for answer grounding
 - local/server placement and model dependency resolution
+- downstream app MVP conformance evidence through `bash scripts/ci/downstream_app_mvp_conformance.sh`
 
 Roadmap work that touches runtime, MCP, browser hosting, model inference, or fork-and-run setup must pin an approved Traverse release pairing and include the relevant Traverse validation path.
 
@@ -334,9 +337,10 @@ Dual-licensed: **MIT** and **Apache-2.0**. Users choose.
 
 ### MVP-6 — Local-First Inference Through Traverse
 - [ ] `knowledge.infer` declares inference needs by contract instead of hardcoding a provider.
-- [ ] Traverse can run a compatible local WASM inference capability when available.
+- [ ] Traverse can resolve and run a compatible governed local inference capability or provider when available.
 - [ ] Traverse can choose a server-side inference capability when allowed and available.
 - [ ] Missing inference capability fails clearly before user-facing execution begins.
+- [ ] If the model engine itself is not yet WASM-native, the release notes and readiness checks state that caveat explicitly while preserving the Traverse-governed dependency boundary.
 
 ### Later — Fork, Federation, and Network Effects
 - [ ] One-command setup documented in README with a target under 15 minutes.

--- a/docs/mvp-ticket-backlog.md
+++ b/docs/mvp-ticket-backlog.md
@@ -374,7 +374,7 @@ bash scripts/smoke.sh
 
 Create a strict local test harness that mimics the future Traverse response shape.
 
-This allows the PWA chat UI to be developed while Traverse implements missing runtime/model dependency features.
+This allowed the PWA chat UI to be developed before the Traverse-backed runtime path was ready. After Traverse `v0.4.0`, the harness remains a replaceable development fallback while youaskm3 implements its real bundle, WASM capabilities, and Traverse adapter.
 
 ### Scope
 
@@ -461,21 +461,24 @@ PYTHON=/opt/homebrew/bin/python3.14 \
 bash scripts/smoke.sh
 ```
 
-## Ticket MVP-010: Create Traverse Application Bundle Skeleton
+## Ticket MVP-010: Create Traverse v0.4.0 Application Bundle Skeleton
 
 ### Objective
 
-Create the repo structure for the future Traverse application bundle without requiring Traverse to support all missing features yet.
+Create the repo structure and checked-in manifest files for the first youaskm3 Traverse application bundle, aligned to Traverse `v0.4.0` public manifest surfaces.
+
+This is no longer a placeholder for missing Traverse manifest/model features. Traverse `v0.4.0` provides application bundle manifests, WASM component manifests, governed model dependency declarations, atomic registration, and downstream conformance evidence.
 
 ### Scope
 
 Add:
 
-- bundle manifest placeholder
+- bundle manifest
 - capability contract references
 - workflow references
-- README explaining how it maps to Traverse
-- TODO markers for fields blocked by Traverse requirements
+- README explaining how it maps to Traverse `v0.4.0`
+- model dependency declaration for `knowledge.infer`
+- placement policy and permitted target metadata suitable for local-first MVP execution
 
 Suggested path:
 
@@ -487,14 +490,15 @@ Suggested path:
 
 - Executable WASM capabilities
 - real Traverse registration
-- model dependency resolution
+- live local model/Ollama proof
 
 ### Definition of Done
 
 - Bundle skeleton exists.
 - Bundle references the capability contracts from MVP-002.
-- README explains which Traverse requirements block full registration.
-- Manifest avoids pretending unsupported Traverse features already exist.
+- Manifest names Traverse `v0.4.0` as the minimum tested runtime baseline.
+- README explains which fields depend on real WASM binaries from later tickets.
+- Manifest includes governed model dependency metadata without hardcoding an inference provider in downstream app logic.
 - `bash scripts/smoke.sh` passes.
 
 ### Validation

--- a/docs/traverse-mvp-requirements.md
+++ b/docs/traverse-mvp-requirements.md
@@ -1,8 +1,8 @@
 # Traverse Requirements for the First Knowledge-App MVP
 
-Status: Draft for Traverse team review
+Status: Updated for Traverse v0.4.0 first-MVP baseline
 Owner: youaskm3 downstream integration
-Last updated: 2026-06-12
+Last updated: 2026-06-22
 
 ## Purpose
 
@@ -44,27 +44,39 @@ The downstream app should only depend on Traverse public surfaces, not private c
 
 ## Current Baseline Confirmed
 
-As of 2026-06-12, the local Traverse checkout and public GitHub `main` matched commit `b30ff93` (`docs: add youaskm3 v0.3.0 readiness index`).
+As of 2026-06-22, Traverse `v0.4.0` is the minimum approved first-MVP integration baseline for this downstream app.
 
-The following validation passed locally after installing the required Rust toolchain:
+Release:
+
+- Tag: `v0.4.0`
+- URL: https://github.com/enricopiovesan/Traverse/releases/tag/v0.4.0
+- Release date: 2026-06-22
+- Governing Traverse specs: `044-application-bundle-manifest` and `045-governed-model-dependency-resolution`
+
+The exact `v0.4.0` tag conformance path passed locally:
 
 ```bash
-bash scripts/ci/youaskm3_compatibility_conformance.sh
+bash scripts/ci/downstream_app_mvp_conformance.sh
 ```
 
-The current Traverse baseline appears sufficient for a narrow claim:
+Traverse `v0.4.0` covers the first-MVP runtime baseline:
 
-- source-build runtime surface exists
+- application bundle manifests
+- WASM component manifests
+- atomic app bundle registration
+- governed model dependency schema and resolution
+- deterministic selected/rejected model candidate evidence
+- local Ollama inference provider path, opt-in for live local conformance
 - HTTP/JSON app path exists
 - MCP stdio path exists
 - WASM execution via Wasmtime exists
-- stdin/stdout JSON contract exists
-- capability and agent package manifests exist
-- execution traces exist
+- public trace evidence exists
 - programmatic registration exists
-- browser adapter validation exists
+- downstream app MVP conformance exists
 
-The main MVP gap is model/capability dependency handling: current docs say `model_dependencies` are documentation-only and are not resolved or injected by the runtime.
+Important caveat:
+
+Traverse `v0.4.0` proves governed model dependency resolution and includes a local Ollama provider path, but the default conformance suite does not require a reachable live local model. Live local Ollama conformance is separately gated with `TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1`. Also, this baseline does not prove that the model engine itself is WASM-native. The first youaskm3 MVP may proceed as long as `knowledge.infer` is declared, resolved, placed, traced, and failed through Traverse-governed dependency surfaces rather than hardcoded downstream app provider logic.
 
 ## MVP Runtime Flow
 
@@ -200,9 +212,7 @@ Acceptance criteria:
 
 #### TRV-P0-004: Runtime Dependency Resolution for Model Dependencies
 
-Current agent docs describe `model_dependencies` as documentation-only. For this MVP, that is not enough.
-
-Traverse must turn model dependencies into runtime-governed dependencies.
+Traverse `v0.4.0` turns model dependency declarations into runtime-governed dependencies. youaskm3 must consume those public surfaces and must not hardcode an inference provider in product/business logic.
 
 Acceptance criteria:
 
@@ -507,7 +517,7 @@ The downstream app needs stable public APIs for:
 - discovering MCP tools
 - executing MCP entrypoints
 
-Current v0.3.0 surfaces already cover much of this through HTTP/JSON and MCP. The main missing part is runtime-governed model dependency resolution and a clear application manifest story.
+Traverse `v0.4.0` covers the required public API baseline through application manifests, WASM component manifests, atomic registration, governed model dependency resolution, HTTP/JSON trace paths, MCP reporting, and downstream MVP conformance evidence.
 
 ## Required Validation Evidence
 
@@ -522,17 +532,17 @@ Traverse should provide or extend validation scripts that prove:
 7. Browser/PWA consumption works without private Traverse internals.
 8. The conformance suite can run from a pinned release tag.
 
-Suggested validation command shape:
+Required Traverse validation command:
 
 ```bash
-bash scripts/ci/downstream_app_bundle_registration_smoke.sh
-bash scripts/ci/downstream_wasm_workflow_smoke.sh
-bash scripts/ci/downstream_model_dependency_smoke.sh
-bash scripts/ci/downstream_browser_app_smoke.sh
-bash scripts/ci/downstream_mcp_smoke.sh
+bash scripts/ci/downstream_app_mvp_conformance.sh
 ```
 
-The exact names do not matter. The evidence does.
+Optional live local model conformance:
+
+```bash
+TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1 bash scripts/ci/downstream_app_mvp_conformance.sh
+```
 
 ## Non-Goals for Traverse
 
@@ -551,23 +561,20 @@ Traverse should only care about these external tools if the downstream app wraps
 
 ## Open Questions for Traverse
 
-1. Should `model_dependencies` evolve into a first-class dependency resolver, or should model inference be represented as ordinary capability dependencies?
-2. Should model inference implementations be registered as capabilities, connectors, agents, or a new artifact type?
-3. How should large model weights or local indexes be referenced, digested, and placed?
-4. Can a workflow call another capability as a dependency without embedding provider-specific code inside a WASM module?
-5. What is the minimum local inference capability Traverse can prove first?
-6. Should application manifests live in Traverse, downstream apps, or both?
-7. What trace fields are safe for public UI display when inference and private source data are involved?
+1. What is the minimum local inference setup youaskm3 will document for first-MVP users?
+2. How should large model weights or local indexes be referenced, digested, and placed after the first MVP?
+3. When should the model engine itself become WASM-native, and what readiness evidence will prove that step?
+4. What trace fields are safe for public UI display when inference and private source data are involved?
 
 ## Recommended Traverse Work Order
 
-1. Promote model dependency declarations from documentation-only to governed runtime resolution.
-2. Define a minimal inference capability contract and trace shape.
-3. Add a smoke test proving one WASM workflow can depend on one inference capability.
-4. Add a downstream application manifest/bundle example with registration through public HTTP APIs.
-5. Extend MCP discovery/execution evidence to include the downstream workflow.
-6. Extend browser app validation to call the downstream workflow instead of only a demo fixture.
-7. Improve distribution beyond source-build once the contract is stable.
+1. Pin youaskm3 specs and docs to Traverse `v0.4.0`.
+2. Create the youaskm3 application bundle skeleton using v0.4.0 manifest fields.
+3. Add a youaskm3 readiness check that delegates to `downstream_app_mvp_conformance.sh`.
+4. Implement the MVP WASM capabilities and component manifests.
+5. Register the youaskm3 app bundle through Traverse public APIs.
+6. Wire the PWA and MCP paths to the same registered workflow.
+7. Add optional live local model conformance after the default no-paid-service path is stable.
 
 ## MVP Readiness Definition
 
@@ -579,12 +586,15 @@ Traverse is ready for this downstream MVP when the downstream app can honestly s
 
 Traverse already has a strong foundation for the first integration:
 
+- application bundle manifests
+- WASM component manifests
+- atomic app bundle registration
+- governed model dependency resolution
 - public HTTP/JSON app path
 - public MCP path
 - WASM execution
 - programmatic registration
-- traces
-- browser adapter validation
-- source-build conformance evidence
+- trace evidence
+- downstream app MVP conformance evidence
 
-The critical missing piece for the MVP is not generic runtime execution. It is governed dependency/model resolution for LLM inference and the ability for a downstream app to register and execute its full business workflow as a Traverse application bundle.
+The critical missing piece has moved to the downstream app: youaskm3 must now build and register its own Traverse v0.4.0 application bundle, implement the MVP WASM capabilities, wire the PWA/MCP paths to the registered workflow, and document the local inference caveat clearly.


### PR DESCRIPTION
## Summary
- Pins the youaskm3 first-MVP Traverse baseline to `v0.4.0` in the project spec and Traverse requirement docs.
- Records the v0.4.0 release date, downstream conformance command, manifest/model-dependency coverage, and live local Ollama caveat.
- Updates the MVP backlog language so the application bundle skeleton targets v0.4.0 instead of obsolete missing-runtime assumptions.

## Governing Spec
- `SPEC.md`
- `openspec/specs/traverse-integration/spec.md`

## Project Item
- Closes #83
- Tracked in Project 3

## Validation
- `rg -n "v0\.3|v0\.4\.0|downstream_app_mvp_conformance|model dependency|Ollama" SPEC.md README.md docs openspec/specs/traverse-integration/spec.md`
- `PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`

## Notes
- Docs explicitly preserve the Traverse-governed inference boundary while noting that v0.4.0 does not prove a WASM-native model engine.
- No runtime code or capability contracts changed.