### PR TITLE
Add Traverse v0.4.0 readiness check

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ This repo is intentionally structured so humans and agents can navigate the same
 | Start or resume ops workflow | [docs/youaskm3-ops.md](docs/youaskm3-ops.md) |
 | Inspect the repo command surface | [scripts/m3.sh](scripts/m3.sh) |
 | Run the full validation path | [scripts/smoke.sh](scripts/smoke.sh) |
+| Check Traverse v0.4.0 readiness | [scripts/traverse-readiness.sh](scripts/traverse-readiness.sh) |
 | Review current knowledge layout | [knowledge/index.md](knowledge/index.md) |
 
 ## Command Surface Today
@@ -134,6 +135,14 @@ Available now:
 - `m3 search <query>` queries the generated local search index from the CLI
 - `m3 serve [port]` serves the static PWA shell from `app/site` for local inspection
 - `m3 smoke` runs the full repository validation path
+
+Traverse integration readiness is checked with:
+
+```bash
+bash scripts/traverse-readiness.sh
+```
+
+By default it looks for a sibling Traverse checkout at `../Traverse`. Set `TRAVERSE_REPO=/path/to/Traverse` when the checkout lives somewhere else. Set `TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1` only when the local model provider must be reachable during readiness validation.
 
 ## Project Standards
 

--- a/docs/traverse-mvp-requirements.md
+++ b/docs/traverse-mvp-requirements.md
@@ -538,11 +538,32 @@ Required Traverse validation command:
 bash scripts/ci/downstream_app_mvp_conformance.sh
 ```
 
+Downstream readiness wrapper:
+
+```bash
+bash scripts/traverse-readiness.sh
+```
+
+The wrapper looks for a local Traverse checkout at `../Traverse` by default. Use `TRAVERSE_REPO=/path/to/Traverse` or `TRAVERSE_CHECKOUT=/path/to/Traverse` when the checkout is elsewhere. It verifies that the checkout contains the `v0.4.0` baseline, reports the active tag and commit, delegates to Traverse's public downstream conformance script, and summarizes the capability areas instead of printing full passing logs:
+
+```text
+Traverse readiness passed.
+Capability areas:
+- application bundle registration: passed
+- WASM workflow execution: passed
+- model dependency resolution: passed
+- HTTP/JSON app path: passed
+- MCP parity path: passed
+- live local model conformance: optional skipped
+```
+
 Optional live local model conformance:
 
 ```bash
-TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1 bash scripts/ci/downstream_app_mvp_conformance.sh
+TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1 bash scripts/traverse-readiness.sh
 ```
+
+Normal repository smoke does not require Traverse to be installed. Run `scripts/traverse-readiness.sh` when validating the Traverse pairing for integration work, release evidence, or a ticket that touches the Traverse runtime boundary.
 
 ## Non-Goals for Traverse
 

--- a/scripts/traverse-readiness.sh
+++ b/scripts/traverse-readiness.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MIN_TRAVERSE_TAG="${MIN_TRAVERSE_TAG:-v0.4.0}"
+TRAVERSE_REPO="${TRAVERSE_REPO:-${TRAVERSE_CHECKOUT:-}}"
+
+if [[ -z "$TRAVERSE_REPO" ]]; then
+  if [[ -d "$ROOT_DIR/../Traverse/.git" ]]; then
+    TRAVERSE_REPO="$ROOT_DIR/../Traverse"
+  else
+    echo "Traverse readiness failed: set TRAVERSE_REPO to a local Traverse checkout." >&2
+    echo "Expected default sibling checkout at: $ROOT_DIR/../Traverse" >&2
+    exit 1
+  fi
+fi
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Traverse readiness failed: missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_file() {
+  local path="$1"
+
+  if [[ ! -f "$path" ]]; then
+    echo "Traverse readiness failed: missing required Traverse file: $path" >&2
+    exit 1
+  fi
+}
+
+print_area_summary() {
+  local log_file="$1"
+  local status="$2"
+  local live_model_status
+
+  if grep -q "Skipping local Ollama conformance" "$log_file"; then
+    live_model_status="optional skipped"
+  elif [[ "${TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE:-0}" == "1" ]]; then
+    live_model_status="required by TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1"
+  else
+    live_model_status="not required"
+  fi
+
+  echo "Traverse readiness ${status}."
+  echo "Capability areas:"
+  summarize_area "$log_file" "application bundle registration" "downstream app bundle registration smoke passed."
+  summarize_area "$log_file" "WASM workflow execution" "downstream WASM workflow smoke passed."
+  summarize_area "$log_file" "model dependency resolution" "downstream model dependency smoke passed."
+  summarize_area "$log_file" "HTTP/JSON app path" "downstream HTTP/JSON smoke passed."
+  summarize_area "$log_file" "MCP parity path" "downstream MCP smoke passed."
+  echo "- live local model conformance: ${live_model_status}"
+}
+
+summarize_area() {
+  local log_file="$1"
+  local label="$2"
+  local success_line="$3"
+
+  if grep -qF "$success_line" "$log_file"; then
+    echo "- ${label}: passed"
+  else
+    echo "- ${label}: not confirmed"
+  fi
+}
+
+require_cmd bash
+require_cmd git
+require_cmd cargo
+
+if [[ ! -d "$TRAVERSE_REPO/.git" ]]; then
+  echo "Traverse readiness failed: TRAVERSE_REPO is not a git checkout: $TRAVERSE_REPO" >&2
+  exit 1
+fi
+
+TRAVERSE_REPO="$(cd "$TRAVERSE_REPO" && pwd)"
+CONFORMANCE_SCRIPT="$TRAVERSE_REPO/scripts/ci/downstream_app_mvp_conformance.sh"
+require_file "$CONFORMANCE_SCRIPT"
+
+if ! git -C "$TRAVERSE_REPO" rev-parse --verify --quiet "$MIN_TRAVERSE_TAG^{commit}" >/dev/null; then
+  echo "Traverse readiness failed: Traverse checkout is missing required tag $MIN_TRAVERSE_TAG." >&2
+  echo "Fetch tags in the Traverse checkout, then retry." >&2
+  exit 1
+fi
+
+if ! git -C "$TRAVERSE_REPO" merge-base --is-ancestor "$MIN_TRAVERSE_TAG" HEAD; then
+  traverse_commit="$(git -C "$TRAVERSE_REPO" rev-parse --short HEAD)"
+  echo "Traverse readiness failed: Traverse checkout $traverse_commit is older than $MIN_TRAVERSE_TAG." >&2
+  exit 1
+fi
+
+traverse_commit="$(git -C "$TRAVERSE_REPO" rev-parse --short HEAD)"
+traverse_tag="$(git -C "$TRAVERSE_REPO" describe --tags --exact-match 2>/dev/null || true)"
+if [[ -z "$traverse_tag" ]]; then
+  traverse_tag="$(git -C "$TRAVERSE_REPO" describe --tags --abbrev=12 --always)"
+fi
+
+log_file="$(mktemp "${TMPDIR:-/tmp}/youaskm3-traverse-readiness.XXXXXX.log")"
+trap 'rm -f "$log_file"' EXIT
+
+echo "Checking Traverse readiness..."
+echo "Traverse repo: $TRAVERSE_REPO"
+echo "Traverse commit: $traverse_commit"
+echo "Traverse tag: $traverse_tag"
+echo "Minimum baseline: $MIN_TRAVERSE_TAG"
+echo "Conformance: scripts/ci/downstream_app_mvp_conformance.sh"
+
+set +e
+(
+  cd "$TRAVERSE_REPO"
+  TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE="${TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE:-0}" \
+    bash scripts/ci/downstream_app_mvp_conformance.sh
+) >"$log_file" 2>&1
+conformance_status=$?
+set -e
+
+if [[ "$conformance_status" -eq 0 ]]; then
+  print_area_summary "$log_file" "passed"
+  exit 0
+fi
+
+print_area_summary "$log_file" "failed"
+echo "Actionable failure excerpt:"
+tail -n 60 "$log_file"
+exit "$conformance_status"


### PR DESCRIPTION
## Summary
- Adds `scripts/traverse-readiness.sh` to verify a local Traverse checkout against the v0.4.0 first-MVP baseline.
- Delegates to Traverse public downstream conformance and summarizes capability-area results.
- Documents checkout discovery, env overrides, expected output, and local model caveat.

## Issue
Closes #70

## Governing Spec
- `openspec/specs/traverse-integration/spec.md`

## Validation
- `bash -n scripts/traverse-readiness.sh`
- `bash scripts/traverse-readiness.sh`
  - Traverse repo: `/Users/enricopiovesan/Documents/repos/Traverse`
  - Traverse commit: `dbbadbf`
  - Traverse tag: `v0.4.0`
  - Result: bundle registration, WASM workflow, model dependency, HTTP/JSON, and MCP parity passed; live local model conformance optional skipped.
- `PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`

## Notes
- Normal smoke still does not require a Traverse checkout.
- The readiness command intentionally uses only Traverse public conformance scripts, not private Traverse internals.