### PR TITLE
Define next product-led MVP tranche

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -202,6 +202,18 @@ Roadmap work that touches runtime, MCP, browser hosting, model inference, or for
 
 The first-MVP personas, "As a..., I want..., so that..." stories, capability mappings, and demo acceptance path are maintained in [docs/mvp-user-stories.md](docs/mvp-user-stories.md). Runtime and UI work should map back to those stories when defining tickets, smoke tests, and demo evidence.
 
+### Next product-led MVP tranche
+
+After Traverse `v0.4.0` readiness and the first youaskm3 WASM capability tranche, the next highest-ROI work is tracked as MVP-031 through MVP-035 in [docs/mvp-ticket-backlog.md](docs/mvp-ticket-backlog.md):
+
+- prove the local Traverse-backed chat happy path
+- wire real WASM artifacts and component digests for implemented capabilities
+- add a real imported-document question acceptance test
+- enforce explicit Browser demo fallback semantics
+- create a Traverse blocker escalation template for confirmed upstream gaps
+
+These tickets keep youaskm3 product-led while using concrete app evidence to drive Traverse requirements. They must not add downstream runtime/provider shortcuts that bypass Traverse-governed WASM capability execution.
+
 ### Local inference readiness
 
 The first-MVP local inference policy is maintained in [docs/mvp-local-inference-policy.md](docs/mvp-local-inference-policy.md). Default CI and smoke must not require a live local LLM. Live local model conformance is opt-in with `TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1`, and missing inference capability must fail as a Traverse dependency failure rather than as hidden downstream fallback logic.

--- a/SPEC.md
+++ b/SPEC.md
@@ -214,6 +214,17 @@ After Traverse `v0.4.0` readiness and the first youaskm3 WASM capability tranche
 
 These tickets keep youaskm3 product-led while using concrete app evidence to drive Traverse requirements. They must not add downstream runtime/provider shortcuts that bypass Traverse-governed WASM capability execution.
 
+### Real runtime implementation rule
+
+First-MVP runtime acceptance requires the real product/business implementation, not placeholders:
+
+- deterministic product/business logic runs as real Rust/WASM microservice capabilities through Traverse
+- judgement, generation, model-use, or planning behavior runs as real WASM agent capabilities through Traverse
+- `knowledge.query.answer` is Traverse workflow composition, not a monolithic fake capability
+- Browser demo and temporary harnesses are allowed only as explicit developer aids and never count as MVP acceptance evidence
+- placeholder component manifests, all-zero digests, contract stubs, fake workflow steps, or skeleton runtime paths must fail acceptance
+- when Traverse cannot run the required real workflow, the youaskm3 ticket is blocked and a detailed Traverse requirement is created instead of adding downstream workaround logic
+
 ### Local inference readiness
 
 The first-MVP local inference policy is maintained in [docs/mvp-local-inference-policy.md](docs/mvp-local-inference-policy.md). Default CI and smoke must not require a live local LLM. Live local model conformance is opt-in with `TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1`, and missing inference capability must fail as a Traverse dependency failure rather than as hidden downstream fallback logic.
@@ -346,7 +357,7 @@ Dual-licensed: **MIT** and **Apache-2.0**. Users choose.
 ### MVP-4 — UI-Only PWA Chat
 - [ ] The PWA provides the first user-facing product: a local-first chat interface.
 - [ ] Web Components render chat messages, source cards, graph evidence, and execution status.
-- [ ] The PWA can call a temporary local harness that exactly mirrors the Traverse app-facing contract.
+- [ ] The PWA can call the real Traverse app-facing workflow for MVP acceptance.
 - [ ] The PWA contains no retrieval, ranking, graph traversal, prompt construction, inference selection, or answer validation logic.
 
 ### MVP-5 — Traverse Runtime Integration
@@ -396,7 +407,7 @@ The first chat workflow is composed from these product-level capability contract
 | `knowledge.answer.validate` | Grounding, citation, and failure validation |
 | `knowledge.answer.format` | Final response shaping for chat and MCP clients |
 
-All seven capabilities must run as governed WASM capabilities or agents through Traverse for the production MVP. Temporary local harnesses are allowed only when they implement the same contract envelopes and are marked as replaceable.
+All seven capabilities must run as governed WASM capabilities or WASM agents through Traverse for the MVP runtime. Temporary local harnesses and Browser demo paths are developer aids only and do not count as MVP acceptance evidence.
 
 ---
 

--- a/docs/mvp-ticket-backlog.md
+++ b/docs/mvp-ticket-backlog.md
@@ -1,7 +1,7 @@
 # youaskm3 MVP Ticket Backlog
 
 Status: Draft implementation backlog
-Last updated: 2026-06-12
+Last updated: 2026-06-25
 
 ## Goal
 
