### PR TITLE
Adopt Traverse v0.5.0 MVP baseline

### DIFF
--- a/.github/ISSUE_TEMPLATE/traverse-blocker.yml
+++ b/.github/ISSUE_TEMPLATE/traverse-blocker.yml
@@ -39,7 +39,7 @@ body:
     attributes:
       label: Observed failure
       description: Include the stable failure code and a short actionable error excerpt.
-      placeholder: MISSING_PUBLIC_APP_REGISTRATION_SURFACE - no public external app-register CLI for this manifest shape.
+      placeholder: MISSING_REAL_WASM_AGENT_EXECUTION - Traverse cannot execute knowledge.infer as a real WASM agent capability.
     validations:
       required: true
   - type: textarea
@@ -55,7 +55,7 @@ body:
     attributes:
       label: Traverse version or commit
       description: Include the release tag, describe output, or commit used for the reproduction.
-      placeholder: v0.4.0-5-g755da626860a
+      placeholder: v0.5.0
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ This repo is intentionally structured so humans and agents can navigate the same
 | Start or resume ops workflow | [docs/youaskm3-ops.md](docs/youaskm3-ops.md) |
 | Inspect the repo command surface | [scripts/m3.sh](scripts/m3.sh) |
 | Run the full validation path | [scripts/smoke.sh](scripts/smoke.sh) |
-| Check Traverse v0.4.0 readiness | [scripts/traverse-readiness.sh](scripts/traverse-readiness.sh) |
+| Check Traverse v0.5.0 readiness | [scripts/traverse-readiness.sh](scripts/traverse-readiness.sh) |
 | Update Traverse component manifests | [scripts/traverse-component-manifests.sh](scripts/traverse-component-manifests.sh) |
 | Review current knowledge layout | [knowledge/index.md](knowledge/index.md) |
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -44,7 +44,7 @@ Anyone can fork it, fill it with their own knowledge, and run their own instance
 |---|---|---|
 | Business logic | **Rust → WASM** | Portable, safe, fast. Runs anywhere. |
 | WASM runtime | **Wasmtime** (CLI/server) / **browser native** | Same module, different host |
-| Runtime model | **Traverse v0.4.0 baseline / UMA** | Contract-driven, governed, explainable release surface for portable capabilities |
+| Runtime model | **Traverse v0.5.0 baseline / UMA** | Contract-driven, governed, explainable release surface for portable capabilities |
 | MCP interface | **WASM MCP module** | Portable MCP server compiled to WASM |
 | Runtime integration | **Traverse app bundle** | Registers capability contracts, event contracts, workflows, WASM packages, and model dependencies |
 
@@ -183,7 +183,7 @@ idea → /openspec:proposal → proposal.md + design.md + tasks.md + spec delta
 
 ### Traverse integration baseline
 
-youaskm3 integrates with Traverse through documented public release surfaces instead of private Traverse internals. The minimum approved first-MVP integration baseline is Traverse `v0.4.0`, released on 2026-06-22, as described in [docs/traverse-mvp-requirements.md](docs/traverse-mvp-requirements.md):
+youaskm3 integrates with Traverse through documented public release surfaces instead of private Traverse internals. The minimum approved first-MVP integration baseline for MVP-031 onward is Traverse `v0.5.0`, released on 2026-06-26, as described in [docs/traverse-mvp-requirements.md](docs/traverse-mvp-requirements.md):
 
 - governed application bundle registration
 - WASM component manifest validation
@@ -195,6 +195,8 @@ youaskm3 integrates with Traverse through documented public release surfaces ins
 - public traces for answer grounding
 - local/server placement and model dependency resolution
 - downstream app MVP conformance evidence through `bash scripts/ci/downstream_app_mvp_conformance.sh`
+- public CLI app validation with `traverse-cli app validate --manifest <path> --json`
+- public CLI local workspace app registration with `traverse-cli app register --manifest <path> --workspace <workspace-id> --json`
 
 Roadmap work that touches runtime, MCP, browser hosting, model inference, or fork-and-run setup must pin an approved Traverse release pairing and include the relevant Traverse validation path.
 
@@ -204,13 +206,14 @@ The first-MVP personas, "As a..., I want..., so that..." stories, capability map
 
 ### Next product-led MVP tranche
 
