### PR TITLE
Define local inference readiness policy

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -202,6 +202,10 @@ Roadmap work that touches runtime, MCP, browser hosting, model inference, or for
 
 The first-MVP personas, "As a..., I want..., so that..." stories, capability mappings, and demo acceptance path are maintained in [docs/mvp-user-stories.md](docs/mvp-user-stories.md). Runtime and UI work should map back to those stories when defining tickets, smoke tests, and demo evidence.
 
+### Local inference readiness
+
+The first-MVP local inference policy is maintained in [docs/mvp-local-inference-policy.md](docs/mvp-local-inference-policy.md). Default CI and smoke must not require a live local LLM. Live local model conformance is opt-in with `TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1`, and missing inference capability must fail as a Traverse dependency failure rather than as hidden downstream fallback logic.
+
 ### Spec format (OpenSpec)
 
 ```markdown

--- a/docs/mvp-local-inference-policy.md
+++ b/docs/mvp-local-inference-policy.md
@@ -1,0 +1,96 @@
+# First MVP Local Inference Readiness Policy
+
+Status: First-MVP policy
+Owner: youaskm3 Traverse integration
+Last updated: 2026-06-22
+
+## Purpose
+
+This policy defines what "local inference ready" means for the first MVP.
+
+The first MVP must not require a paid external service, hosted account, hosted database, or live local LLM in the default validation path. Inference is still a governed runtime dependency: youaskm3 declares `knowledge.infer` and Traverse resolves, places, traces, and fails that dependency through public Traverse surfaces.
+
+## Policy
+
+### Default Validation
+
+Default CI and `bash scripts/smoke.sh` MUST NOT require a live local LLM.
+
+Default smoke validates that:
+
+- the inference need is declared in `contracts/capabilities/knowledge.infer.json`
+- the app manifest declares governed `model_dependencies`
+- Traverse-specific readiness can be checked separately with `bash scripts/traverse-readiness.sh`
+- missing inference capability is treated as a runtime dependency failure, not as a missing repo setup step
+
+### Optional Live Local Conformance
+
+Live local inference proof is opt-in for the first MVP:
+
+```bash
+TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1 bash scripts/traverse-readiness.sh
+```
+
+Minimum supported first-MVP local provider configuration:
+
+- Provider path: Traverse-governed local Ollama provider candidate
+- Candidate id: `local-ollama-llama-3-2`
+- Model identifier: `llama3.2:3b`
+- Default base URL: `http://127.0.0.1:11434`
+- Minimum context window: 8192 tokens
+
+This provider is a Traverse-resolved candidate. youaskm3 UI, CLI, and business capability code MUST NOT hardcode Ollama, WebLLM, llama.cpp, a cloud API, or any fallback provider.
+
+### Missing Model Dependency
+
+When no compatible inference capability is available, the app-facing answer workflow MUST fail clearly as a dependency failure.
+
+Required failure category:
+
+- `MISSING_MODEL_DEPENDENCY`
+
+Allowed more-specific failure codes:
+
+- `INFERENCE_PROVIDER_UNAVAILABLE`
+- `INFERENCE_PLACEMENT_UNSATISFIED`
+- `INFERENCE_DEPENDENCY_REJECTED`
+
+Required user-facing copy shape:
+
+```text
+Inference dependency unavailable. Traverse could not resolve a compatible local or allowed server inference capability for this workspace.
+```
+
+The UI may shorten that copy for layout, but it must preserve the meaning:
+
+- the app setup is not necessarily broken
+- the knowledge artifacts are not necessarily broken
+- the failure is about Traverse dependency resolution or provider availability
+- the user can enable optional local conformance only when they intentionally run a compatible local provider
+
+### Trace Evidence
+
+When Traverse resolves inference, the public trace or execution report SHOULD expose:
+
+- inference interface id
+- selected candidate id when resolution succeeds
+- rejected candidate ids or rejection reasons when resolution fails
+- placement target considered or selected
+- provider implementation id only when safe for public display
+- stable failure code for missing or rejected inference dependency
+
+The UI may display summarized placement and dependency status, but it must not duplicate Traverse's routing or provider-selection logic.
+
+### WASM-Native Model Caveat
+
+Traverse `v0.4.0` proves governed model dependency resolution and includes an opt-in local Ollama provider path. It does not prove that the model engine itself is WASM-native.
+
+The first MVP may proceed while this caveat is true because the architectural requirement is that inference selection, placement, trace evidence, and failure handling are governed by Traverse rather than hardcoded downstream app logic. A later release may require the model engine itself to run as WASM when Traverse exposes stable readiness evidence for that path.
+
+## Acceptance Checks
+
+- `scripts/traverse-readiness.sh` reports live local model conformance separately from baseline Traverse readiness.
+- Default smoke passes without `TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1`.
+- Optional live local model conformance is documented with the exact opt-in command.
+- Missing inference capability uses `MISSING_MODEL_DEPENDENCY` or a more-specific inference dependency code.
+- Docs preserve the WASM-native model caveat until Traverse proves that path.

