### PR TITLE
MVP-035: Add Traverse blocker escalation process

### DIFF
--- a/.codex/skills/youaskm3-ops/SKILL.md
+++ b/.codex/skills/youaskm3-ops/SKILL.md
@@ -56,6 +56,12 @@ Between tickets, keep the transition lean: sync `main`, verify clean status, ins
 - **Spec/contracts gardener:** align `README.md`, `SPEC.md`, `openspec/specs/`, `contracts/`, and smoke validation with the approved MVP direction.
 - **Traverse dependency checker:** verify whether blocked youaskm3 tickets depend on Traverse runtime requirements in `docs/traverse-mvp-requirements.md`.
 
+When focused evidence shows a missing Traverse public surface, follow
+`docs/traverse-blocker-escalation.md`: keep the youaskm3 issue Blocked, link an
+upstream Traverse requirement or issue, and do not add downstream provider or
+runtime shortcuts, Browser demo acceptance, placeholders, stubs, or fake
+workflow steps.
+
 ## Project Guardrails
 
 - Do not mark work `In Progress` unless a real dev thread has started it.

--- a/.github/ISSUE_TEMPLATE/traverse-blocker.yml
+++ b/.github/ISSUE_TEMPLATE/traverse-blocker.yml
@@ -1,0 +1,86 @@
+name: Traverse blocker
+description: Escalate a confirmed missing Traverse public surface from youaskm3 evidence.
+title: "traverse blocker: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the missing Traverse surface or behavior and why it blocks youaskm3.
+    validations:
+      required: true
+  - type: input
+    id: downstream_issue
+    attributes:
+      label: Blocked youaskm3 issue or PR
+      description: Link the downstream issue or PR that cannot satisfy its DoD.
+      placeholder: https://github.com/enricopiovesan/youaskm3/issues/120
+    validations:
+      required: true
+  - type: input
+    id: affected_surface
+    attributes:
+      label: Affected capability or public surface
+      description: Name the capability, workflow, API, CLI, MCP path, or trace surface.
+      placeholder: knowledge.query.answer app registration through Traverse HTTP/JSON
+    validations:
+      required: true
+  - type: textarea
+    id: expected_surface
+    attributes:
+      label: Expected Traverse behavior
+      description: State the public surface or governed runtime behavior youaskm3 needs.
+    validations:
+      required: true
+  - type: textarea
+    id: observed_failure
+    attributes:
+      label: Observed failure
+      description: Include the stable failure code and a short actionable error excerpt.
+      placeholder: MISSING_PUBLIC_APP_REGISTRATION_SURFACE - no public external app-register CLI for this manifest shape.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Focused reproduction command
+      description: Provide the smallest local command that demonstrates the blocker, or explain why no focused command exists.
+      placeholder: TRAVERSE_REPO=/path/to/Traverse bash scripts/register-traverse-app.sh --json
+    validations:
+      required: true
+  - type: input
+    id: traverse_version
+    attributes:
+      label: Traverse version or commit
+      description: Include the release tag, describe output, or commit used for the reproduction.
+      placeholder: v0.4.0-5-g755da626860a
+    validations:
+      required: true
+  - type: input
+    id: youaskm3_version
+    attributes:
+      label: youaskm3 branch or commit
+      description: Include the downstream branch or commit used for the reproduction.
+      placeholder: main @ a6ea7be
+    validations:
+      required: true
+  - type: textarea
+    id: downstream_impact
+    attributes:
+      label: Downstream impact
+      description: Explain which youaskm3 DoD item remains blocked and why downstream shortcuts are not acceptable.
+    validations:
+      required: true
+  - type: checkboxes
+    id: guardrails
+    attributes:
+      label: Guardrails
+      options:
+        - label: The blocked youaskm3 issue is linked from this report.
+          required: true
+        - label: The blocked youaskm3 issue is or will be set to Blocked in Project 3.
+          required: true
+        - label: This report does not request a downstream provider/runtime shortcut, Browser demo acceptance, placeholder digest, contract stub, or fake workflow step.
+          required: true