-After Traverse `v0.4.0` readiness and the first youaskm3 WASM capability tranche, the next highest-ROI work is tracked as MVP-031 through MVP-035 in [docs/mvp-ticket-backlog.md](docs/mvp-ticket-backlog.md):
+After Traverse `v0.5.0` readiness and the first youaskm3 WASM capability tranche, the next highest-ROI work is tracked as MVP-031 through MVP-038 in [docs/mvp-ticket-backlog.md](docs/mvp-ticket-backlog.md):
 
 - prove the local Traverse-backed chat happy path
 - wire real WASM artifacts and component digests for implemented capabilities
 - add a real imported-document question acceptance test
 - enforce explicit Browser demo fallback semantics
 - create a Traverse blocker escalation template for confirmed upstream gaps
+- adopt the v0.5.0 public CLI app validation/registration baseline
 
 These tickets keep youaskm3 product-led while using concrete app evidence to drive Traverse requirements. They must not add downstream runtime/provider shortcuts that bypass Traverse-governed WASM capability execution.
 

--- a/docs/local-development-toolchain.md
+++ b/docs/local-development-toolchain.md
@@ -72,4 +72,4 @@ TRAVERSE_REPO=/path/to/Traverse bash scripts/traverse-readiness.sh
 ```
 
 See [traverse-mvp-requirements.md](traverse-mvp-requirements.md) for the
-release-pinned Traverse `v0.4.0` evidence checklist.
+release-pinned Traverse `v0.5.0` evidence checklist.

--- a/docs/mvp-local-inference-policy.md
+++ b/docs/mvp-local-inference-policy.md
@@ -83,7 +83,7 @@ The UI may display summarized placement and dependency status, but it must not d
 
 ### WASM-Native Model Caveat
 
-Traverse `v0.4.0` proves governed model dependency resolution and includes an opt-in local Ollama provider path. It does not prove that the model engine itself is WASM-native.
+Traverse `v0.5.0` preserves governed model dependency resolution and includes an opt-in local Ollama provider path. It does not prove that the model engine itself is WASM-native.
 
 The first MVP may proceed while this caveat is true because the architectural requirement is that inference selection, placement, trace evidence, and failure handling are governed by Traverse rather than hardcoded downstream app logic. A later release may require the model engine itself to run as WASM when Traverse exposes stable readiness evidence for that path.
 

--- a/docs/mvp-ticket-backlog.md
+++ b/docs/mvp-ticket-backlog.md
@@ -991,6 +991,150 @@ PYTHON=/opt/homebrew/bin/python3.14 \
 bash scripts/smoke.sh
 ```
 
