### PR TITLE
MVP-034: Enforce explicit Browser demo fallback semantics

### DIFF
--- a/app/components/browser-runtime.test.ts
+++ b/app/components/browser-runtime.test.ts
@@ -484,6 +484,27 @@ describe("Traverse HTTP answer adapter", () => {
     ]);
   });
 
+  it("keeps the temporary harness out of the Traverse HTTP adapter", () => {
+    const runtimeSource = readFileSync(
+      path.resolve(process.cwd(), "app", "components", "browser-runtime.ts"),
+      "utf8"
+    );
+    const httpAdapter = sourceSection(
+      runtimeSource,
+      "export async function executeTraverseAnswerHttp",
+      "export function browserArtifactState"
+    );
+    const browserToolAdapter = sourceSection(
+      runtimeSource,
+      "export function callBrowserTool",
+      "export function documentsFromSearchIndex"
+    );
+
+    expect(httpAdapter).toContain("mapTraverseAnswerFailure");
+    expect(httpAdapter).not.toContain("temporaryTraverseChatHarness");
+    expect(browserToolAdapter.match(/temporaryTraverseChatHarness/gu)).toHaveLength(1);
+  });
+
   it("reports missing Traverse endpoint configuration separately", async () => {
     const output = await executeTraverseAnswerHttp(
       { query: "portable" },
@@ -497,6 +518,16 @@ describe("Traverse HTTP answer adapter", () => {
     });
   });
 });
+
+function sourceSection(source: string, startMarker: string, endMarker: string): string {
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker);
+
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+
+  return source.slice(start, end);
+}
 
 describe("browserArtifactState", () => {
   it("loads generated search-index documents", () => {

--- a/docs/temporary-traverse-chat-harness.md
+++ b/docs/temporary-traverse-chat-harness.md
@@ -24,3 +24,9 @@ graph expansion, context packing, inference selection, answer validation, and
 answer formatting remain Traverse-run capability responsibilities. Configured
 Traverse failures must be surfaced as runtime errors; the PWA must not silently
 fall back to this harness when Traverse mode is selected.
+
+Retire this harness for MVP runtime acceptance once the local Traverse
+`knowledge.query.answer` workflow can register and execute with real WASM
+microservice or WASM agent components, source citations, graph evidence,
+validation status, and a public trace reference. Until then, harness output is
+developer/demo evidence only and cannot satisfy MVP runtime tickets.


### PR DESCRIPTION
## What this changes
Adds a regression test that scans the PWA runtime adapter and proves the temporary browser harness is not reachable from the Traverse HTTP answer path. The harness remains available only through the explicit browser tool adapter. Also documents the retirement condition and states that harness output is developer/demo evidence only.

## Spec reference
- `openspec/specs/pwa-shell/spec.md` - Keep Browser demo as an explicit fallback
- `openspec/specs/traverse-integration/spec.md` - Report unavailable Traverse without hidden fallback
- `docs/mvp-ticket-backlog.md` - MVP-034 / #123

## Test coverage
- Added `browser-runtime.test.ts` coverage for the no-hidden-harness path in `executeTraverseAnswerHttp`.
- Existing tests continue to prove Traverse failures map to `TRAVERSE_UNAVAILABLE` without provider switching.

## Lean ops / minimality
- Kept the Browser demo harness intact.
- Added one source-level regression scan and one documentation update; no runtime/provider behavior was broadened.

## Validation
- `npm test -- app/components/browser-runtime.test.ts` - passed; 26 tests
- `PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh` - passed; frontend 5 files / 41 tests, full smoke green

Closes #123

## Breaking changes
None.