--- a/docs/traverse-mvp-requirements.md
+++ b/docs/traverse-mvp-requirements.md
@@ -78,6 +78,8 @@ Important caveat:
 
 Traverse `v0.4.0` proves governed model dependency resolution and includes a local Ollama provider path, but the default conformance suite does not require a reachable live local model. Live local Ollama conformance is separately gated with `TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1`. Also, this baseline does not prove that the model engine itself is WASM-native. The first youaskm3 MVP may proceed as long as `knowledge.infer` is declared, resolved, placed, traced, and failed through Traverse-governed dependency surfaces rather than hardcoded downstream app provider logic.
 
+The downstream local inference policy is defined in [mvp-local-inference-policy.md](mvp-local-inference-policy.md). Default youaskm3 smoke must not require a live local LLM; optional live local conformance remains explicit and opt-in.
+
 ## MVP Runtime Flow
 
 The downstream app needs this end-to-end runtime flow:
@@ -582,10 +584,9 @@ Traverse should only care about these external tools if the downstream app wraps
 
 ## Open Questions for Traverse
 
-1. What is the minimum local inference setup youaskm3 will document for first-MVP users?
+1. What additional evidence should Traverse expose before youaskm3 can claim the model engine itself is WASM-native?
 2. How should large model weights or local indexes be referenced, digested, and placed after the first MVP?
-3. When should the model engine itself become WASM-native, and what readiness evidence will prove that step?
-4. What trace fields are safe for public UI display when inference and private source data are involved?
+3. What trace fields are safe for public UI display when inference and private source data are involved?
 
 ## Recommended Traverse Work Order
 

--- a/scripts/local-inference-policy-smoke.sh
+++ b/scripts/local-inference-policy-smoke.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+require_pattern() {
+  local pattern="$1"
+  local path="$2"
+  local message="$3"
+
+  if ! grep -Eq "$pattern" "$path"; then
+    echo "Local inference policy smoke failed: $message" >&2
+    exit 1
+  fi
+}
+
+POLICY_DOC="docs/mvp-local-inference-policy.md"
+INFER_CONTRACT="contracts/capabilities/knowledge.infer.json"
+APP_MANIFEST="traverse/youaskm3-app/manifest.json"
+READINESS_SCRIPT="scripts/traverse-readiness.sh"
+
+require_pattern "Default CI and .*scripts/smoke\\.sh.*MUST NOT require a live local LLM" "$POLICY_DOC" "policy must keep default smoke independent of a live local LLM."
+require_pattern "TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1 bash scripts/traverse-readiness\\.sh" "$POLICY_DOC" "policy must document the opt-in local model conformance command."
+require_pattern "MISSING_MODEL_DEPENDENCY" "$POLICY_DOC" "policy must define the missing model dependency failure category."
+require_pattern "WASM-native" "$POLICY_DOC" "policy must keep the WASM-native model caveat visible."
+require_pattern "selected candidate id|rejected candidate ids|placement target" "$POLICY_DOC" "policy must describe trace evidence for inference resolution."
+require_pattern "knowledge\\.infer" "$INFER_CONTRACT" "knowledge.infer contract must exist."
+require_pattern "model_dependencies" "$APP_MANIFEST" "app manifest must declare model dependencies."
+require_pattern "live local model conformance" "$READINESS_SCRIPT" "readiness script must report local model status separately."
+
+echo "Local inference policy smoke passed."

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -73,6 +73,9 @@ bash ./scripts/mvp-contracts-smoke.sh
 echo "Validating Traverse component manifests..."
 bash ./scripts/traverse-component-manifests-smoke.sh
 
+echo "Validating local inference policy..."
+bash ./scripts/local-inference-policy-smoke.sh
+
 echo "Validating MVP fixture corpus..."
 bash ./scripts/mvp-fixture-corpus-smoke.sh
 

--- a/traverse/youaskm3-app/README.md
+++ b/traverse/youaskm3-app/README.md
@@ -100,6 +100,12 @@ TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1 bash scripts/ci/downstream_app_mvp_confo
 The current baseline proves governed model dependency resolution. It does not
 prove that the model engine itself is WASM-native.
 
+The downstream first-MVP policy for this boundary lives in
+[`docs/mvp-local-inference-policy.md`](../../docs/mvp-local-inference-policy.md).
+Missing local inference must fail as `MISSING_MODEL_DEPENDENCY` or a more
+specific inference dependency error, not as a hidden fallback to downstream
+provider logic.
+
 ## Registration Status
 
 This skeleton should fail real Traverse registration until later tickets provide


### PR DESCRIPTION
## Summary
- Adds `docs/mvp-local-inference-policy.md` defining default no-live-LLM smoke, optional local Ollama conformance, missing-model dependency failures, trace evidence, and the WASM-native model caveat.
- Links the policy from `SPEC.md`, Traverse MVP requirements, and the Traverse app bundle README.
- Adds `scripts/local-inference-policy-smoke.sh` and wires it into normal smoke.

## Issue
Closes #86

## Governing Spec
- `SPEC.md`
- `openspec/specs/traverse-integration/spec.md`

## Validation
- `bash scripts/local-inference-policy-smoke.sh`
- `rg -n "local inference|Ollama|TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE|WASM-native model|missing model" docs SPEC.md scripts`
- `PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`

## Notes
- Docs/smoke policy only; no inference runtime internals changed.
- Default CI remains independent of a live local LLM.