### PR TITLE
Add Traverse answer workflow smoke

### DIFF
--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -79,6 +79,9 @@ bash ./scripts/register-traverse-app-smoke.sh
 echo "Validating query answer workflow..."
 bash ./scripts/query-answer-workflow-smoke.sh
 
+echo "Validating Traverse answer workflow integration gate..."
+bash ./scripts/traverse-answer-workflow-smoke.sh
+
 echo "Validating local inference policy..."
 bash ./scripts/local-inference-policy-smoke.sh
 

--- a/scripts/traverse-answer-workflow-smoke.sh
+++ b/scripts/traverse-answer-workflow-smoke.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TRAVERSE_REPO="${TRAVERSE_REPO:-${TRAVERSE_CHECKOUT:-}}"
+REQUIRED="${TRAVERSE_ANSWER_WORKFLOW_REQUIRED:-0}"
+
+cd "$ROOT_DIR"
+
+if [[ -z "$TRAVERSE_REPO" && "$REQUIRED" == "1" && -d "$ROOT_DIR/../Traverse/.git" ]]; then
+  TRAVERSE_REPO="$ROOT_DIR/../Traverse"
+fi
+
+json_file="$(mktemp "${TMPDIR:-/tmp}/youaskm3-answer-workflow.XXXXXX.json")"
+trap 'rm -f "$json_file"' EXIT
+
+bash scripts/query-answer-workflow-smoke.sh
+
+ruby <<'RUBY'
+require "json"
+
+def read_json(path)
+  JSON.parse(File.read(path))
+rescue JSON::ParserError => error
+  abort "Invalid JSON in #{path}: #{error.message}"
+end
+
+search_index = read_json("app/site/search-index.json")
+graph = read_json("app/site/knowledge-graph.json")
+workflow = read_json("traverse/youaskm3-app/workflows/knowledge-query-answer.workflow.json")
+app = read_json("traverse/youaskm3-app/manifest.json")
+
+documents = search_index.fetch("documents")
+abort "answer workflow smoke requires prepared search documents" if documents.empty?
+documents.each do |document|
+  abort "search document missing source_path" unless document.fetch("source_path", "").end_with?(".md")
+end
+
+edges = graph.fetch("edges")
+abort "answer workflow smoke requires graph edges" if edges.empty?
+unless edges.any? { |edge| edge.fetch("source_chunk_ids", []).any? && edge.fetch("source_paths", []).any? }
+  abort "answer workflow smoke requires graph source evidence"
+end
+
+trace = workflow.fetch("trace")
+abort "answer workflow must require public traces" unless trace.fetch("required") == true
+%w[source_evidence graph_evidence model_dependency failure_reasons].each do |evidence|
+  abort "answer workflow trace missing #{evidence}" unless trace.fetch("evidence").include?(evidence)
+end
+
+failure_policy = workflow.fetch("failure_policy")
+missing_model = failure_policy.fetch("missing_model_dependency")
+abort "answer workflow missing inference dependency policy" unless missing_model.fetch("code") == "MISSING_INFERENCE_DEPENDENCY"
+abort "answer workflow missing inference failure must be recoverable" unless missing_model.fetch("recoverable") == true
+
+model_dependencies = app.fetch("model_dependencies")
+unless model_dependencies.any? { |dependency| dependency.fetch("required_capabilities").include?("text_generation") }
+  abort "app manifest must declare text_generation model dependency"
+end
+RUBY
+
+if [[ -z "$TRAVERSE_REPO" || ! -d "$TRAVERSE_REPO/.git" ]]; then
+  message="Traverse answer workflow smoke skipped: set TRAVERSE_REPO to run the live Traverse v0.4.0 gate."
+  if [[ "$REQUIRED" == "1" ]]; then
+    echo "$message" >&2
+    exit 2
+  fi
+  echo "$message"
+  exit 0
+fi
+
+TRAVERSE_REPO="$TRAVERSE_REPO" bash scripts/traverse-readiness.sh
+
+TRAVERSE_REPO="$TRAVERSE_REPO" \
+  bash scripts/register-traverse-app.sh --allow-skeleton --json >"$json_file"
+
+ruby -rjson -e '
+payload = JSON.parse(File.read(ARGV.fetch(0)))
+case payload.fetch("code")
+when "SKELETON_PENDING_WASM_COMPONENTS"
+  abort "expected missing WASM evidence" unless payload.dig("evidence", "missing_wasm_count").to_i.positive?
+  abort "expected skipped skeleton status" unless payload.fetch("status") == "skipped_skeleton_pending_wasm"
+  puts "Traverse answer workflow smoke reached registration boundary: skeleton pending WASM; execution skipped."
+when "REGISTERED", "VALIDATED"
+  abort "registered workflow must expose no errors" unless payload.fetch("errors").empty?
+  puts "Traverse answer workflow registration evidence passed."
+else
+  abort "unexpected Traverse answer workflow registration result: #{payload.fetch("code")}"
+end
+' "$json_file"
+
+echo "Traverse answer workflow smoke passed."

--- a/traverse/youaskm3-app/README.md
+++ b/traverse/youaskm3-app/README.md
@@ -129,6 +129,22 @@ public external app-register CLI for this application manifest shape, the
 command fails with `MISSING_PUBLIC_APP_REGISTRATION_SURFACE`. That is a
 Traverse integration requirement, not a downstream hidden fallback.
 
+The end-to-end answer workflow integration gate is:
+
+```bash
+bash scripts/traverse-answer-workflow-smoke.sh
+TRAVERSE_REPO=/path/to/Traverse bash scripts/traverse-answer-workflow-smoke.sh
+```
+
+The gate validates prepared search artifacts, graph source evidence, public
+trace requirements, model dependency policy, Traverse `v0.4.0` readiness, and
+the app registration boundary. Without `TRAVERSE_REPO`, it validates local
+youaskm3 artifacts and skips the live Traverse step so default smoke remains
+CI-safe. In the current skeleton state, the live Traverse step passes only when
+execution is blocked by `SKELETON_PENDING_WASM_COMPONENTS`; once real component
+WASM artifacts are available, the same gate should be tightened to expect live
+`knowledge.query.answer` execution evidence.
+
 Follow-up tickets:
 
 - MVP-013: first `knowledge.retrieve` WASM capability


### PR DESCRIPTION
## Summary
- Adds `scripts/traverse-answer-workflow-smoke.sh` as the end-to-end Traverse answer workflow integration gate.
- Validates prepared search artifacts, graph source evidence, trace evidence requirements, model dependency policy, and app registration boundary.
- Wires the gate into full smoke as CI-safe: local artifact checks always run, live Traverse runs only when `TRAVERSE_REPO` is set or the gate is required.

## Issue
Closes #94

## Governing Spec
- `SPEC.md`
- `openspec/specs/traverse-integration/spec.md`
- `docs/mvp-user-stories.md`

## Validation
- `bash scripts/traverse-answer-workflow-smoke.sh`
- `TRAVERSE_REPO=/Users/enricopiovesan/Documents/repos/Traverse bash scripts/traverse-answer-workflow-smoke.sh`
- `PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`

## Notes
- Live Traverse gate passed against Traverse `v0.4.0` commit `dbbadbf`.
- Current execution lands on `SKELETON_PENDING_WASM_COMPONENTS` because the app bundle still has placeholder WASM artifacts; this is the expected boundary until the real capability binaries are available.