+## Ticket MVP-036: Adopt Traverse v0.5.0 as the MVP-031 Runtime Baseline
+
+### Objective
+
+Pin youaskm3 MVP-031 and later runtime integration work to Traverse `v0.5.0`, the first Traverse release that adds public CLI app validation and local workspace registration surfaces for downstream apps.
+
+### Scope
+
+Update the repo baseline and validation references so future work uses:
+
+- Traverse release `v0.5.0`
+- governing Traverse spec `046-public-cli-app-registration`
+- `traverse-cli app validate --manifest <path> --json`
+- `traverse-cli app register --manifest <path> --workspace <workspace-id> --json`
+- v0.5.0 release-pinned evidence and caveats
+
+### Out of Scope
+
+- Implementing `scripts/register-traverse-app.sh` consumption of `traverse-cli`
+- Changing Traverse code
+- Claiming real WASM agent execution is proven before MVP-031 validates it
+
+### Definition of Done
+
+- `SPEC.md` names Traverse `v0.5.0` as the minimum approved baseline for MVP-031 onward.
+- `docs/traverse-mvp-requirements.md` documents v0.5.0 release evidence, new CLI surfaces, and remaining caveats.
+- `scripts/traverse-readiness.sh` defaults to `MIN_TRAVERSE_TAG=v0.5.0`.
+- The youaskm3 Traverse app manifest requires `v0.5.0`.
+- Bundle docs reference `traverse-cli app validate` and `traverse-cli app register`.
+- Historical v0.4.0 references remain only where they describe completed earlier work.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+
+MIN_TRAVERSE_TAG=v0.5.0 \
+TRAVERSE_REPO=/Users/enricopiovesan/Documents/repos/Traverse \
+bash scripts/traverse-readiness.sh
+```
+
+If the local Traverse checkout is older than v0.5.0, the readiness command must fail with a clear setup message rather than weakening the baseline.
+
+## Ticket MVP-037: Consume Traverse v0.5.0 Public App Validate/Register CLI
+
+### Objective
+
+Update the youaskm3 registration command to use Traverse v0.5.0 public CLI app validation and local workspace registration instead of stopping at the old missing-surface error.
+
+### Scope
+
+Update `scripts/register-traverse-app.sh` so that, when real component artifacts are present and `TRAVERSE_REPO` points to Traverse v0.5.0 or newer, it invokes:
+
+- `traverse-cli app validate --manifest <path> --json`
+- `traverse-cli app register --manifest <path> --workspace <workspace-id> --json`
+
+The command must preserve machine-readable evidence for local validation, registration status, workspace id, app id, version, digests, failures, and Traverse version.
+
+### Out of Scope
+
+- Hosted registration service
+- HTTP admin API registration
+- Changing Traverse CLI behavior
+- Accepting skeleton manifests, placeholder digests, fake workflow steps, or Browser demo evidence
+
+### Definition of Done
+
+- `scripts/register-traverse-app.sh --validate-only --json` remains CI-safe and validates local bundle evidence without requiring Traverse.
+- With `TRAVERSE_REPO` set to Traverse v0.5.0 or newer and real WASM artifacts present, the script calls public `traverse-cli app validate`.
+- With a workspace id provided, the script calls public `traverse-cli app register`.
+- The script records CLI-produced workspace registration evidence in its JSON output.
+- Missing `traverse-cli`, stale Traverse checkout, invalid manifest, missing workspace id, and CLI validation failures return stable machine-readable error codes.
+- Existing smoke coverage is updated so the old `MISSING_PUBLIC_APP_REGISTRATION_SURFACE` path is no longer the expected success/failure result for v0.5.0.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+cargo build --locked --workspace --target wasm32-wasip1 --release
+
+bash scripts/register-traverse-app.sh --validate-only --json
+
+MIN_TRAVERSE_TAG=v0.5.0 \
+TRAVERSE_REPO=/Users/enricopiovesan/Documents/repos/Traverse \
+bash scripts/register-traverse-app.sh --json
+
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-038: Add Release-Pinned Traverse v0.5.0 Conformance Evidence
+
+### Objective
+
+Add release-pinned evidence proving youaskm3 can validate the Traverse v0.5.0 pairing from a local checkout and distinguish setup failures from runtime blockers.
+
+### Scope
+
+Update readiness docs and smoke evidence around:
+
+- v0.5.0 tag verification
+- downstream app MVP conformance
+- public CLI app registration conformance
+- local checkout freshness errors
+- optional live local model conformance caveat
+
+### Out of Scope
+
+- Implementing missing youaskm3 runtime capabilities
+- Changing Traverse conformance scripts
+- Treating release prose as enough evidence when local conformance can run
+
+### Definition of Done
+
+- `docs/traverse-mvp-requirements.md` contains a v0.5.0 release-pinned evidence checklist.
+- `scripts/traverse-readiness.sh` reports the active Traverse tag/commit and minimum baseline.
+- A stale local Traverse checkout fails clearly as an environment/setup failure.
+- A v0.5.0-or-newer checkout runs downstream conformance through public Traverse surfaces.
+- Readiness output summarizes application bundle registration, WASM workflow execution, model dependency resolution, HTTP/JSON app path, MCP parity path, and public CLI app registration where available.
+- Optional live local model conformance remains opt-in.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+MIN_TRAVERSE_TAG=v0.5.0 \
+TRAVERSE_REPO=/Users/enricopiovesan/Documents/repos/Traverse \
+bash scripts/traverse-readiness.sh
+
+TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1 \
+MIN_TRAVERSE_TAG=v0.5.0 \
+TRAVERSE_REPO=/Users/enricopiovesan/Documents/repos/Traverse \
+bash scripts/traverse-readiness.sh
+
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+```
+
 - Common failures are documented:
   - missing `cargo`
   - missing `wasm32-wasip1`
@@ -1040,6 +1184,9 @@ Next highest-ROI tranche after MVP-030:
 - MVP-033 real imported-document question acceptance test
 - MVP-034 explicit Browser demo fallback semantics
 - MVP-035 Traverse blocker escalation template
+- MVP-036 Traverse v0.5.0 baseline adoption
+- MVP-037 public CLI app validate/register consumption
+- MVP-038 release-pinned v0.5.0 conformance evidence
 
 ## First Ticket to Start
 
@@ -1049,7 +1196,7 @@ Recommended first implementation ticket:
 
 Reason:
 
-- Traverse v0.4.0 readiness is already green.
+- Traverse v0.5.0 is the approved baseline for MVP-031 onward.
 - It validates the user-facing product with real runtime pressure.
 - It exposes any remaining Traverse gaps through concrete evidence.
 - It keeps youaskm3 from drifting into downstream runtime shortcuts.

