### PR TITLE
Add Traverse MCP answer workflow parity smoke

### DIFF
--- a/app/components/mcp-tools-contract.test.ts
+++ b/app/components/mcp-tools-contract.test.ts
@@ -11,11 +11,16 @@ type JsonSchema = {
 };
 
 type ToolContract = {
+  capability_id?: string;
+  contract_path?: string;
   description: string;
   error_schema: JsonSchema;
   input_schema: JsonSchema;
   name: string;
   output_schema: JsonSchema;
+  surface?: string;
+  workflow_id?: string;
+  workflow_path?: string;
 };
 
 type ContractDocument = {
@@ -38,6 +43,7 @@ describe("mcp-tools contracts", () => {
     const contracts = readContracts();
 
     expect(contracts.tools.map((tool) => tool.name)).toEqual([
+      "knowledge.query.answer",
       "search",
       "remember",
       "recall",
@@ -68,12 +74,30 @@ describe("mcp-tools contracts", () => {
 
   it("pins the richer contract details for the first execution slice", () => {
     const contracts = readContracts();
+    const answerContract = contracts.tools.find(
+      (tool) => tool.name === "knowledge.query.answer"
+    );
     const searchContract = contracts.tools.find((tool) => tool.name === "search");
     const rememberContract = contracts.tools.find(
       (tool) => tool.name === "remember"
     );
     const statusContract = contracts.tools.find((tool) => tool.name === "status");
 
+    expect(answerContract).toMatchObject({
+      capability_id: "knowledge.query.answer",
+      contract_path: "contracts/capabilities/knowledge.query.answer.json",
+      surface: "traverse_mcp",
+      workflow_id: "youaskm3.knowledge.query-answer",
+      workflow_path:
+        "traverse/youaskm3-app/workflows/knowledge-query-answer.workflow.json"
+    });
+    expect(answerContract?.output_schema.required).toEqual([
+      "answer",
+      "citations",
+      "graph_evidence",
+      "trace_id",
+      "validation"
+    ]);
     expect(searchContract).toBeDefined();
     expect(searchContract?.output_schema.properties).toHaveProperty("results");
     expect(rememberContract?.input_schema.required).toEqual([

--- a/contracts/capabilities/knowledge.infer.json
+++ b/contracts/capabilities/knowledge.infer.json
@@ -9,7 +9,7 @@
   "execution": {
     "runtime": "traverse",
     "business_logic": "wasm_or_agent",
-    "permitted_targets": ["local", "server"],
+    "permitted_targets": ["local", "server", "mcp"],
     "requires_trace": true
   },
   "model_dependencies": [

--- a/contracts/mcp-tools.json
+++ b/contracts/mcp-tools.json
@@ -1,6 +1,92 @@
 {
   "tools": [
     {
+      "name": "knowledge.query.answer",
+      "description": "Answer a question from prepared knowledge artifacts through the registered Traverse answer workflow.",
+      "capability_id": "knowledge.query.answer",
+      "workflow_id": "youaskm3.knowledge.query-answer",
+      "contract_path": "contracts/capabilities/knowledge.query.answer.json",
+      "workflow_path": "traverse/youaskm3-app/workflows/knowledge-query-answer.workflow.json",
+      "surface": "traverse_mcp",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1
+          },
+          "conversation_id": {
+            "type": "string"
+          },
+          "artifact_scope": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "max_sources": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 20
+          }
+        },
+        "required": ["query"],
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "answer": {
+            "type": "string"
+          },
+          "citations": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "graph_evidence": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "trace_id": {
+            "type": "string"
+          },
+          "validation": {
+            "type": "object"
+          },
+          "failure": {
+            "type": "object"
+          }
+        },
+        "required": ["answer", "citations", "graph_evidence", "trace_id", "validation"],
+        "additionalProperties": false
+      },
+      "error_schema": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": [
+              "MISSING_CHILD_CAPABILITY",
+              "MISSING_INFERENCE_DEPENDENCY",
+              "ANSWER_VALIDATION_FAILED"
+            ]
+          },
+          "message": {
+            "type": "string"
+          },
+          "trace_id": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "message"],
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "search",
       "description": "Semantic and keyword hybrid search across indexed knowledge.",
       "input_schema": {

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -82,6 +82,9 @@ bash ./scripts/query-answer-workflow-smoke.sh
 echo "Validating Traverse answer workflow integration gate..."
 bash ./scripts/traverse-answer-workflow-smoke.sh
 
+echo "Validating Traverse MCP answer workflow parity..."
+bash ./scripts/traverse-mcp-answer-workflow-smoke.sh
+
 echo "Validating local inference policy..."
 bash ./scripts/local-inference-policy-smoke.sh
 

--- a/scripts/traverse-mcp-answer-workflow-smoke.sh
+++ b/scripts/traverse-mcp-answer-workflow-smoke.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TRAVERSE_REPO="${TRAVERSE_REPO:-${TRAVERSE_CHECKOUT:-}}"
+REQUIRED="${TRAVERSE_MCP_ANSWER_WORKFLOW_REQUIRED:-0}"
+
+cd "$ROOT_DIR"
+
+ruby <<'RUBY'
+require "json"
+require "pathname"
+
+ROOT = Pathname.new(Dir.pwd)
+
+def read_json(path)
+  JSON.parse(File.read(path))
+rescue JSON::ParserError => error
+  abort "Invalid JSON in #{path}: #{error.message}"
+end
+
+def relative_contract_path(component_manifest_path, component_manifest)
+  Pathname
+    .new(component_manifest_path)
+    .dirname
+    .join(component_manifest.fetch("contract_path"))
+    .cleanpath
+    .relative_path_from(ROOT)
+    .to_s
+rescue ArgumentError
+  Pathname
+    .new(component_manifest_path)
+    .dirname
+    .join(component_manifest.fetch("contract_path"))
+    .cleanpath
+    .to_s
+end
+
+app = read_json("traverse/youaskm3-app/manifest.json")
+workflow_entry = app.fetch("workflows").find { |entry| entry.fetch("workflow_id") == "youaskm3.knowledge.query-answer" }
+abort "app manifest missing query answer workflow" unless workflow_entry
+
+workflow_path = "traverse/youaskm3-app/#{workflow_entry.fetch("path")}"
+workflow = read_json(workflow_path)
+abort "query answer workflow id mismatch" unless workflow.fetch("id") == workflow_entry.fetch("workflow_id")
+abort "app manifest must expose MCP public surface" unless app.fetch("public_surfaces").include?("mcp")
+abort "app placement policy must permit MCP" unless app.fetch("placement_policy").fetch("permitted_targets").include?("mcp")
+
+mcp_tools = read_json("contracts/mcp-tools.json").fetch("tools")
+mcp_tool = mcp_tools.find { |tool| tool.fetch("name") == "knowledge.query.answer" }
+abort "MCP tools contract missing knowledge.query.answer" unless mcp_tool
+abort "MCP answer tool must map to capability contract" unless mcp_tool.fetch("capability_id") == "knowledge.query.answer"
+abort "MCP answer tool must map to registered workflow" unless mcp_tool.fetch("workflow_id") == workflow.fetch("id")
+abort "MCP answer tool must use Traverse MCP surface" unless mcp_tool.fetch("surface") == "traverse_mcp"
+abort "MCP answer tool contract path mismatch" unless mcp_tool.fetch("contract_path") == "contracts/capabilities/knowledge.query.answer.json"
+abort "MCP answer tool workflow path mismatch" unless mcp_tool.fetch("workflow_path") == workflow_path
+
+query_component_entry = app.fetch("components").find do |entry|
+  entry.fetch("component_id") == "youaskm3.knowledge.query-answer-component"
+end
+abort "app manifest missing query answer component" unless query_component_entry
+query_component_path = "traverse/youaskm3-app/#{query_component_entry.fetch("manifest_path")}"
+query_component = read_json(query_component_path)
+abort "query answer component capability mismatch" unless query_component.fetch("capability_id") == "knowledge.query.answer"
+abort "query answer component must permit MCP" unless query_component.fetch("permitted_targets").include?("mcp")
+abort "query answer component contract mismatch" unless relative_contract_path(query_component_path, query_component) == mcp_tool.fetch("contract_path")
+
+query_contract = read_json(mcp_tool.fetch("contract_path"))
+abort "query answer contract id mismatch" unless query_contract.fetch("id") == mcp_tool.fetch("capability_id")
+abort "query answer contract must permit MCP" unless query_contract.fetch("execution").fetch("permitted_targets").include?("mcp")
+abort "query answer contract must require trace" unless query_contract.fetch("execution").fetch("requires_trace") == true
+
+required_output = %w[answer citations graph_evidence trace_id validation]
+missing_output = required_output - mcp_tool.fetch("output_schema").fetch("required")
+abort "MCP answer tool output missing #{missing_output.join(", ")}" unless missing_output.empty?
+
+trace = workflow.fetch("trace")
+abort "MCP parity requires workflow trace" unless trace.fetch("required") == true
+%w[capability_ids placement source_evidence graph_evidence model_dependency validation_outcome failure_reasons].each do |evidence|
+  abort "workflow trace missing #{evidence}" unless trace.fetch("evidence").include?(evidence)
+end
+
+model_dependencies = app.fetch("model_dependencies")
+model_dependency = model_dependencies.find do |dependency|
+  dependency.fetch("interface_id") == "traverse.inference.generate" &&
+    dependency.fetch("required_capabilities").include?("text_generation")
+end
+abort "app manifest missing Traverse text generation model dependency" unless model_dependency
+abort "model dependency must include at least one candidate" if model_dependency.fetch("candidates").empty?
+
+failure_policy = workflow.fetch("failure_policy")
+%w[MISSING_CHILD_CAPABILITY MISSING_INFERENCE_DEPENDENCY ANSWER_VALIDATION_FAILED].each do |code|
+  unless failure_policy.values.any? { |policy| policy.fetch("code") == code && policy.fetch("recoverable") == true }
+    abort "workflow missing recoverable MCP-visible failure policy #{code}"
+  end
+end
+
+workflow_capabilities = workflow.fetch("nodes").map { |node| node.fetch("capability_id") }
+component_manifests = app.fetch("components").map do |entry|
+  path = "traverse/youaskm3-app/#{entry.fetch("manifest_path")}"
+  [path, read_json(path)]
+end
+component_by_capability = component_manifests.to_h { |path, manifest| [manifest.fetch("capability_id"), [path, manifest]] }
+
+workflow_capabilities.each do |capability_id|
+  manifest_path, manifest = component_by_capability.fetch(capability_id) do
+    abort "workflow capability #{capability_id} is not registered as an app component"
+  end
+  abort "#{capability_id} component must permit MCP" unless manifest.fetch("permitted_targets").include?("mcp")
+
+  contract = read_json(relative_contract_path(manifest_path, manifest))
+  abort "#{capability_id} contract id mismatch" unless contract.fetch("id") == capability_id
+  abort "#{capability_id} contract must permit MCP" unless contract.fetch("execution").fetch("permitted_targets").include?("mcp")
+  abort "#{capability_id} contract must require trace" unless contract.fetch("execution").fetch("requires_trace") == true
+end
+
+format_contract = read_json("contracts/capabilities/knowledge.answer.format.json")
+target_enum = format_contract.fetch("inputs").fetch("schema").fetch("properties").fetch("target").fetch("enum")
+abort "answer format contract must support MCP target" unless target_enum.include?("mcp")
+
+puts "Traverse MCP answer workflow local parity checks passed."
+RUBY
+
+if [[ -z "$TRAVERSE_REPO" || ! -d "$TRAVERSE_REPO/.git" ]]; then
+  message="Traverse MCP answer workflow smoke skipped: set TRAVERSE_REPO to run the live Traverse MCP parity gate."
+  if [[ "$REQUIRED" == "1" ]]; then
+    echo "$message" >&2
+    exit 2
+  fi
+  echo "$message"
+  exit 0
+fi
+
+(cd "$TRAVERSE_REPO" && bash scripts/ci/downstream_mcp_smoke.sh)
+
+echo "Traverse MCP answer workflow smoke passed."

--- a/traverse/youaskm3-app/README.md
+++ b/traverse/youaskm3-app/README.md
@@ -145,6 +145,20 @@ execution is blocked by `SKELETON_PENDING_WASM_COMPONENTS`; once real component
 WASM artifacts are available, the same gate should be tightened to expect live
 `knowledge.query.answer` execution evidence.
 
+The MCP parity gate is:
+
+```bash
+bash scripts/traverse-mcp-answer-workflow-smoke.sh
+TRAVERSE_REPO=/path/to/Traverse bash scripts/traverse-mcp-answer-workflow-smoke.sh
+```
+
+Without `TRAVERSE_REPO`, it proves the MCP tool contract maps to the same
+registered `knowledge.query.answer` workflow, capability contract, component
+manifests, trace evidence, failure policies, and model dependency metadata as
+the app-facing path. With `TRAVERSE_REPO`, it also runs Traverse's public
+downstream MCP smoke so the release pairing proves MCP model-resolution
+evidence through Traverse-owned surfaces.
+
 Follow-up tickets:
 
 - MVP-013: first `knowledge.retrieve` WASM capability

--- a/traverse/youaskm3-app/components/knowledge-infer/component.manifest.json
+++ b/traverse/youaskm3-app/components/knowledge-infer/component.manifest.json
@@ -15,7 +15,8 @@
   },
   "permitted_targets": [
     "local",
-    "server"
+    "server",
+    "mcp"
   ],
   "dependencies": [],
   "connector_requirements": [],


### PR DESCRIPTION
## Summary
- Adds a CI-safe Traverse MCP answer workflow parity smoke for the MVP `knowledge.query.answer` path.
- Maps `knowledge.query.answer` into `contracts/mcp-tools.json` with the same workflow/capability contract used by the app-facing path.
- Permits MCP invocation for `knowledge.infer` while leaving model placement as local/server, then documents the local and live Traverse validation paths.

## Issue
Closes #88

## Governing Spec
- `openspec/specs/mcp-interface/spec.md`
- `openspec/specs/traverse-integration/spec.md`
- `docs/traverse-mvp-requirements.md`

## Validation
- `bash scripts/traverse-mcp-answer-workflow-smoke.sh`
- `TRAVERSE_REPO=/Users/enricopiovesan/Documents/repos/Traverse bash scripts/traverse-mcp-answer-workflow-smoke.sh`
- `npm test -- app/components/mcp-tools-contract.test.ts`
- `PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`

## Notes
- Default smoke remains CI-safe and skips live Traverse MCP execution unless `TRAVERSE_REPO` is set.
- The live Traverse gate passed `validates_youaskm3_mcp_consumption_path` and `mcp_observation_report_exposes_model_resolution_evidence`.
