### PR TITLE
Add Traverse v0.4.0 app bundle skeleton

### DIFF
--- a/traverse/youaskm3-app/README.md
+++ b/traverse/youaskm3-app/README.md
@@ -1,0 +1,118 @@
+# youaskm3 Traverse Application Bundle
+
+This directory contains the first youaskm3 application bundle skeleton for
+Traverse `v0.4.0`.
+
+It is the checked-in target shape for registering the first MVP chat workflow
+through Traverse public application-bundle surfaces. It is intentionally not a
+complete, registerable production bundle yet because the real WASM capability
+binaries and binary digests are created by later MVP tickets.
+
+## Baseline
+
+- Minimum Traverse release: `v0.4.0`
+- Traverse release date: 2026-06-22
+- Traverse release: <https://github.com/enricopiovesan/Traverse/releases/tag/v0.4.0>
+- Governing Traverse specs:
+  - `044-application-bundle-manifest`
+  - `045-governed-model-dependency-resolution`
+- youaskm3 governing spec:
+  - `openspec/specs/traverse-integration/spec.md`
+
+Traverse `v0.4.0` provides the public surfaces this skeleton targets:
+
+- application manifests
+- WASM component manifests
+- atomic app bundle registration
+- governed model dependency resolution
+- HTTP/JSON execution and trace paths
+- MCP reporting
+- downstream app MVP conformance through
+  `bash scripts/ci/downstream_app_mvp_conformance.sh`
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `manifest.json` | Application-level manifest for the youaskm3 knowledge app. |
+| `components/*/component.manifest.json` | Component manifest placeholders for each MVP capability contract. |
+| `workflows/knowledge-query-answer.workflow.json` | First chat workflow composed from MVP capability contracts. |
+
+## Capability Contracts
+
+The bundle references these checked-in capability contracts:
+
+- `knowledge.query.answer`
+- `knowledge.retrieve`
+- `knowledge.graph.expand`
+- `knowledge.context.pack`
+- `knowledge.infer`
+- `knowledge.answer.validate`
+- `knowledge.answer.format`
+
+The first workflow composes them in this order:
+
+1. retrieve candidate sources
+2. expand graph context
+3. pack model context
+4. delegate inference through governed `knowledge.infer`
+5. validate grounding
+6. format the final answer envelope
+
+## Pending Implementation Fields
+
+The component manifests use Traverse v0.4.0 field names now, but the following
+fields are placeholders until the corresponding WASM or agent artifacts exist:
+
+- `wasm_binary_path`
+- `wasm_digest`
+- component `digest` entries in `manifest.json`
+- `implementation_status`
+- `validation_evidence`
+
+Placeholder digests are all-zero SHA-256 values and must not be treated as
+real registration evidence. MVP-027 replaces them with generated component
+manifests and real binary digests.
+
+## Model Dependency
+
+The app manifest declares inference through Traverse v0.4.0
+`model_dependencies` using the `traverse.inference.generate` interface.
+
+The local Ollama candidate is a Traverse-resolved provider candidate, not
+hardcoded downstream business logic. The default readiness path must not require
+a live local model. Live local model conformance remains separately gated by:
+
+```bash
+TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1 bash scripts/ci/downstream_app_mvp_conformance.sh
+```
+
+The current baseline proves governed model dependency resolution. It does not
+prove that the model engine itself is WASM-native.
+
+## Registration Status
+
+This skeleton should fail real Traverse registration until later tickets provide
+real component artifacts and digests. That is expected.
+
+Follow-up tickets:
+
+- MVP-013: first `knowledge.retrieve` WASM capability
+- MVP-014: `knowledge.answer.validate`
+- MVP-023: `knowledge.graph.expand`
+- MVP-024: `knowledge.context.pack`
+- MVP-025: `knowledge.answer.format`
+- MVP-026: `knowledge.query.answer` workflow entrypoint
+- MVP-027: generated component manifests and binary digests
+- MVP-018: real bundle registration with Traverse v0.4.0
+
+## Local Validation
+
+For this skeleton slice:
+
+```bash
+rg -n "v0.4.0|model_dependencies|knowledge.query.answer|knowledge.retrieve|knowledge.infer" traverse/youaskm3-app
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```