--- a/docs/traverse-blocker-escalation.md
+++ b/docs/traverse-blocker-escalation.md
@@ -95,9 +95,9 @@ When a blocker belongs upstream:
 
 ## Current Example
 
-After MVP-032, `scripts/register-traverse-app.sh --json` can prove real
-youaskm3 component evidence with `missing_wasm_count: 0` and
-`zero_digest_component_count: 0`. If the same command fails with
-`MISSING_PUBLIC_APP_REGISTRATION_SURFACE`, the remaining gap is a Traverse
-blocker: youaskm3 has real component artifacts, but Traverse still needs a
-public external app-registration surface for this manifest shape.
+After MVP-037, `scripts/register-traverse-app.sh --json` should consume
+Traverse v0.5.0 public `traverse-cli app validate` and `traverse-cli app
+register` surfaces. If a valid youaskm3 bundle with real component evidence
+then fails because Traverse cannot execute the registered real workflow,
+real WASM microservice, or real WASM agent capability through public surfaces,
+the remaining gap is a Traverse blocker.

--- a/docs/traverse-mvp-requirements.md
+++ b/docs/traverse-mvp-requirements.md
@@ -1,8 +1,8 @@
 # Traverse Requirements for the First Knowledge-App MVP
 
-Status: Updated for Traverse v0.4.0 first-MVP baseline
+Status: Updated for Traverse v0.5.0 first-MVP baseline
 Owner: youaskm3 downstream integration
-Last updated: 2026-06-22
+Last updated: 2026-06-26
 
 ## Purpose
 
@@ -44,22 +44,24 @@ The downstream app should only depend on Traverse public surfaces, not private c
 
 ## Current Baseline Confirmed
 
-As of 2026-06-22, Traverse `v0.4.0` is the minimum approved first-MVP integration baseline for this downstream app.
+As of 2026-06-26, Traverse `v0.5.0` is the minimum approved first-MVP integration baseline for MVP-031 onward.
 
 Release:
 
-- Tag: `v0.4.0`
-- URL: https://github.com/enricopiovesan/Traverse/releases/tag/v0.4.0
-- Release date: 2026-06-22
-- Governing Traverse specs: `044-application-bundle-manifest` and `045-governed-model-dependency-resolution`
+- Tag: `v0.5.0`
+- URL: https://github.com/enricopiovesan/Traverse/releases/tag/v0.5.0
+- Release date: 2026-06-26
+- Governing Traverse specs: `044-application-bundle-manifest`, `045-governed-model-dependency-resolution`, and `046-public-cli-app-registration`
 
-The exact `v0.4.0` tag conformance path passed locally:
+Traverse `v0.5.0` keeps the `v0.4.0` manifest and governed model-dependency baseline intact while adding the public downstream app setup commands needed by youaskm3:
 
-```bash
-bash scripts/ci/downstream_app_mvp_conformance.sh
-```
+- `traverse-cli app validate --manifest <path> --json`
+- `traverse-cli app register --manifest <path> --workspace <workspace-id> --json`
+- durable local workspace registration state under `.traverse/workspaces/<workspace-id>/apps/<app-id>/<version>/registration.json`
+- runtime loading from CLI-produced workspace app state
+- downstream public app registration conformance wired into downstream app MVP conformance
 
-Traverse `v0.4.0` covers the first-MVP runtime baseline:
+Traverse `v0.5.0` covers the first-MVP runtime baseline:
 
 - application bundle manifests
 - WASM component manifests
@@ -72,11 +74,16 @@ Traverse `v0.4.0` covers the first-MVP runtime baseline:
 - WASM execution via Wasmtime exists
 - public trace evidence exists
 - programmatic registration exists
+- public CLI app validation exists
+- public CLI local workspace app registration exists
+- runtime loading from CLI-produced workspace app state exists
 - downstream app MVP conformance exists
 
 Important caveat:
 
