### PR TITLE
Add Traverse component manifest generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ This repo is intentionally structured so humans and agents can navigate the same
 | Inspect the repo command surface | [scripts/m3.sh](scripts/m3.sh) |
 | Run the full validation path | [scripts/smoke.sh](scripts/smoke.sh) |
 | Check Traverse v0.4.0 readiness | [scripts/traverse-readiness.sh](scripts/traverse-readiness.sh) |
+| Update Traverse component manifests | [scripts/traverse-component-manifests.sh](scripts/traverse-component-manifests.sh) |
 | Review current knowledge layout | [knowledge/index.md](knowledge/index.md) |
 
 ## Command Surface Today
@@ -143,6 +144,14 @@ bash scripts/traverse-readiness.sh
 ```
 
 By default it looks for a sibling Traverse checkout at `../Traverse`. Set `TRAVERSE_REPO=/path/to/Traverse` when the checkout lives somewhere else. Set `TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1` only when the local model provider must be reachable during readiness validation.
+
+Traverse component manifests are checked with:
+
+```bash
+bash scripts/traverse-component-manifests.sh --skeleton --check
+```
+
+Omit `--skeleton` when real capability WASM binaries are expected. In that mode the command fails if a referenced binary is missing and writes SHA-256 digests from the actual `.wasm` files.
 
 ## Project Standards
 

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -70,6 +70,9 @@ bash ./scripts/m3-command-surface-smoke.sh
 echo "Validating MVP contracts..."
 bash ./scripts/mvp-contracts-smoke.sh
 
+echo "Validating Traverse component manifests..."
+bash ./scripts/traverse-component-manifests-smoke.sh
+
 echo "Validating MVP fixture corpus..."
 bash ./scripts/mvp-fixture-corpus-smoke.sh
 

--- a/scripts/traverse-component-manifests-smoke.sh
+++ b/scripts/traverse-component-manifests-smoke.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+bash scripts/traverse-component-manifests.sh --skeleton --check
+
+ruby <<'RUBY'
+require "json"
+
+app_manifest = JSON.parse(File.read("traverse/youaskm3-app/manifest.json"))
+components = app_manifest.fetch("components")
+abort "Expected 7 Traverse components, found #{components.length}" unless components.length == 7
+
+components.each do |component|
+  manifest_path = File.join("traverse/youaskm3-app", component.fetch("manifest_path"))
+  manifest = JSON.parse(File.read(manifest_path))
+
+  %w[
+    component_id
+    version
+    capability_id
+    capability_version
+    contract_path
+    wasm_binary_path
+    wasm_digest
+    runtime_constraints
+    permitted_targets
+  ].each do |field|
+    abort "#{manifest_path} missing #{field}" unless manifest.key?(field)
+  end
+
+  abort "#{manifest_path} digest mismatch with app manifest" unless manifest.fetch("wasm_digest") == component.fetch("digest")
+  abort "#{manifest_path} must reference a WASM binary" unless manifest.fetch("wasm_binary_path").end_with?(".wasm")
+  abort "#{manifest_path} must include permitted targets" if manifest.fetch("permitted_targets").empty?
+end
+RUBY
+
+echo "Traverse component manifest smoke passed."

--- a/scripts/traverse-component-manifests.rb
+++ b/scripts/traverse-component-manifests.rb
@@ -1,0 +1,146 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "digest"
+require "json"
+require "pathname"
+require "set"
+
+ROOT = Pathname.new(__dir__).join("..").realpath
+APP_MANIFEST_PATH = ROOT.join("traverse/youaskm3-app/manifest.json")
+ZERO_DIGEST = "sha256:#{"0" * 64}"
+REQUIRED_COMPONENT_FIELDS = %w[
+  component_id
+  version
+  schema_version
+  capability_id
+  capability_version
+  contract_path
+  wasm_binary_path
+  wasm_digest
+  implementation_status
+  runtime_constraints
+  permitted_targets
+].to_set
+
+options = {
+  check: false,
+  skeleton: false
+}
+
+ARGV.each do |arg|
+  case arg
+  when "--check"
+    options[:check] = true
+  when "--skeleton"
+    options[:skeleton] = true
+  when "--help", "-h"
+    puts "Usage: ruby scripts/traverse-component-manifests.rb [--check] [--skeleton]"
+    puts
+    puts "--check     Verify checked-in manifests are current without writing files."
+    puts "--skeleton  Allow missing WASM binaries and keep zero digests for pending components."
+    exit 0
+  else
+    abort "Unknown argument: #{arg}"
+  end
+end
+
+def read_json(path)
+  JSON.parse(path.read)
+rescue JSON::ParserError => error
+  abort "Invalid JSON in #{path.relative_path_from(ROOT)}: #{error.message}"
+end
+
+def pretty_json(data)
+  JSON.pretty_generate(data)
+      .gsub(/: \[\n\s*\]/, ": []")
+      .gsub(/: \{\n\s*\}/, ": {}")
+      .concat("\n")
+end
+
+def relative(path)
+  path.relative_path_from(ROOT).to_s
+end
+
+def checked_write(path, data, check:)
+  next_content = pretty_json(data)
+  current_content = path.file? ? path.read : nil
+
+  if check
+    abort "#{relative(path)} is not current; run bash scripts/traverse-component-manifests.sh --skeleton" unless current_content == next_content
+  else
+    path.write(next_content)
+  end
+end
+
+app_manifest = read_json(APP_MANIFEST_PATH)
+components = app_manifest.fetch("components")
+seen_component_ids = Set.new
+missing_binaries = []
+
+components.each do |app_component|
+  manifest_path = ROOT.join("traverse/youaskm3-app", app_component.fetch("manifest_path")).cleanpath
+  abort "Missing component manifest: #{relative(manifest_path)}" unless manifest_path.file?
+
+  component = read_json(manifest_path)
+  missing_fields = REQUIRED_COMPONENT_FIELDS - component.keys.to_set
+  abort "#{relative(manifest_path)} missing fields: #{missing_fields.to_a.sort.join(", ")}" unless missing_fields.empty?
+
+  component_id = app_component.fetch("component_id")
+  abort "Duplicate component_id in app manifest: #{component_id}" unless seen_component_ids.add?(component_id)
+  abort "#{relative(manifest_path)} component_id does not match app manifest" unless component.fetch("component_id") == component_id
+
+  contract_path = manifest_path.dirname.join(component.fetch("contract_path")).cleanpath
+  abort "Missing capability contract: #{relative(contract_path)}" unless contract_path.file?
+
+  contract = read_json(contract_path)
+  capability_id = contract.fetch("id")
+  capability_version = contract.fetch("version")
+  abort "#{relative(manifest_path)} capability_id does not match #{relative(contract_path)}" unless component.fetch("capability_id") == capability_id
+
+  wasm_binary_path = manifest_path.dirname.join(component.fetch("wasm_binary_path")).cleanpath
+  if wasm_binary_path.file?
+    digest = "sha256:#{Digest::SHA256.file(wasm_binary_path).hexdigest}"
+    implementation_status = "wasm_binary_ready"
+    validation_evidence = [
+      {
+        "evidence_type" => "wasm_binary_digest",
+        "status" => "verified",
+        "path" => component.fetch("wasm_binary_path"),
+        "digest" => digest
+      }
+    ]
+  elsif options[:skeleton]
+    digest = ZERO_DIGEST
+    implementation_status = component.fetch("implementation_status")
+    validation_evidence = component.fetch("validation_evidence", [])
+    missing_binaries << relative(wasm_binary_path)
+  else
+    abort "Missing WASM binary for #{capability_id}: #{relative(wasm_binary_path)}. Re-run with --skeleton only for pending components."
+  end
+
+  component["version"] = app_component.fetch("version")
+  component["capability_version"] = capability_version
+  component["wasm_digest"] = digest
+  component["implementation_status"] = implementation_status
+  component["permitted_targets"] = contract.fetch("execution").fetch("permitted_targets")
+  component["validation_evidence"] = validation_evidence
+
+  app_component["digest"] = digest
+  app_component["implementation_status"] = implementation_status
+
+  checked_write(manifest_path, component, check: options[:check])
+end
+
+if missing_binaries.empty?
+  app_manifest["integration_status"] = "wasm_components_ready"
+elsif options[:skeleton]
+  app_manifest["integration_status"] = "skeleton_pending_wasm_components"
+end
+
+checked_write(APP_MANIFEST_PATH, app_manifest, check: options[:check])
+
+mode = options[:check] ? "checked" : "updated"
+puts "Traverse component manifests #{mode}."
+puts "Components: #{components.length}"
+puts "Missing WASM binaries allowed by skeleton mode: #{missing_binaries.length}"

--- a/scripts/traverse-component-manifests.sh
+++ b/scripts/traverse-component-manifests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+ruby scripts/traverse-component-manifests.rb "$@"

--- a/traverse/youaskm3-app/README.md
+++ b/traverse/youaskm3-app/README.md
@@ -71,8 +71,18 @@ fields are placeholders until the corresponding WASM or agent artifacts exist:
 - `validation_evidence`
 
 Placeholder digests are all-zero SHA-256 values and must not be treated as
-real registration evidence. MVP-027 replaces them with generated component
-manifests and real binary digests.
+real registration evidence. The manifest generator keeps these placeholders
+only when explicitly run in skeleton mode:
+
+```bash
+bash scripts/traverse-component-manifests.sh --skeleton
+bash scripts/traverse-component-manifests.sh --skeleton --check
+```
+
+When real capability WASM binaries are expected, omit `--skeleton`. The command
+then fails on any missing `wasm_binary_path` and writes SHA-256 digests from the
+actual `.wasm` files into each component manifest and the app manifest component
+entries.
 
 ## Model Dependency
 
@@ -112,6 +122,7 @@ For this skeleton slice:
 
 ```bash
 rg -n "v0.4.0|model_dependencies|knowledge.query.answer|knowledge.retrieve|knowledge.infer" traverse/youaskm3-app