--- a/traverse/youaskm3-app/components/knowledge-answer-format/component.manifest.json
+++ b/traverse/youaskm3-app/components/knowledge-answer-format/component.manifest.json
@@ -1,0 +1,30 @@
+{
+  "component_id": "youaskm3.knowledge.answer-format-component",
+  "version": "0.1.0",
+  "schema_version": "1.0.0",
+  "capability_id": "knowledge.answer.format",
+  "capability_version": "0.1.0",
+  "contract_path": "../../../../contracts/capabilities/knowledge.answer.format.json",
+  "wasm_binary_path": "../../../../target/wasm32-wasip1/release/youaskm3_knowledge_answer_format.wasm",
+  "wasm_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "implementation_status": "pending_wasm_binary",
+  "runtime_constraints": {
+    "host_api_access": "none",
+    "network_access": "forbidden",
+    "filesystem_access": "none"
+  },
+  "permitted_targets": [
+    "local",
+    "server",
+    "mcp"
+  ],
+  "dependencies": [],
+  "connector_requirements": [],
+  "validation_evidence": [
+    {
+      "evidence_type": "skeleton_manifest",
+      "status": "pending_real_wasm",
+      "tracked_by": "MVP-025"
+    }
+  ]
+}

--- a/traverse/youaskm3-app/components/knowledge-answer-validate/component.manifest.json
+++ b/traverse/youaskm3-app/components/knowledge-answer-validate/component.manifest.json
@@ -1,0 +1,30 @@
+{
+  "component_id": "youaskm3.knowledge.answer-validate-component",
+  "version": "0.1.0",
+  "schema_version": "1.0.0",
+  "capability_id": "knowledge.answer.validate",
+  "capability_version": "0.1.0",
+  "contract_path": "../../../../contracts/capabilities/knowledge.answer.validate.json",
+  "wasm_binary_path": "../../../../target/wasm32-wasip1/release/youaskm3_knowledge_answer_validate.wasm",
+  "wasm_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "implementation_status": "pending_wasm_binary",
+  "runtime_constraints": {
+    "host_api_access": "none",
+    "network_access": "forbidden",
+    "filesystem_access": "none"
+  },
+  "permitted_targets": [
+    "local",
+    "server",
+    "mcp"
+  ],
+  "dependencies": [],
+  "connector_requirements": [],
+  "validation_evidence": [
+    {
+      "evidence_type": "skeleton_manifest",
+      "status": "pending_real_wasm",
+      "tracked_by": "MVP-014"
+    }
+  ]
+}

--- a/traverse/youaskm3-app/components/knowledge-context-pack/component.manifest.json
+++ b/traverse/youaskm3-app/components/knowledge-context-pack/component.manifest.json
@@ -1,0 +1,30 @@
+{
+  "component_id": "youaskm3.knowledge.context-pack-component",
+  "version": "0.1.0",
+  "schema_version": "1.0.0",
+  "capability_id": "knowledge.context.pack",
+  "capability_version": "0.1.0",
+  "contract_path": "../../../../contracts/capabilities/knowledge.context.pack.json",
+  "wasm_binary_path": "../../../../target/wasm32-wasip1/release/youaskm3_knowledge_context_pack.wasm",
+  "wasm_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "implementation_status": "pending_wasm_binary",
+  "runtime_constraints": {
+    "host_api_access": "none",
+    "network_access": "forbidden",
+    "filesystem_access": "none"
+  },
+  "permitted_targets": [
+    "local",
+    "server",
+    "mcp"
+  ],
+  "dependencies": [],
+  "connector_requirements": [],
+  "validation_evidence": [
+    {
+      "evidence_type": "skeleton_manifest",
+      "status": "pending_real_wasm",
+      "tracked_by": "MVP-024"
+    }
+  ]
+}