-Traverse `v0.4.0` proves governed model dependency resolution and includes a local Ollama provider path, but the default conformance suite does not require a reachable live local model. Live local Ollama conformance is separately gated with `TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1`. Also, this baseline does not prove that the model engine itself is WASM-native. The first youaskm3 MVP may proceed as long as `knowledge.infer` is declared, resolved, placed, traced, and failed through Traverse-governed dependency surfaces rather than hardcoded downstream app provider logic.
+Traverse `v0.5.0` proves governed model dependency resolution and includes a local Ollama provider path inherited from the `v0.4.0` baseline, but the default conformance suite does not require a reachable live local model. Live local Ollama conformance is separately gated with `TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1`. Also, this baseline does not prove that the model engine itself is WASM-native. The first youaskm3 MVP may proceed only if `knowledge.infer` is implemented as a real Traverse-governed WASM agent capability or fails with governed missing-dependency evidence; downstream app code must not hardcode provider logic or use fake deterministic inference as acceptance evidence.
+
+Historical note: Traverse `v0.4.0`, released on 2026-06-22, remains the first approved application-manifest and governed model-dependency baseline. MVP-031 onward uses `v0.5.0` because it adds the public CLI app validation and local workspace registration surfaces required for the real downstream setup flow.
 
 The downstream local inference policy is defined in [mvp-local-inference-policy.md](mvp-local-inference-policy.md). Default youaskm3 smoke must not require a live local LLM; optional live local conformance remains explicit and opt-in.
 
@@ -214,7 +221,7 @@ Acceptance criteria:
 
 #### TRV-P0-004: Runtime Dependency Resolution for Model Dependencies
 
-Traverse `v0.4.0` turns model dependency declarations into runtime-governed dependencies. youaskm3 must consume those public surfaces and must not hardcode an inference provider in product/business logic.
+Traverse `v0.5.0` preserves the `v0.4.0` model dependency declarations as runtime-governed dependencies. youaskm3 must consume those public surfaces and must not hardcode an inference provider in product/business logic.
 
 Acceptance criteria:
 
@@ -519,7 +526,7 @@ The downstream app needs stable public APIs for:
 - discovering MCP tools
 - executing MCP entrypoints
 
-Traverse `v0.4.0` covers the required public API baseline through application manifests, WASM component manifests, atomic registration, governed model dependency resolution, HTTP/JSON trace paths, MCP reporting, and downstream MVP conformance evidence.
+Traverse `v0.5.0` covers the required public API baseline through application manifests, WASM component manifests, public CLI app validation, public CLI local workspace registration, runtime loading from CLI-produced workspace app state, governed model dependency resolution, HTTP/JSON trace paths, MCP reporting, and downstream MVP conformance evidence.
 
 ## Required Validation Evidence
 
@@ -546,7 +553,7 @@ Downstream readiness wrapper:
 bash scripts/traverse-readiness.sh
 ```
 
-The wrapper looks for a local Traverse checkout at `../Traverse` by default. Use `TRAVERSE_REPO=/path/to/Traverse` or `TRAVERSE_CHECKOUT=/path/to/Traverse` when the checkout is elsewhere. It verifies that the checkout contains the `v0.4.0` baseline, reports the active tag and commit, delegates to Traverse's public downstream conformance script, and summarizes the capability areas instead of printing full passing logs:
+The wrapper looks for a local Traverse checkout at `../Traverse` by default. Use `TRAVERSE_REPO=/path/to/Traverse` or `TRAVERSE_CHECKOUT=/path/to/Traverse` when the checkout is elsewhere. It verifies that the checkout contains the `v0.5.0` baseline by default, reports the active tag and commit, delegates to Traverse's public downstream conformance script, and summarizes the capability areas instead of printing full passing logs:
 
 ```text
 Traverse readiness passed.
@@ -581,8 +588,8 @@ the first-MVP Traverse baseline is satisfied:
 2. Confirm the checkout contains and is not older than the pinned baseline:
 
    ```bash
-   git -C "${TRAVERSE_REPO:-../Traverse}" rev-parse --verify v0.4.0^{commit}
-   git -C "${TRAVERSE_REPO:-../Traverse}" merge-base --is-ancestor v0.4.0 HEAD
+   git -C "${TRAVERSE_REPO:-../Traverse}" rev-parse --verify v0.5.0^{commit}
+   git -C "${TRAVERSE_REPO:-../Traverse}" merge-base --is-ancestor v0.5.0 HEAD
    ```
 
 3. Run the public downstream conformance path from youaskm3, not a private
@@ -643,8 +650,8 @@ Traverse should only care about these external tools if the downstream app wraps
 
 ## Recommended Traverse Work Order
 
-1. Pin youaskm3 specs and docs to Traverse `v0.4.0`.
-2. Create the youaskm3 application bundle skeleton using v0.4.0 manifest fields.
+1. Pin youaskm3 specs and docs to Traverse `v0.5.0`.
+2. Use the youaskm3 application bundle with v0.5.0-compatible manifest fields and public CLI validation/registration.
 3. Add a youaskm3 readiness check that delegates to `downstream_app_mvp_conformance.sh`.
 4. Implement the MVP WASM capabilities and component manifests.
 5. Register the youaskm3 app bundle through Traverse public APIs.
