### PR TITLE
Tighten knowledge.query.answer workflow entrypoint

### DIFF
--- a/scripts/query-answer-workflow-smoke.sh
+++ b/scripts/query-answer-workflow-smoke.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+ruby <<'RUBY'
+require "json"
+
+APP_MANIFEST = "traverse/youaskm3-app/manifest.json"
+WORKFLOW = "traverse/youaskm3-app/workflows/knowledge-query-answer.workflow.json"
+
+def read_json(path)
+  JSON.parse(File.read(path))
+rescue JSON::ParserError => error
+  abort "Invalid JSON in #{path}: #{error.message}"
+end
+
+app = read_json(APP_MANIFEST)
+workflow = read_json(WORKFLOW)
+
+abort "query-answer workflow must be lifecycle=mvp" unless workflow.fetch("lifecycle") == "mvp"
+abort "query-answer workflow must require trace evidence" unless workflow.dig("trace", "required") == true
+
+expected_capabilities = [
+  "knowledge.retrieve",
+  "knowledge.graph.expand",
+  "knowledge.context.pack",
+  "knowledge.infer",
+  "knowledge.answer.validate",
+  "knowledge.answer.format"
+]
+
+nodes = workflow.fetch("nodes")
+actual_capabilities = nodes.map { |node| node.fetch("capability_id") }
+abort "query-answer workflow capabilities mismatch: #{actual_capabilities.inspect}" unless actual_capabilities == expected_capabilities
+
+expected_edges = nodes.each_cons(2).map { |left, right| [left.fetch("node_id"), right.fetch("node_id")] }
+actual_edges = workflow.fetch("edges").map { |edge| [edge.fetch("from"), edge.fetch("to")] }
+abort "query-answer workflow edges mismatch: #{actual_edges.inspect}" unless actual_edges == expected_edges
+
+trace_required = [
+  "knowledge.graph.expand",
+  "knowledge.context.pack",
+  "knowledge.answer.validate",
+  "knowledge.answer.format"
+]
+
+nodes.each do |node|
+  input = node.fetch("input")
+  if trace_required.include?(node.fetch("capability_id"))
+    abort "#{node.fetch("node_id")} does not receive workflow trace id" unless input.fetch("from_workflow_trace").include?("trace_id")
+  end
+end
+
+state_driven_nodes = nodes.drop(1)
+state_driven_nodes.each do |node|
+  input = node.fetch("input")
+  abort "#{node.fetch("node_id")} must consume workflow state" unless input.key?("from_workflow_state")
+end
+
+failure_policy = workflow.fetch("failure_policy")
+[
+  "MISSING_CHILD_CAPABILITY",
+  "MISSING_INFERENCE_DEPENDENCY",
+  "ANSWER_VALIDATION_FAILED"
+].each do |code|
+  unless failure_policy.values.any? { |policy| policy.fetch("code") == code && policy.fetch("recoverable") == true }
+    abort "query-answer workflow missing recoverable failure policy #{code}"
+  end
+end
+
+model_dependencies = app.fetch("model_dependencies")
+required_model_dependency = model_dependencies.any? do |dependency|
+  dependency.fetch("required_capabilities").include?("text_generation") &&
+    dependency.fetch("selection_policy").fetch("allow_fallback") == true
+end
+abort "app manifest must declare governed text generation dependency" unless required_model_dependency
+
+component_capabilities = app.fetch("components").map do |component|
+  manifest = read_json(File.join("traverse/youaskm3-app", component.fetch("manifest_path")))
+  manifest.fetch("capability_id")
+end
+
+missing = (["knowledge.query.answer"] + expected_capabilities) - component_capabilities
+abort "app manifest missing workflow component capabilities: #{missing.join(", ")}" unless missing.empty?
+RUBY
+
+echo "Query answer workflow smoke passed."

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -73,6 +73,9 @@ bash ./scripts/mvp-contracts-smoke.sh
 echo "Validating Traverse component manifests..."
 bash ./scripts/traverse-component-manifests-smoke.sh
 
+echo "Validating query answer workflow..."
+bash ./scripts/query-answer-workflow-smoke.sh
+
 echo "Validating local inference policy..."
 bash ./scripts/local-inference-policy-smoke.sh
 

--- a/traverse/youaskm3-app/workflows/knowledge-query-answer.workflow.json
+++ b/traverse/youaskm3-app/workflows/knowledge-query-answer.workflow.json
@@ -4,7 +4,7 @@
   "id": "youaskm3.knowledge.query-answer",
   "name": "knowledge-query-answer",
   "version": "0.1.0",