--- a/traverse/youaskm3-app/components/knowledge-graph-expand/component.manifest.json
+++ b/traverse/youaskm3-app/components/knowledge-graph-expand/component.manifest.json
@@ -1,0 +1,30 @@
+{
+  "component_id": "youaskm3.knowledge.graph-expand-component",
+  "version": "0.1.0",
+  "schema_version": "1.0.0",
+  "capability_id": "knowledge.graph.expand",
+  "capability_version": "0.1.0",
+  "contract_path": "../../../../contracts/capabilities/knowledge.graph.expand.json",
+  "wasm_binary_path": "../../../../target/wasm32-wasip1/release/youaskm3_knowledge_graph_expand.wasm",
+  "wasm_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "implementation_status": "pending_wasm_binary",
+  "runtime_constraints": {
+    "host_api_access": "none",
+    "network_access": "forbidden",
+    "filesystem_access": "none"
+  },
+  "permitted_targets": [
+    "local",
+    "server",
+    "mcp"
+  ],
+  "dependencies": [],
+  "connector_requirements": [],
+  "validation_evidence": [
+    {
+      "evidence_type": "skeleton_manifest",
+      "status": "pending_real_wasm",
+      "tracked_by": "MVP-023"
+    }
+  ]
+}

--- a/traverse/youaskm3-app/components/knowledge-infer/component.manifest.json
+++ b/traverse/youaskm3-app/components/knowledge-infer/component.manifest.json
@@ -1,0 +1,29 @@
+{
+  "component_id": "youaskm3.knowledge.infer-component",
+  "version": "0.1.0",
+  "schema_version": "1.0.0",
+  "capability_id": "knowledge.infer",
+  "capability_version": "0.1.0",
+  "contract_path": "../../../../contracts/capabilities/knowledge.infer.json",
+  "wasm_binary_path": "../../../../target/wasm32-wasip1/release/youaskm3_knowledge_infer.wasm",
+  "wasm_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "implementation_status": "pending_wasm_or_agent_binary",
+  "runtime_constraints": {
+    "host_api_access": "none",
+    "network_access": "forbidden",
+    "filesystem_access": "none"
+  },
+  "permitted_targets": [
+    "local",
+    "server"
+  ],
+  "dependencies": [],
+  "connector_requirements": [],
+  "validation_evidence": [
+    {
+      "evidence_type": "skeleton_manifest",
+      "status": "pending_real_wasm_or_agent",
+      "tracked_by": "MVP-021"
+    }
+  ]
+}

--- a/traverse/youaskm3-app/components/knowledge-query-answer/component.manifest.json
+++ b/traverse/youaskm3-app/components/knowledge-query-answer/component.manifest.json
@@ -1,0 +1,55 @@
+{
+  "component_id": "youaskm3.knowledge.query-answer-component",
+  "version": "0.1.0",
+  "schema_version": "1.0.0",
+  "capability_id": "knowledge.query.answer",
+  "capability_version": "0.1.0",
+  "contract_path": "../../../../contracts/capabilities/knowledge.query.answer.json",
+  "wasm_binary_path": "../../../../target/wasm32-wasip1/release/youaskm3_knowledge_query_answer.wasm",
+  "wasm_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "implementation_status": "pending_wasm_binary",
+  "runtime_constraints": {
+    "host_api_access": "none",
+    "network_access": "forbidden",
+    "filesystem_access": "none"
+  },
+  "permitted_targets": [
+    "local",
+    "server",
+    "mcp"
+  ],
+  "dependencies": [
+    {
+      "component_id": "youaskm3.knowledge.retrieve-component",
+      "version": "0.1.0"
+    },
+    {
+      "component_id": "youaskm3.knowledge.graph-expand-component",
+      "version": "0.1.0"
+    },
+    {
+      "component_id": "youaskm3.knowledge.context-pack-component",
+      "version": "0.1.0"
+    },
+    {
+      "component_id": "youaskm3.knowledge.infer-component",
+      "version": "0.1.0"
+    },
+    {
+      "component_id": "youaskm3.knowledge.answer-validate-component",
+      "version": "0.1.0"
+    },
+    {
+      "component_id": "youaskm3.knowledge.answer-format-component",
+      "version": "0.1.0"
+    }
+  ],
+  "connector_requirements": [],
+  "validation_evidence": [
+    {
+      "evidence_type": "skeleton_manifest",
+      "status": "pending_real_wasm",
+      "tracked_by": "MVP-026"
+    }
+  ]
+}