@@ -733,6 +733,250 @@ PYTHON=/opt/homebrew/bin/python3.14 \
 bash scripts/smoke.sh
 ```
 
+## Ticket MVP-031: Prove the Local Traverse-Backed Chat Happy Path
+
+### Objective
+
+Make the primary local demo path use Traverse for `knowledge.query.answer` instead of relying on the explicit browser demo fallback.
+
+This ticket validates the product-led integration loop: the PWA remains UI-only, product/business behavior runs behind Traverse-compatible runtime boundaries, and missing local services fail visibly instead of silently falling back.
+
+### Scope
+
+Add or update the smallest set of scripts, docs, fixtures, and tests needed to prove:
+
+- a local Traverse HTTP/JSON runtime can be started or targeted for the youaskm3 app workflow
+- the PWA provider configuration points to that runtime as the default local provider
+- a local question reaches `knowledge.query.answer` through the Traverse app-facing boundary
+- the response includes answer text, citations or source references, graph evidence, validation status, and a trace reference
+- unavailable Traverse runtime returns a stable visible failure such as `TRAVERSE_UNAVAILABLE`
+
+### Out of Scope
+
+- hosted deployment
+- production model quality
+- adding new model providers in downstream UI or CLI code
+- changing Traverse internals except by creating a separate upstream Traverse issue for a confirmed blocker
+- removing the explicit browser demo fallback
+
+### Definition of Done
+
+- A documented command starts or targets the local Traverse-backed youaskm3 answer path.
+- A focused smoke test verifies a successful Traverse-backed answer when the local Traverse runtime is available.
+- The smoke test verifies that source citations or source references are non-empty.
+- The smoke test verifies that graph evidence is non-empty.
+- The smoke test verifies that the response includes validation status and a trace reference.
+- The smoke test verifies that missing Traverse runtime fails with a stable user-visible error and does not auto-fallback to Browser demo.
+- The PWA default local provider remains Traverse-backed.
+- Browser demo remains available only as an explicit user-selected fallback.
+- `docs/mvp-user-stories.md` demo acceptance path references the local Traverse-backed happy path.
+- `bash scripts/smoke.sh` passes without requiring a live Traverse runtime.
+- A separate live validation command is documented for machines that have Traverse available.
+
+### Validation
+
+```bash
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+
+TRAVERSE_REPO=/Users/enricopiovesan/Documents/repos/Traverse \
+bash scripts/traverse-readiness.sh
+
+TRAVERSE_REPO=/Users/enricopiovesan/Documents/repos/Traverse \
+bash scripts/traverse-answer-workflow-smoke.sh
+```
+
+## Ticket MVP-032: Wire Real WASM Artifacts Into the Traverse Bundle
+
+### Objective
+
+Move the checked-in Traverse app bundle from skeleton confidence toward real registration evidence by building the MVP WASM capability artifacts and generating real component digests wherever capability crates already exist.
+
+### Scope
+
+Update the bundle generation path so implemented capabilities can produce real `.wasm` artifacts and real SHA-256 digests in:
+
+- `traverse/youaskm3-app/manifest.json`
+- `traverse/youaskm3-app/components/*/component.manifest.json`
+
+The first pass should cover all capability crates currently implemented in the workspace and leave only genuinely unimplemented capabilities marked as pending.
+
+### Out of Scope
+
+- implementing missing capability business logic
+- inference model quality
+- hosted artifact publishing
+- changing Traverse manifest fields without a confirmed Traverse requirement
+
+### Definition of Done
+
+- A documented command builds implemented capability crates for `wasm32-wasip1`.
+- `scripts/traverse-component-manifests.sh` or the equivalent generator can run without `--skeleton` for implemented capabilities.
+- Implemented component manifests contain real `wasm_digest` values, not all-zero placeholder digests.
+- App manifest component entries contain real digests for implemented capabilities.
+- Pending markers remain only for capabilities that truly have no buildable WASM artifact yet.
+- Registration validation distinguishes between "pending unimplemented capability" and "implemented artifact failed validation."
+- Smoke or a focused script fails if an implemented capability keeps a placeholder digest.
+- `cargo build --locked --workspace --target wasm32-wasip1` passes.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+cargo build --locked --workspace --target wasm32-wasip1
+
+bash scripts/traverse-component-manifests.sh --check
+
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-033: Add a Real Imported-Document Question Acceptance Test
+
+### Objective
+
+Prove the first MVP against a realistic local user flow: import or normalize a source document, build artifacts, ask one question, and verify answer evidence.
+
+### Scope
+
+Create an acceptance smoke that uses repo-safe fixture content and exercises:
+
+- source conversion or normalization into markdown
+- artifact sync/build
+- search index generation
+- graph artifact availability
+- runtime answer request through the configured local path
+- answer text with source-backed citations
+- graph evidence
+- validation status
+
+### Out of Scope
+
+- private user content
+- large copyrighted documents
+- benchmark-quality retrieval scoring
+- mandatory live local LLM availability in default CI
+
+### Definition of Done
+
+- The test starts from fixture input that represents an imported document, not only a prebuilt `app/site/search-index.json`.
+- The test rebuilds or refreshes the relevant markdown/search/graph artifacts.
+- The test asks a concrete user question with an expected source-backed answer path.
+- The test asserts at least one cited source or source reference from the imported fixture.
+- The test asserts at least one graph node or edge from the imported fixture.
+- The test asserts a validation status and trace reference.
+- The default smoke path can run without a live local LLM by using the existing governed fallback/test harness rules.
+- A live Traverse variant is documented when a local Traverse checkout/runtime is available.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+
+TRAVERSE_REPO=/Users/enricopiovesan/Documents/repos/Traverse \
+bash scripts/traverse-readiness.sh
+```
+
+## Ticket MVP-034: Enforce Explicit Browser Demo Fallback Semantics
+
+### Objective
+
+Prevent regressions where the PWA silently falls back to browser-side product/business behavior when Traverse is unavailable.
+
+The Browser demo is useful for local no-server inspection, but it must remain an explicit provider choice and must not become a hidden alternate runtime.
+
+### Scope
+
+Add tests and documentation that enforce:
+
+- Traverse local is the default local provider
+- Browser demo is visible and selectable
+- Browser demo is not selected automatically after a Traverse failure
+- Traverse failures remain visible with stable status, reason, and trace evidence
+- UI code does not duplicate hidden retrieval, graph traversal, context packing, inference selection, validation, or formatting outside the documented temporary harness boundary
+
+### Out of Scope
+
+- removing Browser demo
+- changing Traverse runtime behavior
+- adding a hosted provider
+
+### Definition of Done
+
+- Unit or browser tests prove the default provider is Traverse local.
+- Tests prove that a Traverse failure does not switch the selected provider to Browser demo.
+- Tests prove Browser demo only runs after explicit provider selection.
+- The visible UI status distinguishes Traverse failure from Browser demo success.
+- The temporary harness documentation states the retirement condition.
+- Placeholder/fallback scans do not find undocumented fallback paths in PWA runtime code.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+npm test -- app/components/browser-runtime.test.ts
+
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-035: Add Traverse Blocker Escalation and Upstream Issue Template
+
+### Objective
+
+Create a disciplined feedback loop from youaskm3 to Traverse so app work drives Traverse evolution without adding downstream workarounds.
+
+When a youaskm3 MVP ticket proves that Traverse is missing a required public surface, the agent should create a traceable Traverse requirement instead of hiding the gap in youaskm3 code.
+
+### Scope
+
+Add a lightweight blocker/escalation process covering:
+
+- how to decide a gap belongs to Traverse rather than youaskm3
+- required evidence before opening a Traverse issue
+- required fields for the upstream issue
+- how to link the upstream Traverse issue from the youaskm3 ticket or PR
+- how to keep the youaskm3 ticket blocked instead of adding non-portable downstream logic
+
+Suggested files:
+
+- `docs/traverse-blocker-escalation.md`
+- `.github/ISSUE_TEMPLATE/traverse-blocker.yml` or a markdown template if YAML templates are not used
+- a short reference from `docs/youaskm3-ops.md`
+
+### Out of Scope
+
+- creating speculative Traverse issues without failing evidence
+- changing Traverse code
+- replacing the existing Traverse requirements document
+
+### Definition of Done
+
+- A documented decision checklist distinguishes youaskm3 bugs, Traverse blockers, and environment/setup failures.
+- The template captures affected capability, expected public surface, observed failure, validation command, logs excerpt, Traverse version/commit, and downstream impact.
+- The process requires a local/focused reproduction command or explains why one cannot exist.
+- The process requires linking the upstream issue from the blocked youaskm3 issue.
+- The ops docs tell future agents not to add downstream provider/runtime shortcuts when the blocker belongs upstream.
+- A docs/spec smoke or focused check validates any new issue-template YAML.
+- `bash scripts/smoke.sh` passes, or a docs-only focused validation is recorded with rationale.
+
+### Validation
+
+```bash
+ruby -e 'require "yaml"; Dir.glob(".github/ISSUE_TEMPLATE/*.yml").sort.each { |path| YAML.load_file(path) }'
+
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
 - Common failures are documented:
   - missing `cargo`
   - missing `wasm32-wasip1`
@@ -775,15 +1019,23 @@ These become most useful after fixture artifacts exist:
 - MVP-009 PWA chat interaction
 - MVP-012 product-level MVP acceptance test
 
+Next highest-ROI tranche after MVP-030:
+
+- MVP-031 local Traverse-backed chat happy path
+- MVP-032 real WASM artifacts and component digests
+- MVP-033 real imported-document question acceptance test
+- MVP-034 explicit Browser demo fallback semantics
+- MVP-035 Traverse blocker escalation template
+
 ## First Ticket to Start
 
 Recommended first implementation ticket:
 
-> MVP-002: Define MVP Capability Contracts
+> MVP-031: Prove the Local Traverse-Backed Chat Happy Path
 
 Reason:
 
-- It unblocks Traverse alignment.
-- It unblocks the harness.
-- It unblocks WASM capability implementation.
-- It forces the product shape to become explicit.
+- Traverse v0.4.0 readiness is already green.
+- It validates the user-facing product with real runtime pressure.
+- It exposes any remaining Traverse gaps through concrete evidence.
+- It keeps youaskm3 from drifting into downstream runtime shortcuts.

--- a/docs/mvp-ticket-backlog.md
+++ b/docs/mvp-ticket-backlog.md
@@ -16,8 +16,8 @@ The MVP target is:
 - Each ticket must be independently understandable.
 - Each ticket must include a clear definition of done.
 - Each ticket must keep `bash scripts/smoke.sh` green.
-- Runtime/product business logic must move toward Traverse-compatible contracts and WASM capability boundaries.
-- Temporary harnesses are allowed only when they mimic the future Traverse boundary and are clearly marked as replaceable.
+- MVP runtime/product business logic must run through Traverse as real WASM microservice capabilities or real WASM agent capabilities.
+- Temporary harnesses, Browser demo, skeleton manifests, contract stubs, placeholder digests, and fake workflow steps are developer aids only; they never count as MVP acceptance evidence.
 - The CLI may own mechanical build/setup tasks.
 - The PWA may own rendering and interaction only.
 
@@ -737,19 +737,23 @@ bash scripts/smoke.sh
 
 ### Objective
 
-Make the primary local demo path use Traverse for `knowledge.query.answer` instead of relying on the explicit browser demo fallback.
+Make the primary local demo path use real Traverse workflow composition for `knowledge.query.answer` instead of relying on the explicit browser demo fallback.
 
-This ticket validates the product-led integration loop: the PWA remains UI-only, product/business behavior runs behind Traverse-compatible runtime boundaries, and missing local services fail visibly instead of silently falling back.
+This ticket validates the product-led integration loop: the PWA remains UI-only, product/business behavior runs as real Traverse-governed WASM microservices or WASM agents, and missing runtime capability fails visibly instead of silently falling back.
 
 ### Scope
 
 Add or update the smallest set of scripts, docs, fixtures, and tests needed to prove:
 
 - a local Traverse HTTP/JSON runtime can be started or targeted for the youaskm3 app workflow
+- `knowledge.query.answer` is a Traverse workflow composed from separate real capabilities
+- deterministic steps run as real WASM microservice capabilities
+- judgement, generation, planning, semantic interpretation, or model-use steps run as real WASM agent capabilities
 - the PWA provider configuration points to that runtime as the default local provider
 - a local question reaches `knowledge.query.answer` through the Traverse app-facing boundary
 - the response includes answer text, citations or source references, graph evidence, validation status, and a trace reference
 - unavailable Traverse runtime returns a stable visible failure such as `TRAVERSE_UNAVAILABLE`
+- any missing Traverse support is captured as a detailed Traverse requirement and the ticket is marked blocked rather than completed with placeholders
 
 ### Out of Scope
 
@@ -758,17 +762,22 @@ Add or update the smallest set of scripts, docs, fixtures, and tests needed to p
 - adding new model providers in downstream UI or CLI code
 - changing Traverse internals except by creating a separate upstream Traverse issue for a confirmed blocker
 - removing the explicit browser demo fallback
+- accepting Browser demo, temporary harnesses, contract stubs, fake workflow steps, skeleton manifests, or placeholder digests as completion evidence
 
 ### Definition of Done
 
 - A documented command starts or targets the local Traverse-backed youaskm3 answer path.
 - A focused smoke test verifies a successful Traverse-backed answer when the local Traverse runtime is available.
+- The smoke test proves `knowledge.query.answer` executes as a Traverse-composed workflow, not as a monolithic fake capability.
+- Each workflow step is backed by a real registered WASM microservice or real registered WASM agent capability.
+- `knowledge.infer` is backed by a real WASM agent capability when generation, judgement, planning, semantic interpretation, or model use is required.
 - The smoke test verifies that source citations or source references are non-empty.
 - The smoke test verifies that graph evidence is non-empty.
 - The smoke test verifies that the response includes validation status and a trace reference.
 - The smoke test verifies that missing Traverse runtime fails with a stable user-visible error and does not auto-fallback to Browser demo.
 - The PWA default local provider remains Traverse-backed.
 - Browser demo remains available only as an explicit user-selected fallback.
+- Browser demo, temporary harnesses, skeleton manifests, contract stubs, fake workflow steps, and placeholder digests do not satisfy this ticket.
 - `docs/mvp-user-stories.md` demo acceptance path references the local Traverse-backed happy path.
 - `bash scripts/smoke.sh` passes without requiring a live Traverse runtime.
 - A separate live validation command is documented for machines that have Traverse available.
@@ -791,16 +800,16 @@ bash scripts/traverse-answer-workflow-smoke.sh
 
 ### Objective
 
-Move the checked-in Traverse app bundle from skeleton confidence toward real registration evidence by building the MVP WASM capability artifacts and generating real component digests wherever capability crates already exist.
+Move the checked-in Traverse app bundle from skeleton confidence to real registration evidence by building every MVP runtime capability artifact and generating real component digests.
 
 ### Scope
 
-Update the bundle generation path so implemented capabilities can produce real `.wasm` artifacts and real SHA-256 digests in:
+Update the bundle generation path so every MVP runtime capability can produce real WASM artifacts or real WASM agent artifacts and real SHA-256 digests in:
 
 - `traverse/youaskm3-app/manifest.json`
 - `traverse/youaskm3-app/components/*/component.manifest.json`
 
-The first pass should cover all capability crates currently implemented in the workspace and leave only genuinely unimplemented capabilities marked as pending.
+The MVP acceptance pass must cover every runtime capability required by `knowledge.query.answer`; no required capability may remain pending, skeleton-only, or all-zero-digest.
 
 ### Out of Scope
 
@@ -808,16 +817,17 @@ The first pass should cover all capability crates currently implemented in the w
 - inference model quality
 - hosted artifact publishing
 - changing Traverse manifest fields without a confirmed Traverse requirement
+- accepting partial bundle evidence for MVP runtime completion
 
 ### Definition of Done
 
-- A documented command builds implemented capability crates for `wasm32-wasip1`.
-- `scripts/traverse-component-manifests.sh` or the equivalent generator can run without `--skeleton` for implemented capabilities.
-- Implemented component manifests contain real `wasm_digest` values, not all-zero placeholder digests.
-- App manifest component entries contain real digests for implemented capabilities.
-- Pending markers remain only for capabilities that truly have no buildable WASM artifact yet.
-- Registration validation distinguishes between "pending unimplemented capability" and "implemented artifact failed validation."
-- Smoke or a focused script fails if an implemented capability keeps a placeholder digest.
+- A documented command builds all MVP runtime capability crates or WASM agent artifacts for `wasm32-wasip1`.
+- `scripts/traverse-component-manifests.sh` or the equivalent generator runs without `--skeleton` for the MVP runtime bundle.
+- Every MVP runtime component manifest contains a real `wasm_digest`, not an all-zero placeholder digest.
+- App manifest component entries contain real digests for every MVP runtime capability.
+- Pending markers, skeleton status, all-zero digests, and placeholder validation evidence fail MVP runtime acceptance.
+- Registration validation distinguishes environment/setup failure from real invalid bundle evidence.
+- Smoke or a focused script fails if any required MVP runtime capability keeps placeholder evidence.
 - `cargo build --locked --workspace --target wasm32-wasip1` passes.
 - `bash scripts/smoke.sh` passes.
 
@@ -838,7 +848,7 @@ bash scripts/smoke.sh
 
 ### Objective
 
-Prove the first MVP against a realistic local user flow: import or normalize a source document, build artifacts, ask one question, and verify answer evidence.
+Prove the first MVP against a realistic local user flow: import or normalize a source document, build artifacts, ask one question through the real Traverse-composed workflow, and verify answer evidence.
 
 ### Scope
 
@@ -848,7 +858,7 @@ Create an acceptance smoke that uses repo-safe fixture content and exercises:
 - artifact sync/build
 - search index generation
 - graph artifact availability
-- runtime answer request through the configured local path
+- runtime answer request through the real Traverse-composed local path
 - answer text with source-backed citations
 - graph evidence
 - validation status
@@ -859,16 +869,19 @@ Create an acceptance smoke that uses repo-safe fixture content and exercises:
 - large copyrighted documents
 - benchmark-quality retrieval scoring
 - mandatory live local LLM availability in default CI
+- accepting Browser demo, temporary harnesses, contract stubs, fake workflow steps, skeleton manifests, or placeholder digests as completion evidence
 
 ### Definition of Done
 
 - The test starts from fixture input that represents an imported document, not only a prebuilt `app/site/search-index.json`.
 - The test rebuilds or refreshes the relevant markdown/search/graph artifacts.
 - The test asks a concrete user question with an expected source-backed answer path.
+- The answer path uses the real Traverse-composed `knowledge.query.answer` workflow.
+- Every runtime business step is a real WASM microservice or real WASM agent capability.
 - The test asserts at least one cited source or source reference from the imported fixture.
 - The test asserts at least one graph node or edge from the imported fixture.
 - The test asserts a validation status and trace reference.
-- The default smoke path can run without a live local LLM by using the existing governed fallback/test harness rules.
+- If model-backed inference is required, it runs through a real Traverse-governed WASM agent capability or fails with governed missing-dependency evidence.
 - A live Traverse variant is documented when a local Traverse checkout/runtime is available.
 - `bash scripts/smoke.sh` passes.
 
@@ -889,7 +902,7 @@ bash scripts/traverse-readiness.sh
 
 Prevent regressions where the PWA silently falls back to browser-side product/business behavior when Traverse is unavailable.
 
-The Browser demo is useful for local no-server inspection, but it must remain an explicit provider choice and must not become a hidden alternate runtime.
+The Browser demo is useful for local no-server inspection, but it must remain an explicit developer-only provider choice and must not become a hidden alternate runtime or MVP acceptance path.
 
 ### Scope
 
@@ -899,7 +912,7 @@ Add tests and documentation that enforce:
 - Browser demo is visible and selectable
 - Browser demo is not selected automatically after a Traverse failure
 - Traverse failures remain visible with stable status, reason, and trace evidence
-- UI code does not duplicate hidden retrieval, graph traversal, context packing, inference selection, validation, or formatting outside the documented temporary harness boundary
+- UI code does not duplicate hidden retrieval, graph traversal, context packing, inference selection, validation, or formatting outside the explicit Browser demo developer aid
 
 ### Out of Scope
 
@@ -913,7 +926,8 @@ Add tests and documentation that enforce:
 - Tests prove that a Traverse failure does not switch the selected provider to Browser demo.
 - Tests prove Browser demo only runs after explicit provider selection.
 - The visible UI status distinguishes Traverse failure from Browser demo success.
-- The temporary harness documentation states the retirement condition.
+- Browser demo output is clearly marked as developer/demo evidence and not MVP runtime acceptance evidence.
+- The temporary harness documentation states the retirement condition and says it cannot satisfy MVP runtime tickets.
 - Placeholder/fallback scans do not find undocumented fallback paths in PWA runtime code.
 - `bash scripts/smoke.sh` passes.
 

--- a/docs/mvp-user-stories.md
+++ b/docs/mvp-user-stories.md
@@ -2,7 +2,7 @@
 
 Status: First-MVP acceptance guide
 Owner: youaskm3 product/spec alignment
-Last updated: 2026-06-22
+Last updated: 2026-06-25
 
 ## Purpose
 
@@ -46,6 +46,9 @@ Capability and ticket map:
 - MVP-019 PWA chat adapter to Traverse HTTP/JSON
 - MVP-026 `knowledge.query.answer` workflow entry point
 - MVP-028 end-to-end Traverse answer workflow smoke
+- MVP-031 local Traverse-backed chat happy path
+- MVP-033 real imported-document question acceptance test
+- MVP-034 explicit Browser demo fallback semantics
 
 Acceptance criteria:
 
@@ -54,6 +57,7 @@ Acceptance criteria:
 - THEN the UI receives a structured answer through the Traverse boundary
 - AND the answer includes citations or source references from local artifacts
 - AND the UI does not run hidden retrieval, ranking, context packing, inference selection, validation, or formatting logic
+- AND Browser demo is used only when explicitly selected as a fallback provider
 
 ### Fork-And-Run Developer
 
@@ -68,6 +72,7 @@ Capability and ticket map:
 - MVP-010 Traverse application bundle skeleton
 - MVP-011 Traverse readiness check
 - MVP-027 component manifests and binary digests
+- MVP-032 real WASM artifacts and component digests
 
 Acceptance criteria:
 
@@ -76,6 +81,7 @@ Acceptance criteria:
 - THEN the repo reports pass/fail status with actionable setup messages
 - AND normal smoke does not require Traverse to be installed
 - AND Traverse-specific validation is available when a local Traverse checkout is configured
+- AND implemented capability manifests use real WASM digests rather than skeleton placeholders where artifacts exist
 
 ### Source-Grounded Researcher
 
@@ -93,6 +99,7 @@ Capability and ticket map:
 - MVP-023 `knowledge.graph.expand`
 - MVP-024 `knowledge.context.pack`
 - MVP-025 `knowledge.answer.format`
+- MVP-033 real imported-document question acceptance test
 
 Acceptance criteria:
 
@@ -101,6 +108,7 @@ Acceptance criteria:
 - THEN source ids, source paths, chunk ids, and graph/context evidence are available in the response or trace
 - AND unsupported answer claims fail validation or are marked as failures
 - AND the same grounding evidence can be inspected through the PWA and MCP-facing paths when those paths are enabled
+- AND at least one acceptance test starts from an imported or normalized fixture document rather than only prebuilt static artifacts
 
 ### Privacy-Conscious Professional
 
@@ -113,6 +121,7 @@ Capability and ticket map:
 - `scripts/traverse-readiness.sh`
 - MVP-021 local inference readiness policy
 - MVP-030 `knowledge.infer` dependency failure and evidence tests
+- MVP-034 explicit Browser demo fallback semantics
 
 Acceptance criteria:
 
@@ -121,6 +130,7 @@ Acceptance criteria:
 - THEN selected and rejected model candidates are visible as governed evidence
 - AND no downstream UI or CLI code hardcodes Ollama, WebLLM, llama.cpp, cloud APIs, or a fallback provider
 - AND missing local inference capability fails clearly before or during governed execution
+- AND Traverse runtime failures remain visible instead of automatically switching to Browser demo
 
 ### MCP And Agent User
 
@@ -136,6 +146,7 @@ Capability and ticket map:
 - `knowledge.answer.format`
 - MVP-020 Traverse MCP parity smoke
 - MVP-028 end-to-end Traverse answer workflow smoke
+- MVP-031 local Traverse-backed chat happy path
 
 Acceptance criteria:
 
@@ -143,6 +154,7 @@ Acceptance criteria:
 - WHEN an MCP client discovers or invokes the answer workflow
 - THEN the capability contracts and execution evidence match the app-facing workflow
 - AND MCP does not use a separate implementation path for retrieval, graph context, validation, or formatting
+- AND the app-facing and MCP-facing paths expose equivalent grounding and trace evidence for the same workflow
 
 ### Product Maintainer Validating Traverse Integration
 
@@ -157,6 +169,7 @@ Capability and ticket map:
 - MVP-018 bundle registration
 - MVP-020 MCP parity smoke
 - MVP-028 end-to-end Traverse answer workflow smoke
+- MVP-035 Traverse blocker escalation template
 
 Acceptance criteria:
 
@@ -165,6 +178,7 @@ Acceptance criteria:
 - THEN runtime claims cite a spec, contract, manifest, ticket, or validation script
 - AND readiness commands summarize pass/fail by capability area instead of requiring large log inspection
 - AND remaining gaps are represented as backlog tickets rather than undocumented assumptions
+- AND confirmed missing Traverse public surfaces are escalated upstream with reproduction evidence instead of hidden in downstream workaround code
 
 ## Demo Acceptance Path
 
@@ -173,10 +187,11 @@ The first MVP demo is acceptable when these steps pass from a clean local setup:
 1. Prepare or refresh markdown, search, and graph artifacts from local knowledge files.
 2. Validate normal repo health with `bash scripts/smoke.sh`.
 3. Validate Traverse pairing with `bash scripts/traverse-readiness.sh` when a local Traverse checkout is available.
-4. Generate or check component manifests with `bash scripts/traverse-component-manifests.sh --skeleton --check` until real WASM binaries exist, then without `--skeleton`.
+4. Generate or check component manifests with real WASM digests for implemented capabilities; use skeleton mode only for capabilities that genuinely do not have artifacts yet.
 5. Register the youaskm3 app bundle through Traverse public APIs.
 6. Ask one question through the PWA.
 7. Inspect answer text, citations, graph/source evidence, selected inference dependency, and trace.
 8. Exercise the same answer workflow through MCP parity validation.
+9. Explicitly select Browser demo only when validating the documented no-server fallback path.
 
 The demo must not require a hosted account, hosted database, paid external model service, or product/business logic outside Traverse-governed capabilities.

--- a/docs/mvp-user-stories.md
+++ b/docs/mvp-user-stories.md
@@ -8,7 +8,9 @@ Last updated: 2026-06-25
 
 This document names the first-MVP personas and user-facing stories that guide specs, tickets, tests, and demos.
 
-The first MVP is a local-first PWA chat experience over user-owned knowledge artifacts. The CLI prepares markdown, search, graph, and bundle artifacts. Traverse executes product/business behavior as governed portable WASM capabilities or agents. The UI renders the experience and must not contain alternate retrieval, graph traversal, context packing, inference selection, answer validation, or answer formatting logic.
+The first MVP is a local-first PWA chat experience over user-owned knowledge artifacts. The CLI prepares markdown, search, graph, and bundle artifacts. Traverse executes product/business behavior as governed portable WASM microservice capabilities or WASM agent capabilities. The UI renders the experience and must not contain alternate retrieval, graph traversal, context packing, inference selection, answer validation, or answer formatting logic.
+
+MVP runtime acceptance requires the real implementation. Browser demo, temporary harnesses, contract stubs, fake workflow steps, skeleton manifests, placeholder digests, and all-zero component evidence are developer aids only and do not count as acceptance evidence.
 
 ## MVP Boundary
 
@@ -58,6 +60,7 @@ Acceptance criteria:
 - AND the answer includes citations or source references from local artifacts
 - AND the UI does not run hidden retrieval, ranking, context packing, inference selection, validation, or formatting logic
 - AND Browser demo is used only when explicitly selected as a fallback provider
+- AND Browser demo output does not count as MVP runtime acceptance evidence
 
 ### Fork-And-Run Developer
 
@@ -81,7 +84,8 @@ Acceptance criteria:
 - THEN the repo reports pass/fail status with actionable setup messages
 - AND normal smoke does not require Traverse to be installed
 - AND Traverse-specific validation is available when a local Traverse checkout is configured
-- AND implemented capability manifests use real WASM digests rather than skeleton placeholders where artifacts exist
+- AND MVP runtime capability manifests use real WASM or WASM agent digests rather than skeleton placeholders
+- AND pending markers or all-zero digests block MVP runtime acceptance
 
 ### Source-Grounded Researcher
 
@@ -131,6 +135,7 @@ Acceptance criteria:
 - AND no downstream UI or CLI code hardcodes Ollama, WebLLM, llama.cpp, cloud APIs, or a fallback provider
 - AND missing local inference capability fails clearly before or during governed execution
 - AND Traverse runtime failures remain visible instead of automatically switching to Browser demo
+- AND generation, judgement, planning, semantic interpretation, or model-use behavior is handled by a real Traverse-governed WASM agent capability
 
 ### MCP And Agent User
 
@@ -187,11 +192,12 @@ The first MVP demo is acceptable when these steps pass from a clean local setup:
 1. Prepare or refresh markdown, search, and graph artifacts from local knowledge files.
 2. Validate normal repo health with `bash scripts/smoke.sh`.
 3. Validate Traverse pairing with `bash scripts/traverse-readiness.sh` when a local Traverse checkout is available.
-4. Generate or check component manifests with real WASM digests for implemented capabilities; use skeleton mode only for capabilities that genuinely do not have artifacts yet.
+4. Generate or check component manifests with real WASM or WASM agent digests for every MVP runtime capability; skeleton mode is not acceptable for MVP runtime acceptance.
 5. Register the youaskm3 app bundle through Traverse public APIs.
 6. Ask one question through the PWA.
 7. Inspect answer text, citations, graph/source evidence, selected inference dependency, and trace.
 8. Exercise the same answer workflow through MCP parity validation.
 9. Explicitly select Browser demo only when validating the documented no-server fallback path.
+10. Treat any missing real Traverse workflow/capability support as a blocked youaskm3 ticket plus an upstream Traverse requirement, not as permission to add placeholders.
 
 The demo must not require a hosted account, hosted database, paid external model service, or product/business logic outside Traverse-governed capabilities.

--- a/openspec/specs/pwa-shell/spec.md
+++ b/openspec/specs/pwa-shell/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The pwa-shell capability defines the installable, offline-capable browser shell that hosts the user-facing chat experience, presents sources and graph evidence, and delegates product/business behavior to Traverse-run WASM capabilities.
+The pwa-shell capability defines the installable, offline-capable browser shell that hosts the user-facing chat experience, presents sources and graph evidence, and delegates product/business behavior to Traverse-run WASM microservice and WASM agent capabilities.
 
 ## Requirements
 
@@ -28,13 +28,14 @@ The system SHALL reserve UI surfaces for chat responses and source attribution s
 
 ### Requirement: Keep the PWA as a UI-only application
 
-The system SHALL keep retrieval ranking, graph traversal, context packing, inference selection, answer validation, and answer formatting outside the PWA and behind Traverse-compatible capability contracts.
+The system SHALL keep retrieval ranking, graph traversal, context packing, inference selection, answer validation, and answer formatting outside the PWA and behind real Traverse-run WASM microservice or WASM agent capability contracts.
 
 #### Scenario: Submit a chat prompt
 
 - GIVEN a user enters a prompt in the PWA
 - WHEN the PWA starts the answer workflow
-- THEN it sends the request to the configured Traverse app-facing endpoint or compatible local harness instead of computing the answer in browser UI code
+- THEN it sends the request to the configured Traverse app-facing endpoint instead of computing the answer in browser UI code
+- AND MVP acceptance does not rely on Browser demo, temporary harnesses, contract stubs, or placeholder runtime responses
 
 #### Scenario: Keep Browser demo as an explicit fallback
 
@@ -44,6 +45,7 @@ The system SHALL keep retrieval ranking, graph traversal, context packing, infer
 - THEN the failure remains visible to the user
 - AND the PWA does not automatically switch to Browser demo
 - AND Browser demo runs only after the user explicitly selects it as the provider
+- AND Browser demo output is marked as developer/demo evidence, not MVP runtime acceptance evidence
 
 ### Requirement: Render graph and trace evidence
 

--- a/openspec/specs/pwa-shell/spec.md
+++ b/openspec/specs/pwa-shell/spec.md
@@ -36,6 +36,15 @@ The system SHALL keep retrieval ranking, graph traversal, context packing, infer
 - WHEN the PWA starts the answer workflow
 - THEN it sends the request to the configured Traverse app-facing endpoint or compatible local harness instead of computing the answer in browser UI code
 
+#### Scenario: Keep Browser demo as an explicit fallback
+
+- GIVEN Traverse local is the selected runtime provider
+- AND Traverse returns an unavailable or execution failure
+- WHEN the PWA renders the result
+- THEN the failure remains visible to the user
+- AND the PWA does not automatically switch to Browser demo
+- AND Browser demo runs only after the user explicitly selects it as the provider
+
 ### Requirement: Render graph and trace evidence
 
 The system SHALL provide UI surfaces for graph evidence and execution trace status returned by the runtime.
@@ -45,3 +54,16 @@ The system SHALL provide UI surfaces for graph evidence and execution trace stat
 - GIVEN a completed answer includes graph evidence and a trace reference
 - WHEN the user opens the evidence view
 - THEN the PWA can render cited sources, graph nodes or edges, and runtime status without needing private runtime internals
+
+### Requirement: Demonstrate a real imported-document question path
+
+The system SHALL support an acceptance path where a repo-safe fixture document is converted or normalized, included in generated artifacts, queried through the chat surface, and rendered with evidence.
+
+#### Scenario: Ask about an imported fixture document
+
+- GIVEN a fixture source document has been converted or normalized into markdown
+- AND search and graph artifacts have been refreshed
+- WHEN the user asks a question whose answer is supported by that fixture
+- THEN the PWA renders answer text with at least one source reference
+- AND the PWA renders graph or context evidence from the generated artifacts
+- AND the response includes validation status and trace evidence

--- a/openspec/specs/traverse-integration/spec.md
+++ b/openspec/specs/traverse-integration/spec.md
@@ -26,6 +26,22 @@ The system SHALL execute the first user-facing chat workflow through Traverse or
 - WHEN the runtime workflow starts
 - THEN the workflow composes retrieval, graph expansion, context packing, inference, validation, and formatting capabilities behind the Traverse boundary
 
+#### Scenario: Prove the local Traverse-backed happy path
+
+- GIVEN a local Traverse runtime is available for the youaskm3 app bundle
+- WHEN the PWA sends a `knowledge.query.answer` request through the configured Traverse HTTP/JSON endpoint
+- THEN the response includes answer text, source evidence, graph evidence, validation status, and a trace reference
+- AND the PWA does not execute hidden product/business logic outside the Traverse boundary
+
+#### Scenario: Report unavailable Traverse without hidden fallback
+
+- GIVEN Traverse local is selected as the runtime provider
+- AND the configured Traverse endpoint is unavailable
+- WHEN the user asks a question
+- THEN the UI reports a stable Traverse runtime failure
+- AND the selected provider remains Traverse local
+- AND Browser demo execution does not run unless the user explicitly selects it
+
 ### Requirement: Delegate inference selection and placement
 
 The system SHALL declare inference needs by contract and allow Traverse to choose a compatible local or server-side implementation based on availability, constraints, and placement policy.
@@ -45,3 +61,26 @@ The system SHALL expose enough trace evidence for the UI, MCP clients, and audit
 - GIVEN an answer workflow completed or failed validation
 - WHEN a client fetches the public trace reference
 - THEN the trace includes executed capability ids, versions, placement, source artifacts, graph evidence, inference dependency, validation outcome, and failure reasons where applicable
+
+### Requirement: Generate real component evidence for implemented WASM capabilities
+
+The system SHALL generate real WASM artifacts and component manifest digests for implemented youaskm3 capabilities instead of treating implemented capabilities as skeleton placeholders.
+
+#### Scenario: Build implemented capability artifacts
+
+- GIVEN one or more MVP capability crates build for `wasm32-wasip1`
+- WHEN the Traverse bundle manifest generator runs without skeleton mode
+- THEN implemented components reference real `.wasm` artifacts
+- AND implemented component manifests include real SHA-256 digests
+- AND placeholder digests remain only for capabilities that have no implemented artifact yet
+
+### Requirement: Escalate confirmed Traverse blockers upstream
+
+The system SHALL capture confirmed missing Traverse public surfaces as upstream Traverse requirements instead of adding downstream runtime shortcuts.
+
+#### Scenario: Open a Traverse blocker from youaskm3 evidence
+
+- GIVEN a youaskm3 ticket cannot satisfy its DoD through existing Traverse public surfaces
+- WHEN a focused validation command demonstrates the blocker
+- THEN the blocked youaskm3 issue links to a Traverse requirement or issue with affected capability, expected public surface, observed failure, Traverse version, and reproduction evidence
+- AND youaskm3 does not add non-portable downstream provider, placement, or runtime logic to hide the blocker

--- a/openspec/specs/traverse-integration/spec.md
+++ b/openspec/specs/traverse-integration/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The traverse-integration capability defines how youaskm3 hands product/business execution to Traverse while keeping the PWA as a UI-only application and the CLI as an artifact builder and bundle registrar.
+The traverse-integration capability defines how youaskm3 hands product/business execution to Traverse while keeping the PWA as a UI-only application and the CLI as an artifact builder and bundle registrar. MVP runtime acceptance requires real WASM microservice capabilities for deterministic business logic and real WASM agent capabilities for judgement, generation, planning, or model-use behavior.
 
 ## Requirements
 
@@ -16,15 +16,16 @@ The system SHALL register the youaskm3 application bundle through documented Tra
 - WHEN it registers the application with Traverse
 - THEN Traverse returns machine-readable bundle ids, versions, digests, and validation status without relying on private Traverse internals
 
-### Requirement: Execute the chat workflow through Traverse
+### Requirement: Execute the chat workflow through real Traverse capabilities
 
-The system SHALL execute the first user-facing chat workflow through Traverse or a temporary harness that exactly mirrors the Traverse request and response contract.
+The system SHALL execute the first user-facing chat workflow through Traverse using real registered WASM microservice capabilities or real WASM agent capabilities. Temporary harnesses, contract stubs, fake workflow steps, placeholder component manifests, and Browser demo paths SHALL NOT satisfy MVP runtime acceptance.
 
 #### Scenario: Answer a user prompt
 
 - GIVEN a user submits a prompt in the PWA
 - WHEN the runtime workflow starts
 - THEN the workflow composes retrieval, graph expansion, context packing, inference, validation, and formatting capabilities behind the Traverse boundary
+- AND each product/business step is a real registered WASM microservice or WASM agent capability
 
 #### Scenario: Prove the local Traverse-backed happy path
 
@@ -64,15 +65,27 @@ The system SHALL expose enough trace evidence for the UI, MCP clients, and audit
 
 ### Requirement: Generate real component evidence for implemented WASM capabilities
 
-The system SHALL generate real WASM artifacts and component manifest digests for implemented youaskm3 capabilities instead of treating implemented capabilities as skeleton placeholders.
+The system SHALL generate real WASM artifacts and component manifest digests for every MVP capability before that capability can satisfy runtime acceptance.
 
 #### Scenario: Build implemented capability artifacts
 
-- GIVEN one or more MVP capability crates build for `wasm32-wasip1`
+- GIVEN the MVP capability crates build for `wasm32-wasip1`
 - WHEN the Traverse bundle manifest generator runs without skeleton mode
-- THEN implemented components reference real `.wasm` artifacts
-- AND implemented component manifests include real SHA-256 digests
-- AND placeholder digests remain only for capabilities that have no implemented artifact yet
+- THEN each MVP component references a real `.wasm` artifact or a real WASM agent artifact
+- AND each MVP component manifest includes a real SHA-256 digest
+- AND placeholder digests, skeleton status, and pending implementation markers fail MVP acceptance
+
+### Requirement: Treat inference as a real WASM agent capability
+
+The system SHALL implement `knowledge.infer` as a real Traverse-governed WASM agent capability when the workflow needs judgement, generation, planning, semantic interpretation, or model use.
+
+#### Scenario: Execute inference through a governed agent
+
+- GIVEN the answer workflow needs to generate an answer from packed context
+- WHEN Traverse executes `knowledge.infer`
+- THEN Traverse invokes a real registered WASM agent capability
+- AND model dependency selection, placement, success, or failure is captured in governed trace evidence
+- AND deterministic microservice logic is not used as a fake replacement for the agent behavior
 
 ### Requirement: Escalate confirmed Traverse blockers upstream
 


### PR DESCRIPTION
## Summary
- Adds MVP-031 through MVP-035 to the backlog with scope, out-of-scope items, full Definition of Done, and validation commands.
- Updates OpenSpec Traverse/PWA requirements for real Traverse workflow composition, real WASM microservice capabilities, real WASM agent capabilities, real component digest evidence, explicit Browser demo fallback semantics, imported-document acceptance, and Traverse blocker escalation.
- Updates first-MVP user stories and top-level SPEC references so future work stays product-led while feeding concrete Traverse requirements upstream.

## Brainstorming-Approved Runtime Rule
- MVP runtime acceptance requires the real implementation only.
- Deterministic product/business logic runs as real Rust/WASM microservice capabilities through Traverse.
- Judgement, generation, planning, semantic interpretation, or model-use behavior runs as real WASM agent capabilities through Traverse.
- Browser demo, temporary harnesses, contract stubs, fake workflow steps, skeleton manifests, placeholder digests, and all-zero component evidence do not count as MVP acceptance evidence.
- If Traverse cannot run the required real workflow, the youaskm3 ticket is blocked and linked to a detailed Traverse requirement instead of adding downstream workaround logic.

## Spec Reference
- openspec/specs/traverse-integration/spec.md - real Traverse workflow composition, WASM microservice/agent execution, component artifact evidence, Traverse blocker escalation
- openspec/specs/pwa-shell/spec.md - explicit Browser demo fallback and imported-document acceptance

## Tickets Created
- #120 MVP-031: Prove the Local Traverse-Backed Chat Happy Path
- #121 MVP-032: Wire Real WASM Artifacts Into the Traverse Bundle
- #122 MVP-033: Add a Real Imported-Document Question Acceptance Test
- #123 MVP-034: Enforce Explicit Browser Demo Fallback Semantics
- #124 MVP-035: Add Traverse Blocker Escalation and Upstream Issue Template

All five tickets are open, labeled `status:ready`, set to Ready in Project 3, and updated with the approved real-implementation-only DoD.

## Validation
- `PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`
- Result: passed; frontend 5 files / 40 tests passed; OpenSpec validation passed.