+bash scripts/traverse-component-manifests.sh --skeleton --check
 PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
 PYTHON=/opt/homebrew/bin/python3.14 \
 bash scripts/smoke.sh


### PR DESCRIPTION
## Summary
- Adds `scripts/traverse-component-manifests.sh` and Ruby generator/checker for Traverse v0.4.0 component manifests.
- Computes real SHA-256 digests when referenced WASM binaries exist and fails clearly when they are missing outside explicit `--skeleton` mode.
- Adds a manifest smoke check to normal smoke and documents the validation path.

## Issue
Closes #95

## Governing Spec
- `openspec/specs/traverse-integration/spec.md`

## Validation
- `bash scripts/traverse-component-manifests.sh --skeleton --check`
- `bash scripts/traverse-component-manifests-smoke.sh`
- `bash scripts/traverse-component-manifests.sh` fails clearly today with missing pending WASM binaries unless `--skeleton` is provided.
- `PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH cargo build --locked --workspace --target wasm32-wasip1`
- `rg -n "digest|wasm|capability_id|permitted_targets|runtime_constraints" traverse/youaskm3-app/components`
- `PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`

## Notes
- This does not implement capability WASM binaries. Current checked-in manifests remain skeleton manifests with zero digests until those binaries exist.
- Normal smoke validates skeleton consistency without requiring future real capability artifacts.