--- a/traverse/youaskm3-app/components/knowledge-retrieve/component.manifest.json
+++ b/traverse/youaskm3-app/components/knowledge-retrieve/component.manifest.json
@@ -1,0 +1,30 @@
+{
+  "component_id": "youaskm3.knowledge.retrieve-component",
+  "version": "0.1.0",
+  "schema_version": "1.0.0",
+  "capability_id": "knowledge.retrieve",
+  "capability_version": "0.1.0",
+  "contract_path": "../../../../contracts/capabilities/knowledge.retrieve.json",
+  "wasm_binary_path": "../../../../target/wasm32-wasip1/release/youaskm3_knowledge_retrieve.wasm",
+  "wasm_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "implementation_status": "pending_wasm_binary",
+  "runtime_constraints": {
+    "host_api_access": "none",
+    "network_access": "forbidden",
+    "filesystem_access": "none"
+  },
+  "permitted_targets": [
+    "local",
+    "server",
+    "mcp"
+  ],
+  "dependencies": [],
+  "connector_requirements": [],
+  "validation_evidence": [
+    {
+      "evidence_type": "skeleton_manifest",
+      "status": "pending_real_wasm",
+      "tracked_by": "MVP-013"
+    }
+  ]
+}

--- a/traverse/youaskm3-app/manifest.json
+++ b/traverse/youaskm3-app/manifest.json
@@ -1,0 +1,158 @@
+{
+  "app_id": "youaskm3.knowledge-app",
+  "version": "0.1.0",
+  "schema_version": "1.0.0",
+  "minimum_traverse_version": "v0.4.0",
+  "integration_status": "skeleton_pending_wasm_components",
+  "workspace_defaults": {
+    "workspace_id": "youaskm3-local",
+    "registry_scope": "private"
+  },
+  "components": [
+    {
+      "component_id": "youaskm3.knowledge.query-answer-component",
+      "version": "0.1.0",
+      "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "manifest_path": "components/knowledge-query-answer/component.manifest.json",
+      "implementation_status": "pending_wasm_binary"
+    },
+    {
+      "component_id": "youaskm3.knowledge.retrieve-component",
+      "version": "0.1.0",
+      "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "manifest_path": "components/knowledge-retrieve/component.manifest.json",
+      "implementation_status": "pending_wasm_binary"
+    },
+    {
+      "component_id": "youaskm3.knowledge.graph-expand-component",
+      "version": "0.1.0",
+      "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "manifest_path": "components/knowledge-graph-expand/component.manifest.json",
+      "implementation_status": "pending_wasm_binary"
+    },
+    {
+      "component_id": "youaskm3.knowledge.context-pack-component",
+      "version": "0.1.0",
+      "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "manifest_path": "components/knowledge-context-pack/component.manifest.json",
+      "implementation_status": "pending_wasm_binary"
+    },
+    {
+      "component_id": "youaskm3.knowledge.infer-component",
+      "version": "0.1.0",
+      "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "manifest_path": "components/knowledge-infer/component.manifest.json",
+      "implementation_status": "pending_wasm_or_agent_binary"
+    },
+    {
+      "component_id": "youaskm3.knowledge.answer-validate-component",
+      "version": "0.1.0",
+      "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "manifest_path": "components/knowledge-answer-validate/component.manifest.json",
+      "implementation_status": "pending_wasm_binary"
+    },
+    {
+      "component_id": "youaskm3.knowledge.answer-format-component",
+      "version": "0.1.0",
+      "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "manifest_path": "components/knowledge-answer-format/component.manifest.json",
+      "implementation_status": "pending_wasm_binary"
+    }
+  ],
+  "workflows": [
+    {
+      "workflow_id": "youaskm3.knowledge.query-answer",
+      "workflow_version": "0.1.0",
+      "path": "workflows/knowledge-query-answer.workflow.json"
+    }
+  ],
+  "model_dependencies": [
+    {
+      "interface_id": "traverse.inference.generate",
+      "version_range": "^1.0",
+      "selection_policy": {
+        "strategy": "priority",
+        "allow_fallback": true
+      },
+      "required_capabilities": [
+        "text_generation"
+      ],
+      "minimum_context_window": 8192,
+      "candidates": [
+        {
+          "candidate_id": "local-ollama-llama-3-2",
+          "provider_capability_id": "traverse.inference.generate",
+          "provider_implementation_id": "ollama.local.generate",
+          "model_identifier": "llama3.2:3b",
+          "placement_target": "local",
+          "priority": 10,
+          "required_provider_config_keys": [
+            "ollama_base_url"
+          ],
+          "metadata": {
+            "implementation_kind": "real_local_provider",
+            "provider": "ollama",
+            "model_context_window": 8192,
+            "supports_streaming": true,
+            "live_conformance": "optional_TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE"
+          }
+        }
+      ]
+    }
+  ],
+  "config_schema": {
+    "type": "object",
+    "required": [
+      "workspace_id",
+      "artifact_index_path",
+      "graph_path"
+    ],
+    "properties": {
+      "workspace_id": {
+        "type": "string"
+      },
+      "artifact_index_path": {
+        "type": "string"
+      },
+      "graph_path": {
+        "type": "string"
+      },
+      "default_max_sources": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 20
+      },
+      "ollama_base_url": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false
+  },
+  "default_config": {
+    "workspace_id": "youaskm3-local",
+    "artifact_index_path": "app/site/search-index.json",
+    "graph_path": "app/site/knowledge-graph.json",
+    "default_max_sources": 5,
+    "ollama_base_url": "http://127.0.0.1:11434"
+  },
+  "placement_policy": {
+    "preferred_targets": [
+      "local"
+    ],
+    "permitted_targets": [
+      "local",
+      "server",
+      "mcp"
+    ],
+    "allow_fallback": true,
+    "fallback_order": [
+      "local",
+      "server"
+    ],
+    "default_inference_target": "local"
+  },
+  "public_surfaces": [
+    "http_json",
+    "mcp"
+  ]
+}