@@ -672,4 +679,4 @@ Traverse already has a strong foundation for the first integration:
 - trace evidence
 - downstream app MVP conformance evidence
 
-The critical missing piece has moved to the downstream app: youaskm3 must now build and register its own Traverse v0.4.0 application bundle, implement the MVP WASM capabilities, wire the PWA/MCP paths to the registered workflow, and document the local inference caveat clearly.
+The critical missing piece has moved to the downstream app: youaskm3 must now build and register its own Traverse v0.5.0 application bundle through public CLI app validation/registration, implement the MVP WASM microservices and WASM agents, wire the PWA/MCP paths to the registered workflow, and document the local inference caveat clearly.

--- a/openspec/specs/traverse-integration/spec.md
+++ b/openspec/specs/traverse-integration/spec.md
@@ -10,11 +10,20 @@ The traverse-integration capability defines how youaskm3 hands product/business 
 
 The system SHALL register the youaskm3 application bundle through documented Traverse public APIs, including capability contracts, event contracts, workflow definitions, WASM package manifests, binary digests, runtime constraints, permitted targets, and model dependency declarations.
 
+For MVP-031 onward, the minimum approved Traverse baseline is `v0.5.0`. Local development setup SHALL validate bundles through `traverse-cli app validate --manifest <path> --json` and register them into a workspace through `traverse-cli app register --manifest <path> --workspace <workspace-id> --json`.
+
 #### Scenario: Register the MVP bundle
 
 - GIVEN the CLI has built the MVP artifact and WASM package set
 - WHEN it registers the application with Traverse
 - THEN Traverse returns machine-readable bundle ids, versions, digests, and validation status without relying on private Traverse internals
+
+#### Scenario: Validate and register through the Traverse v0.5.0 CLI
+
+- GIVEN the CLI has built the youaskm3 Traverse application bundle
+- WHEN local development setup validates and registers the bundle
+- THEN it uses Traverse `v0.5.0` or newer public CLI app validation and local workspace registration commands
+- AND the setup path does not depend on private Traverse internals or downstream runtime shortcuts
 
 ### Requirement: Execute the chat workflow through real Traverse capabilities
 

--- a/scripts/register-traverse-app.sh
+++ b/scripts/register-traverse-app.sh
@@ -13,7 +13,7 @@ require "set"
 ROOT = Pathname.new(Dir.pwd)
 APP_MANIFEST = ROOT.join("traverse/youaskm3-app/manifest.json")
 ZERO_DIGEST = "sha256:#{"0" * 64}"
