### PR TITLE
Add inference dependency evidence tests

### DIFF
--- a/app/components/browser-runtime.test.ts
+++ b/app/components/browser-runtime.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -6,7 +9,9 @@ import {
   browserToolNames,
   callBrowserTool,
   documentsFromSearchIndex,
+  isMissingInferenceDependency,
   isBrowserToolName,
+  mapTraverseAnswerFailure,
   temporaryTraverseChatHarness
 } from "./browser-runtime";
 
@@ -204,6 +209,129 @@ describe("temporaryTraverseChatHarness", () => {
     expect(() => temporaryTraverseChatHarness({ query: "   " }, artifactDocuments)).toThrow(
       "missing browser runtime input"
     );
+  });
+});
+
+describe("Traverse inference dependency failures", () => {
+  it("maps missing inference dependency failures into the answer envelope", () => {
+    const output = mapTraverseAnswerFailure("portable", {
+      code: "MISSING_MODEL_DEPENDENCY",
+      message:
+        "Inference dependency unavailable. Traverse could not resolve a compatible local or allowed server inference capability for this workspace.",
+      recoverable: true,
+      trace_id: "trace-missing-model"
+    });
+
+    expect(output).toEqual({
+      answer:
+        "Inference dependency unavailable. Traverse could not resolve a compatible local or allowed server inference capability for this workspace.",
+      citations: [],
+      graph_evidence: [],
+      trace_id: "trace-missing-model",
+      validation: {
+        status: "invalid",
+        checks: [
+          "traverse-runtime-failure",
+          "missing-inference-dependency",
+          "MISSING_MODEL_DEPENDENCY"
+        ]
+      },
+      failure: {
+        code: "MISSING_MODEL_DEPENDENCY",
+        message:
+          "Inference dependency unavailable. Traverse could not resolve a compatible local or allowed server inference capability for this workspace.",
+        recoverable: true
+      }
+    });
+  });
+
+  it("keeps generic Traverse execution failures separate from missing inference", () => {
+    const output = mapTraverseAnswerFailure("portable", {
+      code: "WASM_EXECUTION_FAILED",
+      message: "Traverse execution failed before answer completion.",
+      recoverable: false
+    });
+
+    expect(output.trace_id).toBe("traverse-failure:portable");
+    expect(output.validation).toEqual({
+      status: "invalid",
+      checks: ["traverse-runtime-failure", "execution-failure", "WASM_EXECUTION_FAILED"]
+    });
+    expect(output.failure?.code).toBe("WASM_EXECUTION_FAILED");
+  });
+
+  it("recognizes the first-MVP missing inference failure code set", () => {
+    expect(isMissingInferenceDependency("MISSING_MODEL_DEPENDENCY")).toBe(true);
+    expect(isMissingInferenceDependency("INFERENCE_PROVIDER_UNAVAILABLE")).toBe(true);
+    expect(isMissingInferenceDependency("INFERENCE_PLACEMENT_UNSATISFIED")).toBe(true);
+    expect(isMissingInferenceDependency("INFERENCE_DEPENDENCY_REJECTED")).toBe(true);
+    expect(isMissingInferenceDependency("WASM_EXECUTION_FAILED")).toBe(false);
+  });
+
+  it("keeps provider identifiers out of browser runtime business logic", () => {
+    const runtimeSource = readFileSync(
+      path.resolve(process.cwd(), "app", "components", "browser-runtime.ts"),
+      "utf8"
+    );
+
+    expect(runtimeSource).not.toMatch(/\bOllama\b|\bWebLLM\b|llama\.cpp|openai|anthropic/i);
+  });
+
+  it("pins the Traverse manifest model dependency evidence fixture", () => {
+    const appManifest = JSON.parse(
+      readFileSync(
+        path.resolve(process.cwd(), "traverse", "youaskm3-app", "manifest.json"),
+        "utf8"
+      )
+    ) as {
+      model_dependencies: Array<{
+        candidates: Array<{
+          candidate_id: string;
+          metadata: Record<string, unknown>;
+          placement_target: string;
+          provider_implementation_id: string;
+        }>;
+        interface_id: string;
+      }>;
+    };
+    const dependency = appManifest.model_dependencies.find(
+      (modelDependency) => modelDependency.interface_id === "traverse.inference.generate"
+    );
+
+    expect(dependency).toBeDefined();
+    expect(dependency?.candidates[0]).toMatchObject({
+      candidate_id: "local-ollama-llama-3-2",
+      provider_implementation_id: "ollama.local.generate",
+      placement_target: "local",
+      metadata: {
+        live_conformance: "optional_TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE"
+      }
+    });
+  });
+
+  it("requires knowledge.infer to expose Traverse-owned dependency failure shape", () => {
+    const inferContract = JSON.parse(
+      readFileSync(
+        path.resolve(
+          process.cwd(),
+          "contracts",
+          "capabilities",
+          "knowledge.infer.json"
+        ),
+        "utf8"
+      )
+    ) as {
+      $defs: { failure: { required: string[] } };
+      model_dependencies: Array<{ notes: string; required: boolean }>;
+    };
+
+    expect(inferContract.model_dependencies[0]?.required).toBe(true);
+    expect(inferContract.model_dependencies[0]?.notes).toContain("Traverse resolves");
+    expect(inferContract.$defs.failure.required).toEqual([
+      "code",
+      "message",
+      "recoverable"
+    ]);
   });
 });
 