--- a/traverse/youaskm3-app/workflows/knowledge-query-answer.workflow.json
+++ b/traverse/youaskm3-app/workflows/knowledge-query-answer.workflow.json
@@ -1,0 +1,230 @@
+{
+  "kind": "workflow_definition",
+  "schema_version": "1.0.0",
+  "id": "youaskm3.knowledge.query-answer",
+  "name": "knowledge-query-answer",
+  "version": "0.1.0",
+  "lifecycle": "mvp-skeleton",
+  "owner": {
+    "team": "youaskm3",
+    "contact": "enrico.piovesan10@gmail.com"
+  },
+  "summary": "Answer a user prompt from prepared knowledge artifacts with citations, graph evidence, governed inference, validation, formatting, and public trace evidence.",
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "query"
+      ],
+      "properties": {
+        "query": {
+          "type": "string",
+          "minLength": 1
+        },
+        "conversation_id": {
+          "type": "string"
+        },
+        "artifact_scope": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "max_sources": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 20
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "answer",
+        "citations",
+        "graph_evidence",
+        "trace_id",
+        "validation"
+      ],
+      "properties": {
+        "answer": {
+          "type": "string"
+        },
+        "citations": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "graph_evidence": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "trace_id": {
+          "type": "string"
+        },
+        "validation": {
+          "type": "object"
+        },
+        "failure": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "nodes": [
+    {
+      "node_id": "retrieve_sources",
+      "capability_id": "knowledge.retrieve",
+      "capability_version": "0.1.0",
+      "input": {
+        "from_workflow_input": [
+          "query",
+          "artifact_scope",
+          "max_sources"
+        ]
+      },
+      "output": {
+        "to_workflow_state": [
+          "retrieved_chunks"
+        ]
+      }
+    },
+    {
+      "node_id": "expand_graph_context",
+      "capability_id": "knowledge.graph.expand",
+      "capability_version": "0.1.0",
+      "input": {
+        "from_workflow_input": [
+          "retrieved_chunks"
+        ]
+      },
+      "output": {
+        "to_workflow_state": [
+          "graph_evidence"
+        ]
+      }
+    },
+    {
+      "node_id": "pack_context",
+      "capability_id": "knowledge.context.pack",
+      "capability_version": "0.1.0",
+      "input": {
+        "from_workflow_input": [
+          "query",
+          "retrieved_chunks",
+          "graph_evidence"
+        ]
+      },
+      "output": {
+        "to_workflow_state": [
+          "context_package"
+        ]
+      }
+    },
+    {
+      "node_id": "run_inference",
+      "capability_id": "knowledge.infer",
+      "capability_version": "0.1.0",
+      "input": {
+        "from_workflow_input": [
+          "query",
+          "context_package"
+        ]
+      },
+      "output": {
+        "to_workflow_state": [
+          "raw_answer",
+          "selected_inference_capability",
+          "inference_placement"
+        ]
+      }
+    },
+    {
+      "node_id": "validate_grounding",
+      "capability_id": "knowledge.answer.validate",
+      "capability_version": "0.1.0",
+      "input": {
+        "from_workflow_input": [
+          "raw_answer",
+          "retrieved_chunks",
+          "graph_evidence"
+        ]
+      },
+      "output": {
+        "to_workflow_state": [
+          "validation"
+        ]
+      }
+    },
+    {
+      "node_id": "format_answer",
+      "capability_id": "knowledge.answer.format",
+      "capability_version": "0.1.0",
+      "input": {
+        "from_workflow_input": [
+          "raw_answer",
+          "retrieved_chunks",
+          "graph_evidence",
+          "validation"
+        ]
+      },
+      "output": {
+        "to_workflow_state": [
+          "answer",
+          "citations",
+          "graph_evidence",
+          "trace_id",
+          "validation"
+        ]
+      }
+    }
+  ],
+  "edges": [
+    {
+      "from": "retrieve_sources",
+      "to": "expand_graph_context",
+      "type": "direct"
+    },
+    {
+      "from": "expand_graph_context",
+      "to": "pack_context",
+      "type": "direct"
+    },
+    {
+      "from": "pack_context",
+      "to": "run_inference",
+      "type": "direct"
+    },
+    {
+      "from": "run_inference",
+      "to": "validate_grounding",
+      "type": "direct"
+    },
+    {
+      "from": "validate_grounding",
+      "to": "format_answer",
+      "type": "direct"
+    }
+  ],
+  "start_nodes": [
+    "retrieve_sources"
+  ],
+  "terminal_nodes": [
+    "format_answer"
+  ],
+  "tags": [
+    "youaskm3",
+    "mvp",
+    "knowledge",
+    "answer",
+    "traverse-v0.4.0"
+  ],
+  "governing_spec": "openspec/specs/traverse-integration/spec.md"
+}