-MIN_TRAVERSE_TAG = ENV.fetch("MIN_TRAVERSE_TAG", "v0.4.0")
+MIN_TRAVERSE_TAG = ENV.fetch("MIN_TRAVERSE_TAG", "v0.5.0")
 
 options = {
   json: false,
@@ -300,7 +300,7 @@ payload["status"] = "failed"
 payload["code"] = "MISSING_PUBLIC_APP_REGISTRATION_SURFACE"
 payload["errors"] << {
   "code" => "MISSING_PUBLIC_APP_REGISTRATION_SURFACE",
-  "message" => "Traverse #{MIN_TRAVERSE_TAG} exposes application registration through traverse-registry but no public external app-register CLI for this checked-in manifest. Add that Traverse surface before real youaskm3 registration can complete."
+  "message" => "Traverse #{MIN_TRAVERSE_TAG} exposes public app validation and local workspace registration through traverse-cli. Wire scripts/register-traverse-app.sh to invoke traverse-cli app validate/register before real youaskm3 registration can complete."
 }
 finish(payload, options, 5)
 RUBY

--- a/scripts/traverse-answer-workflow-smoke.sh
+++ b/scripts/traverse-answer-workflow-smoke.sh
@@ -60,7 +60,7 @@ end
 RUBY
 
 if [[ -z "$TRAVERSE_REPO" || ! -d "$TRAVERSE_REPO/.git" ]]; then
-  message="Traverse answer workflow smoke skipped: set TRAVERSE_REPO to run the live Traverse v0.4.0 gate."
+  message="Traverse answer workflow smoke skipped: set TRAVERSE_REPO to run the live Traverse v0.5.0 gate."
   if [[ "$REQUIRED" == "1" ]]; then
     echo "$message" >&2
     exit 2

--- a/scripts/traverse-readiness.sh
+++ b/scripts/traverse-readiness.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-MIN_TRAVERSE_TAG="${MIN_TRAVERSE_TAG:-v0.4.0}"
+MIN_TRAVERSE_TAG="${MIN_TRAVERSE_TAG:-v0.5.0}"
 TRAVERSE_REPO="${TRAVERSE_REPO:-${TRAVERSE_CHECKOUT:-}}"
 
 if [[ -z "$TRAVERSE_REPO" ]]; then

--- a/scripts/traverse-readiness.sh
+++ b/scripts/traverse-readiness.sh
@@ -70,7 +70,7 @@ require_cmd bash
 require_cmd git
 require_cmd cargo
 
-if [[ ! -d "$TRAVERSE_REPO/.git" ]]; then
+if ! git -C "$TRAVERSE_REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "Traverse readiness failed: TRAVERSE_REPO is not a git checkout: $TRAVERSE_REPO" >&2
   exit 1
 fi

--- a/traverse/youaskm3-app/README.md
+++ b/traverse/youaskm3-app/README.md
@@ -1,26 +1,27 @@
 # youaskm3 Traverse Application Bundle
 
 This directory contains the first youaskm3 application bundle for Traverse
-`v0.4.0`.
+`v0.5.0`.
 
 It is the checked-in target shape for registering the first MVP chat workflow
 through Traverse public application-bundle surfaces. The checked-in component
 manifests now carry real release WASM binary digests for the MVP capability
-artifacts; live app registration still depends on Traverse exposing the
-external registration surface for this manifest shape.
+artifacts; live app registration now targets the public Traverse CLI app
+validation and local workspace registration surfaces added in Traverse v0.5.0.
 
 ## Baseline
 
-- Minimum Traverse release: `v0.4.0`
-- Traverse release date: 2026-06-22
-- Traverse release: <https://github.com/enricopiovesan/Traverse/releases/tag/v0.4.0>
+- Minimum Traverse release: `v0.5.0`
+- Traverse release date: 2026-06-26
+- Traverse release: <https://github.com/enricopiovesan/Traverse/releases/tag/v0.5.0>
 - Governing Traverse specs:
   - `044-application-bundle-manifest`
   - `045-governed-model-dependency-resolution`
+  - `046-public-cli-app-registration`
 - youaskm3 governing spec:
   - `openspec/specs/traverse-integration/spec.md`
 
-Traverse `v0.4.0` provides the public surfaces this skeleton targets:
+Traverse `v0.5.0` provides the public surfaces this bundle targets:
 
 - application manifests
 - WASM component manifests
@@ -30,6 +31,10 @@ Traverse `v0.4.0` provides the public surfaces this skeleton targets:
 - MCP reporting
 - downstream app MVP conformance through
   `bash scripts/ci/downstream_app_mvp_conformance.sh`
+- public CLI app validation through
+  `traverse-cli app validate --manifest <path> --json`
+- public CLI local workspace registration through
+  `traverse-cli app register --manifest <path> --workspace <workspace-id> --json`
 
 ## Files
 
@@ -62,7 +67,7 @@ The first workflow composes them in this order:
 
 ## Component Artifact Evidence
 
-The component manifests use Traverse v0.4.0 field names and reference release
+The component manifests use Traverse v0.5.0-compatible field names and reference release
 WASM artifacts under `target/wasm32-wasip1/release`. Generate or verify real
 component evidence with:
 
@@ -81,7 +86,7 @@ implementation markers, or placeholder validation evidence.
 
 ## Model Dependency
 
-The app manifest declares inference through Traverse v0.4.0
+The app manifest declares inference through Traverse v0.5.0
 `model_dependencies` using the `traverse.inference.generate` interface.
 
 The local Ollama candidate is a Traverse-resolved provider candidate, not
@@ -104,8 +109,8 @@ provider logic.
 ## Registration Status
 
 The bundle has real component artifact digests and passes local validation.
-Real Traverse registration can still fail when Traverse does not expose a
-public external app-register CLI for this checked-in manifest shape.
+Real Traverse registration must now use the public v0.5.0 CLI app validation
+and local workspace registration surfaces.
 
 The youaskm3-side registration entrypoint is:
 
@@ -115,13 +120,14 @@ TRAVERSE_REPO=/path/to/Traverse bash scripts/register-traverse-app.sh --json
 ```
 
 `--validate-only` is CI-safe and does not require a Traverse checkout. Real
-registration requires Traverse `v0.4.0` or newer and real WASM component
+registration requires Traverse `v0.5.0` or newer and real WASM component
 artifacts.
 
-If real component artifacts are present but Traverse does not yet expose a
-public external app-register CLI for this application manifest shape, the
-command fails with `MISSING_PUBLIC_APP_REGISTRATION_SURFACE`. That is a
-Traverse integration requirement, not a downstream hidden fallback.
+Traverse v0.5.0 exposes public local-dev app validation and registration through
+`traverse-cli app validate` and `traverse-cli app register`. Until
+`scripts/register-traverse-app.sh` consumes those commands directly, the
+remaining work is tracked as youaskm3 implementation work, not a Traverse
+surface gap.
 
 The end-to-end answer workflow integration gate is:
 
@@ -131,12 +137,12 @@ TRAVERSE_REPO=/path/to/Traverse bash scripts/traverse-answer-workflow-smoke.sh
 ```
 
 The gate validates prepared search artifacts, graph source evidence, public
-trace requirements, model dependency policy, Traverse `v0.4.0` readiness, and
+trace requirements, model dependency policy, Traverse `v0.5.0` readiness, and
 the app registration boundary. Without `TRAVERSE_REPO`, it validates local
 youaskm3 artifacts and skips the live Traverse step so default smoke remains
 CI-safe. With real component artifacts available, the live Traverse step should
-either validate/register through Traverse or return a stable upstream Traverse
-surface gap such as `MISSING_PUBLIC_APP_REGISTRATION_SURFACE`.
+validate/register through Traverse v0.5.0 public CLI surfaces or return a stable
+youaskm3 implementation/setup error that is tracked by MVP-037.
 
 The MCP parity gate is:
 
@@ -163,7 +169,7 @@ Follow-up tickets:
 For this bundle slice:
 
 ```bash
-rg -n "v0.4.0|model_dependencies|knowledge.query.answer|knowledge.retrieve|knowledge.infer" traverse/youaskm3-app
+rg -n "v0.5.0|model_dependencies|knowledge.query.answer|knowledge.retrieve|knowledge.infer" traverse/youaskm3-app
 PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
 cargo build --locked --workspace --target wasm32-wasip1 --release
 bash scripts/traverse-component-manifests.sh --check

--- a/traverse/youaskm3-app/manifest.json
+++ b/traverse/youaskm3-app/manifest.json
@@ -2,7 +2,7 @@
   "app_id": "youaskm3.knowledge-app",
   "version": "0.1.0",
   "schema_version": "1.0.0",
-  "minimum_traverse_version": "v0.4.0",
+  "minimum_traverse_version": "v0.5.0",
   "integration_status": "wasm_components_ready",
   "workspace_defaults": {
     "workspace_id": "youaskm3-local",

--- a/traverse/youaskm3-app/workflows/knowledge-query-answer.workflow.json
+++ b/traverse/youaskm3-app/workflows/knowledge-query-answer.workflow.json
@@ -280,7 +280,7 @@
     "mvp",
     "knowledge",
     "answer",
-    "traverse-v0.4.0"
+    "traverse-v0.5.0"
   ],
   "governing_spec": "openspec/specs/traverse-integration/spec.md"
 }


### PR DESCRIPTION
## Summary
- Approves Traverse v0.5.0 as the minimum runtime baseline for MVP-031 onward.
- Updates specs, readiness defaults, app manifest/docs, blocker guidance, and local toolchain references for v0.5.0.
- Adds MVP-036 through MVP-038 to capture baseline adoption, public CLI app validate/register consumption, and release-pinned v0.5.0 conformance evidence.

## Spec Reference
- openspec/specs/traverse-integration/spec.md - Traverse runtime boundary and real WASM microservice/agent execution requirements

## Tickets Created
- #129 MVP-036: Adopt Traverse v0.5.0 as the MVP-031 Runtime Baseline
- #130 MVP-037: Consume Traverse v0.5.0 Public App Validate/Register CLI
- #131 MVP-038: Add Release-Pinned Traverse v0.5.0 Conformance Evidence

All three tickets are open, labeled `status:ready`, and set to Ready in Project 3.

## Traverse v0.5.0 Evidence
- Release: https://github.com/enricopiovesan/Traverse/releases/tag/v0.5.0
- Adds `traverse-cli app validate --manifest <path> --json`.
- Adds `traverse-cli app register --manifest <path> --workspace <workspace-id> --json`.
- Keeps v0.4.0 manifest/model-dependency baseline intact.
- Remaining caveat: real WASM agent execution for `knowledge.infer` must still be validated by MVP-031; if missing, create a Traverse blocker.

## Validation
- `PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`
- Result: passed; frontend 5 files / 41 tests passed; OpenSpec validation passed.