--- a/app/components/browser-runtime.ts
+++ b/app/components/browser-runtime.ts
@@ -98,13 +98,31 @@ export type BrowserValidation = {
   checks: string[];
 };
 
+export type BrowserFailure = {
+  code: string;
+  message: string;
+  recoverable: boolean;
+};
+
 export type BrowserAnswerResponse = {
   answer: string;
   citations: BrowserCitation[];
   graph_evidence: BrowserGraphEvidence[];
   trace_id: string;
   validation: BrowserValidation;
+  failure?: BrowserFailure;
 };
+
+export type TraverseAnswerFailure = BrowserFailure & {
+  trace_id?: string;
+};
+
+export const MISSING_INFERENCE_DEPENDENCY_CODES = [
+  "MISSING_MODEL_DEPENDENCY",
+  "INFERENCE_PROVIDER_UNAVAILABLE",
+  "INFERENCE_PLACEMENT_UNSATISFIED",
+  "INFERENCE_DEPENDENCY_REJECTED"
+] as const;
 
 export type BrowserRuntimeOutput =
   | { type: "answer"; payload: BrowserAnswerResponse }
@@ -188,6 +206,39 @@ export function documentsFromSearchIndex(artifact: SearchIndexArtifact): Browser
     excerpt: document.excerpt,
     sourcePath: document.source_path
   }));
+}
+
+export function isMissingInferenceDependency(code: string): boolean {
+  return MISSING_INFERENCE_DEPENDENCY_CODES.includes(
+    code as (typeof MISSING_INFERENCE_DEPENDENCY_CODES)[number]
+  );
+}
+
+export function mapTraverseAnswerFailure(
+  query: string,
+  failure: TraverseAnswerFailure
+): BrowserAnswerResponse {
+  const missingInference = isMissingInferenceDependency(failure.code);
+
+  return {
+    answer: failure.message,
+    citations: [],
+    graph_evidence: [],
+    trace_id: failure.trace_id ?? `traverse-failure:${slugify(query)}`,
+    validation: {
+      status: "invalid",
+      checks: [
+        "traverse-runtime-failure",
+        missingInference ? "missing-inference-dependency" : "execution-failure",
+        failure.code
+      ]
+    },
+    failure: {
+      code: failure.code,
+      message: failure.message,
+      recoverable: failure.recoverable
+    }
+  };
 }
 
 export function browserArtifactState(


### PR DESCRIPTION
## Summary
- Adds browser-runtime mapping for Traverse answer failures so missing inference dependency errors are distinct from generic execution failures.
- Adds fixture tests for missing inference codes, generic failures, manifest model dependency evidence, `knowledge.infer` failure shape, and no hardcoded provider identifiers in browser runtime logic.

## Issue
Closes #97

## Governing Spec
- `openspec/specs/traverse-integration/spec.md`
- `docs/mvp-local-inference-policy.md`

## Validation
- `npm test`
- `npm run typecheck`
- `cargo test --locked --workspace`
- `bash scripts/traverse-readiness.sh`
- `PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`

## Notes
- Default validation still does not require live local Ollama or any paid external model service.
- This does not implement an inference provider or change Traverse model resolution.