--- a/docs/traverse-blocker-escalation.md
+++ b/docs/traverse-blocker-escalation.md
@@ -1,0 +1,103 @@
+# Traverse Blocker Escalation
+
+Status: MVP operating process
+
+## Purpose
+
+Use this process when a youaskm3 MVP ticket cannot satisfy its definition of
+done through current Traverse public surfaces.
+
+The goal is to keep youaskm3 product-led without hiding Traverse gaps behind
+downstream runtime shortcuts, provider-specific code, Browser demo acceptance,
+contract stubs, fake workflow steps, skeleton manifests, or placeholder
+evidence.
+
+## Decision Checklist
+
+Before opening or linking a Traverse blocker, classify the failure.
+
+### youaskm3 bug
+
+Treat the issue as a youaskm3 bug when the required Traverse public surface
+exists and the local repo misuses it.
+
+Examples:
+
+- invalid youaskm3 app manifest shape
+- missing or stale component digest after a successful WASM build
+- PWA request body does not match the configured Traverse HTTP/JSON contract
+- local smoke fixture is incomplete or points at the wrong artifact
+
+Action: fix the youaskm3 code, docs, contract, fixture, or script in the active
+ticket.
+
+### Traverse blocker
+
+Treat the issue as a Traverse blocker when a focused command proves that
+youaskm3 has valid downstream evidence but Traverse lacks a required public
+surface or governed runtime behavior.
+
+Examples:
+
+- no public app-register command exists for a valid downstream app manifest
+- a documented HTTP/JSON execution path cannot execute a registered workflow
+- a public trace omits required source, graph, dependency, or validation evidence
+- MCP parity cannot call the same registered workflow through public Traverse
+  surfaces
+
+Action: keep the youaskm3 ticket Blocked in Project 3, open or link a Traverse
+requirement, and do not add downstream runtime/provider shortcuts.
+
+### Environment or setup failure
+
+Treat the issue as environment/setup when the required public surface exists but
+the local machine lacks a prerequisite.
+
+Examples:
+
+- missing `TRAVERSE_REPO`
+- Traverse checkout older than the required release tag
+- optional local model provider unavailable while live model conformance is
+  explicitly opt-in
+- missing Rust target, local tool, or credentials
+
+Action: report the setup failure with the missing prerequisite. Do not open an
+upstream Traverse blocker unless the setup step itself exposes a missing public
+surface.
+
+## Required Evidence
+
+Every Traverse blocker must include:
+
+- affected youaskm3 issue or PR
+- affected capability, workflow, or contract
+- expected Traverse public surface
+- observed failure code and short error excerpt
+- focused reproduction command
+- Traverse version, tag, or commit
+- youaskm3 branch or commit
+- downstream impact and why Browser demo, temporary harnesses, skeleton
+  manifests, stubs, or fake workflow steps cannot satisfy the ticket
+
+If no focused reproduction command can exist, explain why and include the
+smallest available validation path.
+
+## Linking and Board State
+
+When a blocker belongs upstream:
+
+1. Comment on the blocked youaskm3 issue with the focused evidence.
+2. Link the upstream Traverse issue or requirement from that comment.
+3. Set the youaskm3 Project 3 Status to `Blocked`.
+4. Do not keep the issue `In Progress` unless active downstream work remains.
+5. Resume the ticket only after the linked Traverse requirement is available
+   through a public surface.
+
+## Current Example
+
+After MVP-032, `scripts/register-traverse-app.sh --json` can prove real
+youaskm3 component evidence with `missing_wasm_count: 0` and
+`zero_digest_component_count: 0`. If the same command fails with
+`MISSING_PUBLIC_APP_REGISTRATION_SURFACE`, the remaining gap is a Traverse
+blocker: youaskm3 has real component artifacts, but Traverse still needs a
+public external app-registration surface for this manifest shape.

--- a/docs/youaskm3-ops.md
+++ b/docs/youaskm3-ops.md
@@ -97,6 +97,12 @@ For release-pinned Traverse evidence, use the checklist in
 rely on release prose alone when `scripts/traverse-readiness.sh` can run against
 a local Traverse checkout.
 
+When focused evidence shows a missing Traverse public surface, follow
+`docs/traverse-blocker-escalation.md`: keep the youaskm3 issue Blocked, link an
+upstream Traverse requirement or issue, and do not add downstream provider or
+runtime shortcuts, Browser demo acceptance, placeholders, stubs, or fake
+workflow steps.
+
 ## Guardrails
 
 - Do not mark work `In Progress` unless a real dev thread has started it.


### PR DESCRIPTION
## What this changes
Adds a lightweight Traverse blocker escalation process for youaskm3 MVP work, including a decision checklist, required evidence, board/linking rules, and a GitHub issue template for confirmed missing Traverse public surfaces. Also updates the repo ops doc and Codex skill mirror so future agent runs block/escalate instead of adding downstream runtime shortcuts.

## Spec reference
- `openspec/specs/traverse-integration/spec.md` - Escalate confirmed Traverse blockers upstream
- `docs/mvp-ticket-backlog.md` - MVP-035 / #124
- `docs/youaskm3-ops.md` - Traverse dependency checker lane

## Test coverage
Docs/template only. Added YAML template validation through the existing smoke path.

## Lean ops / minimality
- Added one process doc, one issue template, and small ops references.
- Did not change Traverse code, runtime behavior, or existing requirements docs.

## Validation
- `ruby -e 'require "yaml"; Dir.glob(".github/ISSUE_TEMPLATE/*.yml").sort.each { |path| YAML.load_file(path) }'` - passed
- `PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh` - passed; full smoke green

Closes #124

## Breaking changes
None.