-  "lifecycle": "mvp-skeleton",
+  "lifecycle": "mvp",
   "owner": {
     "team": "youaskm3",
     "contact": "enrico.piovesan10@gmail.com"
@@ -86,8 +86,10 @@
       "input": {
         "from_workflow_input": [
           "query",
-          "artifact_scope",
           "max_sources"
+        ],
+        "from_app_config": [
+          "artifact_index_path"
         ]
       },
       "output": {
@@ -101,8 +103,14 @@
       "capability_id": "knowledge.graph.expand",
       "capability_version": "0.1.0",
       "input": {
-        "from_workflow_input": [
-          "retrieved_chunks"
+        "from_workflow_state": [
+          "retrieved_chunks.results[].chunk_id"
+        ],
+        "from_app_config": [
+          "graph_path"
+        ],
+        "from_workflow_trace": [
+          "trace_id"
         ]
       },
       "output": {
@@ -117,9 +125,17 @@
       "capability_version": "0.1.0",
       "input": {
         "from_workflow_input": [
-          "query",
+          "query"
+        ],
+        "from_workflow_state": [
           "retrieved_chunks",
           "graph_evidence"
+        ],
+        "literal": {
+          "token_budget": 4096
+        },
+        "from_workflow_trace": [
+          "trace_id"
         ]
       },
       "output": {
@@ -134,9 +150,14 @@
       "capability_version": "0.1.0",
       "input": {
         "from_workflow_input": [
-          "query",
+          "query"
+        ],
+        "from_workflow_state": [
           "context_package"
-        ]
+        ],
+        "literal": {
+          "max_output_tokens": 1024
+        }
       },
       "output": {
         "to_workflow_state": [
@@ -151,10 +172,13 @@
       "capability_id": "knowledge.answer.validate",
       "capability_version": "0.1.0",
       "input": {
-        "from_workflow_input": [
+        "from_workflow_state": [
           "raw_answer",
           "retrieved_chunks",
           "graph_evidence"
+        ],
+        "from_workflow_trace": [
+          "trace_id"
         ]
       },
       "output": {
@@ -168,11 +192,17 @@
       "capability_id": "knowledge.answer.format",
       "capability_version": "0.1.0",
       "input": {
-        "from_workflow_input": [
+        "from_workflow_state": [
           "raw_answer",
           "retrieved_chunks",
           "graph_evidence",
           "validation"
+        ],
+        "literal": {
+          "target": "chat"
+        },
+        "from_workflow_trace": [
+          "trace_id"
         ]
       },
       "output": {
@@ -219,6 +249,32 @@
   "terminal_nodes": [
     "format_answer"
   ],
+  "trace": {
+    "required": true,
+    "evidence": [
+      "capability_ids",
+      "placement",
+      "source_evidence",
+      "graph_evidence",
+      "model_dependency",
+      "validation_outcome",
+      "failure_reasons"
+    ]
+  },
+  "failure_policy": {
+    "missing_child_capability": {
+      "code": "MISSING_CHILD_CAPABILITY",
+      "recoverable": true
+    },
+    "missing_model_dependency": {
+      "code": "MISSING_INFERENCE_DEPENDENCY",
+      "recoverable": true
+    },
+    "validation_failure": {
+      "code": "ANSWER_VALIDATION_FAILED",
+      "recoverable": true
+    }
+  },
   "tags": [
     "youaskm3",
     "mvp",


### PR DESCRIPTION
## Summary
- Promotes the `knowledge.query.answer` workflow definition from skeleton to MVP entrypoint metadata.
- Fixes child capability wiring to consume workflow state/app config where appropriate and propagate workflow trace id to trace-required child contracts.
- Adds `scripts/query-answer-workflow-smoke.sh` and wires it into full smoke to guard composition, trace evidence, failure policy, model dependency, and component coverage.

## Issue
Closes #92

## Governing Spec / Contract
- `SPEC.md`
- `openspec/specs/traverse-integration/spec.md`
- `contracts/capabilities/knowledge.query.answer.json`
- `traverse/youaskm3-app/workflows/knowledge-query-answer.workflow.json`

## Validation
- `bash scripts/query-answer-workflow-smoke.sh`
- `bash scripts/traverse-component-manifests-smoke.sh`
- `bash scripts/traverse-readiness.sh`
- `PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`

## Notes
- Manifest/workflow slice only; no UI or runtime-provider implementation.
- The workflow remains dependent on Traverse execution/registration work for live execution, but the checked-in entrypoint is now guarded by smoke validation.