### PR DESCRIPTION
## Summary
- Adds the first `traverse/youaskm3-app` bundle skeleton targeting Traverse `v0.4.0`.
- Adds an application manifest with seven MVP capability component refs, the `knowledge.query.answer` workflow ref, local-first placement policy, and governed model dependency declaration.
- Adds component manifest placeholders for all MVP capabilities and a workflow definition composing retrieval, graph expansion, context packing, inference, validation, and formatting.
- Documents that this skeleton is intentionally pending real WASM/agent binaries and digests from later MVP tickets.

## Governing Spec
- `SPEC.md`
- `openspec/specs/traverse-integration/spec.md`

## Project Item
- Closes #69
- Tracked in Project 3

## Validation
- JSON parse check for `traverse/youaskm3-app/manifest.json`, component manifests, and workflow file
- Structural skeleton check: Traverse baseline, seven component refs, six workflow nodes, contract paths, pending implementation markers
- `rg -n "v0\.4\.0|model_dependencies|knowledge\.query\.answer|knowledge\.retrieve|knowledge\.infer|pending_wasm|044-application-bundle-manifest|045-governed-model-dependency-resolution" traverse/youaskm3-app`
- `PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`

## Notes
- This PR does not perform real Traverse registration. Placeholder all-zero digests and `pending_*` implementation markers are intentional until the WASM capability and component manifest generation tickets land.
- The manifest declares inference through Traverse `model_dependencies`; it does not add downstream provider logic.