### PR TITLE
Consume Traverse v0.5 app registration CLI

### DIFF
--- a/docs/traverse-blocker-escalation.md
+++ b/docs/traverse-blocker-escalation.md
@@ -95,9 +95,9 @@ When a blocker belongs upstream:
 
 ## Current Example
 
-After MVP-037, `scripts/register-traverse-app.sh --json` should consume
-Traverse v0.5.0 public `traverse-cli app validate` and `traverse-cli app
-register` surfaces. If a valid youaskm3 bundle with real component evidence
-then fails because Traverse cannot execute the registered real workflow,
-real WASM microservice, or real WASM agent capability through public surfaces,
-the remaining gap is a Traverse blocker.
+`scripts/register-traverse-app.sh --json` consumes Traverse v0.5.0 public
+`traverse-cli app validate` and `traverse-cli app register` surfaces. If a
+valid youaskm3 bundle with real component evidence validates/registers and then
+fails because Traverse cannot execute the registered real workflow, real WASM
+microservice, or real WASM agent capability through public surfaces, the
+remaining gap is a Traverse blocker.

--- a/scripts/register-traverse-app-smoke.sh
+++ b/scripts/register-traverse-app-smoke.sh
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 cd "$ROOT_DIR"
 
-json_file="$(mktemp "${TMPDIR:-/tmp}/youaskm3-register-traverse-app.XXXXXX.json")"
+json_file="$(mktemp "${TMPDIR:-/tmp}/youaskm3-register-traverse-app.XXXXXX")"
 missing_traverse_dir="$(mktemp -d "${TMPDIR:-/tmp}/youaskm3-missing-traverse.XXXXXX")"
 rmdir "$missing_traverse_dir"
 trap 'rm -f "$json_file"; rm -rf "$missing_traverse_dir"' EXIT

--- a/scripts/register-traverse-app.sh
+++ b/scripts/register-traverse-app.sh
@@ -7,6 +7,7 @@ cd "$ROOT_DIR"
 
 ruby - "$@" <<'RUBY'
 require "json"
+require "open3"
 require "pathname"
 require "set"
 
@@ -19,7 +20,8 @@ options = {
   json: false,
   validate_only: false,
   allow_skeleton: false,
-  traverse_repo: ENV["TRAVERSE_REPO"] || ENV["TRAVERSE_CHECKOUT"]
+  traverse_repo: ENV["TRAVERSE_REPO"] || ENV["TRAVERSE_CHECKOUT"],
+  workspace_id: ENV["TRAVERSE_WORKSPACE_ID"]
 }
 
 until ARGV.empty?
@@ -34,15 +36,19 @@ until ARGV.empty?
   when "--traverse-repo"
     options[:traverse_repo] = ARGV.shift
     abort "--traverse-repo requires a path" if options[:traverse_repo].nil? || options[:traverse_repo].empty?
+  when "--workspace"
+    options[:workspace_id] = ARGV.shift
+    abort "--workspace requires a workspace id" if options[:workspace_id].nil? || options[:workspace_id].empty?
   when "--help", "-h"
     puts <<~HELP
-      Usage: bash scripts/register-traverse-app.sh [--json] [--validate-only] [--allow-skeleton] [--traverse-repo PATH]
+      Usage: bash scripts/register-traverse-app.sh [--json] [--validate-only] [--allow-skeleton] [--traverse-repo PATH] [--workspace ID]
 
       Validates and registers the checked-in youaskm3 Traverse application manifest.
 
       --validate-only   Validate local manifest/component/workflow shape without requiring Traverse.
       --allow-skeleton  Treat missing WASM binaries as an expected MVP skeleton state.
       --traverse-repo   Local Traverse checkout. Defaults to TRAVERSE_REPO, TRAVERSE_CHECKOUT, or ../Traverse.
+      --workspace       Workspace id for Traverse CLI registration. Defaults to TRAVERSE_WORKSPACE_ID or manifest workspace_defaults.workspace_id.
       --json            Emit machine-readable evidence.
     HELP
     exit 0
@@ -70,6 +76,32 @@ end
 def git(repo, *args)
   output = IO.popen(["git", "-C", repo.to_s, *args], err: [:child, :out], &:read)
   [$?.exitstatus, output.strip]
+end
+
+def run_traverse_cli(repo, *args)
+  command = ["cargo", "run", "-p", "traverse-cli", "--", *args]
+  stdout, stderr, status = Open3.capture3(*command, chdir: repo.to_s)
+  parsed = JSON.parse(stdout)
+  {
+    "command" => ["traverse-cli", *args],
+    "exit_status" => status.exitstatus,
+    "stdout" => parsed,
+    "stderr_excerpt" => stderr.lines.last(12).join.strip
+  }
+rescue Errno::ENOENT
+  {
+    "command" => ["traverse-cli", *args],
+    "exit_status" => 127,
+    "stdout" => nil,
+    "stderr_excerpt" => "missing required command: cargo"
+  }
+rescue JSON::ParserError
+  {
+    "command" => ["traverse-cli", *args],
+    "exit_status" => status && status.exitstatus,
+    "stdout" => nil,
+    "stderr_excerpt" => [stderr, stdout].join("\n").lines.last(20).join.strip
+  }
 end
 
 def default_traverse_repo
@@ -217,6 +249,8 @@ payload = {
     "zero_digest_components" => zero_digest_components
   },
   "traverse" => {},
+  "cli" => {},
+  "registration" => {},
   "warnings" => warnings,
   "errors" => errors
 }
@@ -244,7 +278,7 @@ if options[:validate_only]
 end
 
 traverse_repo = options[:traverse_repo] || default_traverse_repo
-unless traverse_repo && File.directory?(File.join(traverse_repo, ".git"))
+unless traverse_repo && git(traverse_repo, "rev-parse", "--is-inside-work-tree").first.zero?
   payload["status"] = "failed"
   payload["code"] = "MISSING_TRAVERSE_CHECKOUT"
   payload["errors"] << {
@@ -296,11 +330,81 @@ if missing_wasm.any? && options[:allow_skeleton]
   finish(payload, options, 0)
 end
 
-payload["status"] = "failed"
-payload["code"] = "MISSING_PUBLIC_APP_REGISTRATION_SURFACE"
-payload["errors"] << {
-  "code" => "MISSING_PUBLIC_APP_REGISTRATION_SURFACE",
-  "message" => "Traverse #{MIN_TRAVERSE_TAG} exposes public app validation and local workspace registration through traverse-cli. Wire scripts/register-traverse-app.sh to invoke traverse-cli app validate/register before real youaskm3 registration can complete."
+validate = run_traverse_cli(
+  traverse_repo,
+  "app", "validate",
+  "--manifest", APP_MANIFEST.realpath.to_s,
+  "--json"
+)
+payload["cli"]["validate"] = validate
+
+if validate.fetch("exit_status") != 0 || validate["stdout"].nil? || validate.dig("stdout", "status") != "validated"
+  payload["status"] = "failed"
+  payload["code"] = validate["exit_status"] == 127 ? "MISSING_TRAVERSE_CLI" : "TRAVERSE_CLI_VALIDATION_FAILED"
+  payload["errors"] << {
+    "code" => payload["code"],
+    "message" => "Traverse CLI app validation failed.",
+    "details" => validate["stdout"] || validate["stderr_excerpt"]
+  }
+  finish(payload, options, 5)
+end
+
+workspace_id = options[:workspace_id] || app.dig("workspace_defaults", "workspace_id")
+if workspace_id.nil? || workspace_id.empty?
+  payload["status"] = "failed"
+  payload["code"] = "MISSING_WORKSPACE_ID"
+  payload["errors"] << {
+    "code" => "MISSING_WORKSPACE_ID",
+    "message" => "Provide --workspace, TRAVERSE_WORKSPACE_ID, or workspace_defaults.workspace_id in the app manifest."
+  }
+  finish(payload, options, 5)
+end
+
+register = run_traverse_cli(
+  traverse_repo,
+  "app", "register",
+  "--manifest", APP_MANIFEST.realpath.to_s,
+  "--workspace", workspace_id,
+  "--json"
+)
+payload["cli"]["register"] = register
+
+if register.fetch("exit_status") != 0 || register["stdout"].nil?
+  payload["status"] = "failed"
+  payload["code"] = register["exit_status"] == 127 ? "MISSING_TRAVERSE_CLI" : "TRAVERSE_CLI_REGISTRATION_FAILED"
+  payload["errors"] << {
+    "code" => payload["code"],
+    "message" => "Traverse CLI app registration failed.",
+    "details" => register["stdout"] || register["stderr_excerpt"]
+  }
+  finish(payload, options, 5)
+end
+
+registration_status = register.dig("stdout", "status")
+unless %w[registered already_registered].include?(registration_status)
+  payload["status"] = "failed"
+  payload["code"] = "TRAVERSE_CLI_REGISTRATION_FAILED"
+  payload["errors"] << {
+    "code" => "TRAVERSE_CLI_REGISTRATION_FAILED",
+    "message" => "Traverse CLI app registration returned #{registration_status.inspect}.",
+    "details" => register["stdout"]
+  }
+  finish(payload, options, 5)
+end
+
+payload["status"] = registration_status
+payload["code"] = registration_status == "already_registered" ? "ALREADY_REGISTERED" : "REGISTERED"
+payload["registration"] = {
+  "workspace_id" => register.dig("stdout", "workspace_id"),
+  "app_id" => register.dig("stdout", "app_id"),
+  "app_version" => register.dig("stdout", "app_version"),
+  "state_scope" => register.dig("stdout", "state_scope"),
+  "state_path" => register.dig("stdout", "state_path"),
+  "component_ids" => register.dig("stdout", "component_ids"),
+  "workflow_ids" => register.dig("stdout", "workflow_ids"),
+  "digest_verification" => register.dig("stdout", "digest_verification"),
+  "model_readiness" => register.dig("stdout", "model_readiness"),
+  "links" => register.dig("stdout", "links")
 }
-finish(payload, options, 5)
+finish(payload, options, 0)
 RUBY

--- a/scripts/traverse-answer-workflow-smoke.sh
+++ b/scripts/traverse-answer-workflow-smoke.sh
@@ -11,7 +11,7 @@ if [[ -z "$TRAVERSE_REPO" && "$REQUIRED" == "1" && -d "$ROOT_DIR/../Traverse/.gi
   TRAVERSE_REPO="$ROOT_DIR/../Traverse"
 fi
 
-json_file="$(mktemp "${TMPDIR:-/tmp}/youaskm3-answer-workflow.XXXXXX.json")"
+json_file="$(mktemp "${TMPDIR:-/tmp}/youaskm3-answer-workflow.XXXXXX")"
 trap 'rm -f "$json_file"' EXIT
 
 bash scripts/query-answer-workflow-smoke.sh
@@ -59,7 +59,7 @@ unless model_dependencies.any? { |dependency| dependency.fetch("required_capabil
 end
 RUBY
 
-if [[ -z "$TRAVERSE_REPO" || ! -d "$TRAVERSE_REPO/.git" ]]; then
+if [[ -z "$TRAVERSE_REPO" ]] || ! git -C "$TRAVERSE_REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   message="Traverse answer workflow smoke skipped: set TRAVERSE_REPO to run the live Traverse v0.5.0 gate."
   if [[ "$REQUIRED" == "1" ]]; then
     echo "$message" >&2
@@ -81,7 +81,7 @@ when "SKELETON_PENDING_WASM_COMPONENTS"
   abort "expected missing WASM evidence" unless payload.dig("evidence", "missing_wasm_count").to_i.positive?
   abort "expected skipped skeleton status" unless payload.fetch("status") == "skipped_skeleton_pending_wasm"
   puts "Traverse answer workflow smoke reached registration boundary: skeleton pending WASM; execution skipped."
-when "REGISTERED", "VALIDATED"
+when "REGISTERED", "ALREADY_REGISTERED", "VALIDATED"
   abort "registered workflow must expose no errors" unless payload.fetch("errors").empty?
   puts "Traverse answer workflow registration evidence passed."
 else

--- a/scripts/traverse-component-manifests.rb
+++ b/scripts/traverse-component-manifests.rb
@@ -8,6 +8,7 @@ require "set"
 
 ROOT = Pathname.new(__dir__).join("..").realpath
 APP_MANIFEST_PATH = ROOT.join("traverse/youaskm3-app/manifest.json")
+TRAVERSE_CONTRACTS_DIR = ROOT.join("traverse/youaskm3-app/contracts")
 ZERO_DIGEST = "sha256:#{"0" * 64}"
 REQUIRED_COMPONENT_FIELDS = %w[
   component_id
@@ -73,10 +74,85 @@ def checked_write(path, data, check:)
   end
 end
 
+def traverse_component_targets(contract_targets)
+  contract_targets.map do |target|
+    case target
+    when "server"
+      "cloud"
+    when "mcp"
+      nil
+    else
+      target
+    end
+  end.compact.uniq
+end
+
+def traverse_contract_for(contract)
+  capability_id = contract.fetch("id")
+  namespace, name = capability_id.rpartition(".").values_at(0, 2)
+  {
+    "kind" => "capability_contract",
+    "schema_version" => "1.0.0",
+    "id" => capability_id,
+    "namespace" => namespace,
+    "name" => name,
+    "version" => contract.fetch("version"),
+    "lifecycle" => "active",
+    "owner" => {
+      "team" => "youaskm3",
+      "contact" => "maintainers@youaskm3.com"
+    },
+    "summary" => contract.fetch("summary"),
+    "description" => contract.fetch("description"),
+    "inputs" => contract.fetch("inputs"),
+    "outputs" => contract.fetch("outputs"),
+    "preconditions" => [],
+    "postconditions" => [],
+    "side_effects" => [
+      {
+        "kind" => "none",
+        "description" => "Pure governed WASM capability execution."
+      }
+    ],
+    "emits" => [],
+    "consumes" => [],
+    "permissions" => [],
+    "execution" => {
+      "binary_format" => "wasm",
+      "entrypoint" => {
+        "kind" => "wasi-command",
+        "command" => "run"
+      },
+      "preferred_targets" => ["local"],
+      "constraints" => {
+        "host_api_access" => "none",
+        "network_access" => "forbidden",
+        "filesystem_access" => "none"
+      }
+    },
+    "policies" => [],
+    "dependencies" => [],
+    "provenance" => {
+      "source" => "greenfield",
+      "author" => "youaskm3",
+      "created_at" => "2026-06-26T00:00:00Z",
+      "spec_ref" => "openspec/specs/traverse-integration/spec.md",
+      "adr_refs" => [],
+      "exception_refs" => []
+    },
+    "evidence" => [],
+    "service_type" => "stateless",
+    "permitted_targets" => traverse_component_targets(contract.fetch("execution").fetch("permitted_targets")),
+    "artifact_type" => "native"
+  }
+end
+
 app_manifest = read_json(APP_MANIFEST_PATH)
 components = app_manifest.fetch("components")
+component_digest_by_id = components.to_h { |component| [component.fetch("component_id"), component.fetch("digest")] }
 seen_component_ids = Set.new
 missing_binaries = []
+TRAVERSE_CONTRACTS_DIR.mkpath
 
 components.each do |app_component|
   manifest_path = ROOT.join("traverse/youaskm3-app", app_component.fetch("manifest_path")).cleanpath
@@ -90,13 +166,15 @@ components.each do |app_component|
   abort "Duplicate component_id in app manifest: #{component_id}" unless seen_component_ids.add?(component_id)
   abort "#{relative(manifest_path)} component_id does not match app manifest" unless component.fetch("component_id") == component_id
 
-  contract_path = manifest_path.dirname.join(component.fetch("contract_path")).cleanpath
+  contract_path = ROOT.join("contracts/capabilities/#{component.fetch("capability_id")}.json").cleanpath
   abort "Missing capability contract: #{relative(contract_path)}" unless contract_path.file?
 
   contract = read_json(contract_path)
   capability_id = contract.fetch("id")
   capability_version = contract.fetch("version")
   abort "#{relative(manifest_path)} capability_id does not match #{relative(contract_path)}" unless component.fetch("capability_id") == capability_id
+  traverse_contract_path = TRAVERSE_CONTRACTS_DIR.join("#{capability_id}.contract.json")
+  checked_write(traverse_contract_path, traverse_contract_for(contract), check: options[:check])
 
   wasm_binary_path = manifest_path.dirname.join(component.fetch("wasm_binary_path")).cleanpath
   if wasm_binary_path.file?
@@ -121,9 +199,13 @@ components.each do |app_component|
 
   component["version"] = app_component.fetch("version")
   component["capability_version"] = capability_version
+  component["contract_path"] = traverse_contract_path.relative_path_from(manifest_path.dirname).to_s
   component["wasm_digest"] = digest
   component["implementation_status"] = implementation_status
-  component["permitted_targets"] = contract.fetch("execution").fetch("permitted_targets")
+  component["permitted_targets"] = traverse_component_targets(contract.fetch("execution").fetch("permitted_targets"))
+  component.fetch("dependencies", []).each do |dependency|
+    dependency["digest"] = component_digest_by_id.fetch(dependency.fetch("component_id"))
+  end
   component["validation_evidence"] = validation_evidence
 
   app_component["digest"] = digest

--- a/scripts/traverse-mcp-answer-workflow-smoke.sh
+++ b/scripts/traverse-mcp-answer-workflow-smoke.sh
@@ -44,7 +44,6 @@ workflow_path = "traverse/youaskm3-app/#{workflow_entry.fetch("path")}"
 workflow = read_json(workflow_path)
 abort "query answer workflow id mismatch" unless workflow.fetch("id") == workflow_entry.fetch("workflow_id")
 abort "app manifest must expose MCP public surface" unless app.fetch("public_surfaces").include?("mcp")
-abort "app placement policy must permit MCP" unless app.fetch("placement_policy").fetch("permitted_targets").include?("mcp")
 
 mcp_tools = read_json("contracts/mcp-tools.json").fetch("tools")
 mcp_tool = mcp_tools.find { |tool| tool.fetch("name") == "knowledge.query.answer" }
@@ -62,8 +61,7 @@ abort "app manifest missing query answer component" unless query_component_entry
 query_component_path = "traverse/youaskm3-app/#{query_component_entry.fetch("manifest_path")}"
 query_component = read_json(query_component_path)
 abort "query answer component capability mismatch" unless query_component.fetch("capability_id") == "knowledge.query.answer"
-abort "query answer component must permit MCP" unless query_component.fetch("permitted_targets").include?("mcp")
-abort "query answer component contract mismatch" unless relative_contract_path(query_component_path, query_component) == mcp_tool.fetch("contract_path")
+abort "query answer component must permit local placement" unless query_component.fetch("permitted_targets").include?("local")
 
 query_contract = read_json(mcp_tool.fetch("contract_path"))
 abort "query answer contract id mismatch" unless query_contract.fetch("id") == mcp_tool.fetch("capability_id")
@@ -106,12 +104,14 @@ workflow_capabilities.each do |capability_id|
   manifest_path, manifest = component_by_capability.fetch(capability_id) do
     abort "workflow capability #{capability_id} is not registered as an app component"
   end
-  abort "#{capability_id} component must permit MCP" unless manifest.fetch("permitted_targets").include?("mcp")
+  abort "#{capability_id} component must permit local placement" unless manifest.fetch("permitted_targets").include?("local")
 
-  contract = read_json(relative_contract_path(manifest_path, manifest))
-  abort "#{capability_id} contract id mismatch" unless contract.fetch("id") == capability_id
-  abort "#{capability_id} contract must permit MCP" unless contract.fetch("execution").fetch("permitted_targets").include?("mcp")
-  abort "#{capability_id} contract must require trace" unless contract.fetch("execution").fetch("requires_trace") == true
+  traverse_contract = read_json(relative_contract_path(manifest_path, manifest))
+  abort "#{capability_id} Traverse contract id mismatch" unless traverse_contract.fetch("id") == capability_id
+
+  product_contract = read_json("contracts/capabilities/#{capability_id}.json")
+  abort "#{capability_id} product contract must permit MCP" unless product_contract.fetch("execution").fetch("permitted_targets").include?("mcp")
+  abort "#{capability_id} product contract must require trace" unless product_contract.fetch("execution").fetch("requires_trace") == true
 end
 
 format_contract = read_json("contracts/capabilities/knowledge.answer.format.json")
@@ -121,7 +121,7 @@ abort "answer format contract must support MCP target" unless target_enum.includ
 puts "Traverse MCP answer workflow local parity checks passed."
 RUBY
 
-if [[ -z "$TRAVERSE_REPO" || ! -d "$TRAVERSE_REPO/.git" ]]; then
+if [[ -z "$TRAVERSE_REPO" ]] || ! git -C "$TRAVERSE_REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   message="Traverse MCP answer workflow smoke skipped: set TRAVERSE_REPO to run the live Traverse MCP parity gate."
   if [[ "$REQUIRED" == "1" ]]; then
     echo "$message" >&2

--- a/scripts/traverse-readiness.sh
+++ b/scripts/traverse-readiness.sh
@@ -97,7 +97,7 @@ if [[ -z "$traverse_tag" ]]; then
   traverse_tag="$(git -C "$TRAVERSE_REPO" describe --tags --abbrev=12 --always)"
 fi
 
-log_file="$(mktemp "${TMPDIR:-/tmp}/youaskm3-traverse-readiness.XXXXXX.log")"
+log_file="$(mktemp "${TMPDIR:-/tmp}/youaskm3-traverse-readiness.XXXXXX")"
 trap 'rm -f "$log_file"' EXIT
 
 echo "Checking Traverse readiness..."

--- a/traverse/youaskm3-app/README.md
+++ b/traverse/youaskm3-app/README.md
@@ -119,15 +119,12 @@ bash scripts/register-traverse-app.sh --validate-only --json
 TRAVERSE_REPO=/path/to/Traverse bash scripts/register-traverse-app.sh --json
 ```
 
-`--validate-only` is CI-safe and does not require a Traverse checkout. Real
-registration requires Traverse `v0.5.0` or newer and real WASM component
-artifacts.
-
-Traverse v0.5.0 exposes public local-dev app validation and registration through
-`traverse-cli app validate` and `traverse-cli app register`. Until
-`scripts/register-traverse-app.sh` consumes those commands directly, the
-remaining work is tracked as youaskm3 implementation work, not a Traverse
-surface gap.
+`--validate-only` is CI-safe and does not require a Traverse checkout. With
+`TRAVERSE_REPO` set to Traverse `v0.5.0` or newer and real WASM component
+artifacts present, the wrapper invokes public `traverse-cli app validate` and
+`traverse-cli app register` and returns the CLI-produced validation,
+registration, digest, workspace, app, workflow, model-readiness, and failure
+evidence in its JSON output.
 
 The end-to-end answer workflow integration gate is:
 
@@ -140,9 +137,9 @@ The gate validates prepared search artifacts, graph source evidence, public
 trace requirements, model dependency policy, Traverse `v0.5.0` readiness, and
 the app registration boundary. Without `TRAVERSE_REPO`, it validates local
 youaskm3 artifacts and skips the live Traverse step so default smoke remains
-CI-safe. With real component artifacts available, the live Traverse step should
-validate/register through Traverse v0.5.0 public CLI surfaces or return a stable
-youaskm3 implementation/setup error that is tracked by MVP-037.
+CI-safe. With real component artifacts available, the live Traverse step
+validates/registers through Traverse v0.5.0 public CLI surfaces or returns a
+stable youaskm3 implementation/setup error.
 
 The MCP parity gate is:
 

--- a/traverse/youaskm3-app/components/knowledge-answer-format/component.manifest.json
+++ b/traverse/youaskm3-app/components/knowledge-answer-format/component.manifest.json
@@ -4,7 +4,7 @@
   "schema_version": "1.0.0",
   "capability_id": "knowledge.answer.format",
   "capability_version": "0.1.0",
-  "contract_path": "../../../../contracts/capabilities/knowledge.answer.format.json",
+  "contract_path": "../../contracts/knowledge.answer.format.contract.json",
   "wasm_binary_path": "../../../../target/wasm32-wasip1/release/youaskm3_knowledge_answer_format.wasm",
   "wasm_digest": "sha256:d4ad5b271b43c1caf6ac8eafaf3d955a85b2518e6516dcf1e4e6848d712c0685",
   "implementation_status": "wasm_binary_ready",
@@ -15,8 +15,7 @@
   },
   "permitted_targets": [
     "local",
-    "server",
-    "mcp"
+    "cloud"
   ],
   "dependencies": [],
   "connector_requirements": [],

--- a/traverse/youaskm3-app/components/knowledge-answer-validate/component.manifest.json
+++ b/traverse/youaskm3-app/components/knowledge-answer-validate/component.manifest.json
@@ -4,7 +4,7 @@
   "schema_version": "1.0.0",
   "capability_id": "knowledge.answer.validate",
   "capability_version": "0.1.0",
-  "contract_path": "../../../../contracts/capabilities/knowledge.answer.validate.json",
+  "contract_path": "../../contracts/knowledge.answer.validate.contract.json",
   "wasm_binary_path": "../../../../target/wasm32-wasip1/release/youaskm3_knowledge_answer_validate.wasm",
   "wasm_digest": "sha256:173f42ff50bc9ae05baddd504f880525965e3658695020cae121008f1ac452d8",
   "implementation_status": "wasm_binary_ready",
@@ -15,8 +15,7 @@
   },
   "permitted_targets": [
     "local",
-    "server",
-    "mcp"
+    "cloud"
   ],
   "dependencies": [],
   "connector_requirements": [],

--- a/traverse/youaskm3-app/components/knowledge-context-pack/component.manifest.json
+++ b/traverse/youaskm3-app/components/knowledge-context-pack/component.manifest.json
@@ -4,7 +4,7 @@
   "schema_version": "1.0.0",
   "capability_id": "knowledge.context.pack",
   "capability_version": "0.1.0",
-  "contract_path": "../../../../contracts/capabilities/knowledge.context.pack.json",
+  "contract_path": "../../contracts/knowledge.context.pack.contract.json",
   "wasm_binary_path": "../../../../target/wasm32-wasip1/release/youaskm3_knowledge_context_pack.wasm",
   "wasm_digest": "sha256:0a99fd6ac7664dbfdc3e913ff5f85e141bdc6ded9bceec24c64737066008d9bf",
   "implementation_status": "wasm_binary_ready",
@@ -15,8 +15,7 @@
   },
   "permitted_targets": [
     "local",
-    "server",
-    "mcp"
+    "cloud"
   ],
   "dependencies": [],
   "connector_requirements": [],

--- a/traverse/youaskm3-app/components/knowledge-graph-expand/component.manifest.json
+++ b/traverse/youaskm3-app/components/knowledge-graph-expand/component.manifest.json
@@ -4,7 +4,7 @@
   "schema_version": "1.0.0",
   "capability_id": "knowledge.graph.expand",
   "capability_version": "0.1.0",
-  "contract_path": "../../../../contracts/capabilities/knowledge.graph.expand.json",
+  "contract_path": "../../contracts/knowledge.graph.expand.contract.json",
   "wasm_binary_path": "../../../../target/wasm32-wasip1/release/youaskm3_knowledge_graph_expand.wasm",
   "wasm_digest": "sha256:4a7cbb539d76657467ac773c5b5aa6e2d16eaca98eecb1b854a453c7ee8ba78e",
   "implementation_status": "wasm_binary_ready",
@@ -15,8 +15,7 @@
   },
   "permitted_targets": [
     "local",
-    "server",
-    "mcp"
+    "cloud"
   ],
   "dependencies": [],
   "connector_requirements": [],

--- a/traverse/youaskm3-app/components/knowledge-infer/component.manifest.json
+++ b/traverse/youaskm3-app/components/knowledge-infer/component.manifest.json
@@ -4,7 +4,7 @@
   "schema_version": "1.0.0",
   "capability_id": "knowledge.infer",
   "capability_version": "0.1.0",
-  "contract_path": "../../../../contracts/capabilities/knowledge.infer.json",
+  "contract_path": "../../contracts/knowledge.infer.contract.json",
   "wasm_binary_path": "../../../../target/wasm32-wasip1/release/youaskm3_knowledge_infer.wasm",
   "wasm_digest": "sha256:e4ad1417c2b9b059a4f3db48f6368c801b115a974533e72cdd63ab0f54a42340",
   "implementation_status": "wasm_binary_ready",
@@ -15,8 +15,7 @@
   },
   "permitted_targets": [
     "local",
-    "server",
-    "mcp"
+    "cloud"
   ],
   "dependencies": [],
   "connector_requirements": [],

--- a/traverse/youaskm3-app/components/knowledge-query-answer/component.manifest.json
+++ b/traverse/youaskm3-app/components/knowledge-query-answer/component.manifest.json
@@ -4,7 +4,7 @@
   "schema_version": "1.0.0",
   "capability_id": "knowledge.query.answer",
   "capability_version": "0.1.0",
-  "contract_path": "../../../../contracts/capabilities/knowledge.query.answer.json",
+  "contract_path": "../../contracts/knowledge.query.answer.contract.json",
   "wasm_binary_path": "../../../../target/wasm32-wasip1/release/youaskm3_knowledge_query_answer.wasm",
   "wasm_digest": "sha256:9edbbe4b12962c1b4220000a6d513e6e5e07d32d09db53d009370cc28dd73f41",
   "implementation_status": "wasm_binary_ready",
@@ -15,33 +15,38 @@
   },
   "permitted_targets": [
     "local",
-    "server",
-    "mcp"
+    "cloud"
   ],
   "dependencies": [
     {
       "component_id": "youaskm3.knowledge.retrieve-component",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "digest": "sha256:e4d078b9a4e894e41521f051929d43f662bcce71f84f36ff6b1edfe633146d33"
     },
     {
       "component_id": "youaskm3.knowledge.graph-expand-component",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "digest": "sha256:4a7cbb539d76657467ac773c5b5aa6e2d16eaca98eecb1b854a453c7ee8ba78e"
     },
     {
       "component_id": "youaskm3.knowledge.context-pack-component",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "digest": "sha256:0a99fd6ac7664dbfdc3e913ff5f85e141bdc6ded9bceec24c64737066008d9bf"
     },
     {
       "component_id": "youaskm3.knowledge.infer-component",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "digest": "sha256:e4ad1417c2b9b059a4f3db48f6368c801b115a974533e72cdd63ab0f54a42340"
     },
     {
       "component_id": "youaskm3.knowledge.answer-validate-component",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "digest": "sha256:173f42ff50bc9ae05baddd504f880525965e3658695020cae121008f1ac452d8"
     },
     {
       "component_id": "youaskm3.knowledge.answer-format-component",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "digest": "sha256:d4ad5b271b43c1caf6ac8eafaf3d955a85b2518e6516dcf1e4e6848d712c0685"
     }
   ],
   "connector_requirements": [],

--- a/traverse/youaskm3-app/components/knowledge-retrieve/component.manifest.json
+++ b/traverse/youaskm3-app/components/knowledge-retrieve/component.manifest.json
@@ -4,7 +4,7 @@
   "schema_version": "1.0.0",
   "capability_id": "knowledge.retrieve",
   "capability_version": "0.1.0",
-  "contract_path": "../../../../contracts/capabilities/knowledge.retrieve.json",
+  "contract_path": "../../contracts/knowledge.retrieve.contract.json",
   "wasm_binary_path": "../../../../target/wasm32-wasip1/release/youaskm3_knowledge_retrieve.wasm",
   "wasm_digest": "sha256:e4d078b9a4e894e41521f051929d43f662bcce71f84f36ff6b1edfe633146d33",
   "implementation_status": "wasm_binary_ready",
@@ -15,8 +15,7 @@
   },
   "permitted_targets": [
     "local",
-    "server",
-    "mcp"
+    "cloud"
   ],
   "dependencies": [],
   "connector_requirements": [],

--- a/traverse/youaskm3-app/contracts/knowledge.answer.format.contract.json
+++ b/traverse/youaskm3-app/contracts/knowledge.answer.format.contract.json
@@ -1,0 +1,144 @@
+{
+  "kind": "capability_contract",
+  "schema_version": "1.0.0",
+  "id": "knowledge.answer.format",
+  "namespace": "knowledge.answer",
+  "name": "format",
+  "version": "0.1.0",
+  "lifecycle": "active",
+  "owner": {
+    "team": "youaskm3",
+    "contact": "maintainers@youaskm3.com"
+  },
+  "summary": "Format validated answer envelopes for chat and MCP clients.",
+  "description": "Shapes final answer text, citations, source cards, graph evidence, and trace references without changing business meaning.",
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "raw_answer": {
+          "type": "string"
+        },
+        "citations": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "graph_evidence": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "validation": {
+          "type": "object"
+        },
+        "target": {
+          "type": "string",
+          "enum": [
+            "chat",
+            "mcp"
+          ]
+        },
+        "trace_id": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "raw_answer",
+        "citations",
+        "graph_evidence",
+        "validation",
+        "target",
+        "trace_id"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "answer": {
+          "type": "string"
+        },
+        "source_cards": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "graph_cards": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "trace_id": {
+          "type": "string"
+        },
+        "display_status": {
+          "type": "string",
+          "enum": [
+            "grounded",
+            "needs_review",
+            "failed"
+          ]
+        }
+      },
+      "required": [
+        "answer",
+        "source_cards",
+        "graph_cards",
+        "trace_id",
+        "display_status"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "preconditions": [],
+  "postconditions": [],
+  "side_effects": [
+    {
+      "kind": "none",
+      "description": "Pure governed WASM capability execution."
+    }
+  ],
+  "emits": [],
+  "consumes": [],
+  "permissions": [],
+  "execution": {
+    "binary_format": "wasm",
+    "entrypoint": {
+      "kind": "wasi-command",
+      "command": "run"
+    },
+    "preferred_targets": [
+      "local"
+    ],
+    "constraints": {
+      "host_api_access": "none",
+      "network_access": "forbidden",
+      "filesystem_access": "none"
+    }
+  },
+  "policies": [],
+  "dependencies": [],
+  "provenance": {
+    "source": "greenfield",
+    "author": "youaskm3",
+    "created_at": "2026-06-26T00:00:00Z",
+    "spec_ref": "openspec/specs/traverse-integration/spec.md",
+    "adr_refs": [],
+    "exception_refs": []
+  },
+  "evidence": [],
+  "service_type": "stateless",
+  "permitted_targets": [
+    "local",
+    "cloud"
+  ],
+  "artifact_type": "native"
+}

--- a/traverse/youaskm3-app/contracts/knowledge.answer.validate.contract.json
+++ b/traverse/youaskm3-app/contracts/knowledge.answer.validate.contract.json
@@ -1,0 +1,150 @@
+{
+  "kind": "capability_contract",
+  "schema_version": "1.0.0",
+  "id": "knowledge.answer.validate",
+  "namespace": "knowledge.answer",
+  "name": "validate",
+  "version": "0.1.0",
+  "lifecycle": "active",
+  "owner": {
+    "team": "youaskm3",
+    "contact": "maintainers@youaskm3.com"
+  },
+  "summary": "Validate answer grounding, citations, and graph evidence.",
+  "description": "Checks that an answer is supported by source chunks and graph evidence before the product renders it as grounded.",
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "answer": {
+          "type": "string"
+        },
+        "citations": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "retrieved_chunks": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "graph_evidence": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "trace_id": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "answer",
+        "citations",
+        "retrieved_chunks",
+        "graph_evidence",
+        "trace_id"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "valid",
+            "invalid",
+            "partial"
+          ]
+        },
+        "checks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "pass",
+                  "fail",
+                  "warn"
+                ]
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "status",
+              "message"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "trace_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "status",
+        "checks",
+        "trace_id"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "preconditions": [],
+  "postconditions": [],
+  "side_effects": [
+    {
+      "kind": "none",
+      "description": "Pure governed WASM capability execution."
+    }
+  ],
+  "emits": [],
+  "consumes": [],
+  "permissions": [],
+  "execution": {
+    "binary_format": "wasm",
+    "entrypoint": {
+      "kind": "wasi-command",
+      "command": "run"
+    },
+    "preferred_targets": [
+      "local"
+    ],
+    "constraints": {
+      "host_api_access": "none",
+      "network_access": "forbidden",
+      "filesystem_access": "none"
+    }
+  },
+  "policies": [],
+  "dependencies": [],
+  "provenance": {
+    "source": "greenfield",
+    "author": "youaskm3",
+    "created_at": "2026-06-26T00:00:00Z",
+    "spec_ref": "openspec/specs/traverse-integration/spec.md",
+    "adr_refs": [],
+    "exception_refs": []
+  },
+  "evidence": [],
+  "service_type": "stateless",
+  "permitted_targets": [
+    "local",
+    "cloud"
+  ],
+  "artifact_type": "native"
+}

--- a/traverse/youaskm3-app/contracts/knowledge.context.pack.contract.json
+++ b/traverse/youaskm3-app/contracts/knowledge.context.pack.contract.json
@@ -1,0 +1,137 @@
+{
+  "kind": "capability_contract",
+  "schema_version": "1.0.0",
+  "id": "knowledge.context.pack",
+  "namespace": "knowledge.context",
+  "name": "pack",
+  "version": "0.1.0",
+  "lifecycle": "active",
+  "owner": {
+    "team": "youaskm3",
+    "contact": "maintainers@youaskm3.com"
+  },
+  "summary": "Build bounded prompt context from retrieved chunks and graph evidence.",
+  "description": "Constructs deterministic context packages inside model limits while preserving source and graph references.",
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "minLength": 1
+        },
+        "retrieved_chunks": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "graph_evidence": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "token_budget": {
+          "type": "integer",
+          "minimum": 256,
+          "maximum": 32768
+        },
+        "trace_id": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "query",
+        "retrieved_chunks",
+        "graph_evidence",
+        "token_budget",
+        "trace_id"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "context": {
+          "type": "string"
+        },
+        "included_chunk_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "included_edge_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "omitted_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "trace_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "context",
+        "included_chunk_ids",
+        "included_edge_ids",
+        "omitted_reasons",
+        "trace_id"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "preconditions": [],
+  "postconditions": [],
+  "side_effects": [
+    {
+      "kind": "none",
+      "description": "Pure governed WASM capability execution."
+    }
+  ],
+  "emits": [],
+  "consumes": [],
+  "permissions": [],
+  "execution": {
+    "binary_format": "wasm",
+    "entrypoint": {
+      "kind": "wasi-command",
+      "command": "run"
+    },
+    "preferred_targets": [
+      "local"
+    ],
+    "constraints": {
+      "host_api_access": "none",
+      "network_access": "forbidden",
+      "filesystem_access": "none"
+    }
+  },
+  "policies": [],
+  "dependencies": [],
+  "provenance": {
+    "source": "greenfield",
+    "author": "youaskm3",
+    "created_at": "2026-06-26T00:00:00Z",
+    "spec_ref": "openspec/specs/traverse-integration/spec.md",
+    "adr_refs": [],
+    "exception_refs": []
+  },
+  "evidence": [],
+  "service_type": "stateless",
+  "permitted_targets": [
+    "local",
+    "cloud"
+  ],
+  "artifact_type": "native"
+}

--- a/traverse/youaskm3-app/contracts/knowledge.graph.expand.contract.json
+++ b/traverse/youaskm3-app/contracts/knowledge.graph.expand.contract.json
@@ -1,0 +1,120 @@
+{
+  "kind": "capability_contract",
+  "schema_version": "1.0.0",
+  "id": "knowledge.graph.expand",
+  "namespace": "knowledge.graph",
+  "name": "expand",
+  "version": "0.1.0",
+  "lifecycle": "active",
+  "owner": {
+    "team": "youaskm3",
+    "contact": "maintainers@youaskm3.com"
+  },
+  "summary": "Expand source-backed graph context around retrieved evidence.",
+  "description": "Consumes graph artifacts and retrieved chunks to return bounded graph evidence for answer context.",
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "graph_path": {
+          "type": "string"
+        },
+        "seed_chunk_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "max_hops": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3
+        },
+        "max_edges": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "trace_id": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "graph_path",
+        "seed_chunk_ids",
+        "trace_id"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "$ref": "knowledge-graph.schema.json#/properties/nodes"
+        },
+        "edges": {
+          "$ref": "knowledge-graph.schema.json#/properties/edges"
+        },
+        "trace_id": {
+          "type": "string"
+        },
+        "failure": {
+          "$ref": "#/$defs/failure"
+        }
+      },
+      "required": [
+        "nodes",
+        "edges",
+        "trace_id"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "preconditions": [],
+  "postconditions": [],
+  "side_effects": [
+    {
+      "kind": "none",
+      "description": "Pure governed WASM capability execution."
+    }
+  ],
+  "emits": [],
+  "consumes": [],
+  "permissions": [],
+  "execution": {
+    "binary_format": "wasm",
+    "entrypoint": {
+      "kind": "wasi-command",
+      "command": "run"
+    },
+    "preferred_targets": [
+      "local"
+    ],
+    "constraints": {
+      "host_api_access": "none",
+      "network_access": "forbidden",
+      "filesystem_access": "none"
+    }
+  },
+  "policies": [],
+  "dependencies": [],
+  "provenance": {
+    "source": "greenfield",
+    "author": "youaskm3",
+    "created_at": "2026-06-26T00:00:00Z",
+    "spec_ref": "openspec/specs/traverse-integration/spec.md",
+    "adr_refs": [],
+    "exception_refs": []
+  },
+  "evidence": [],
+  "service_type": "stateless",
+  "permitted_targets": [
+    "local",
+    "cloud"
+  ],
+  "artifact_type": "native"
+}

--- a/traverse/youaskm3-app/contracts/knowledge.infer.contract.json
+++ b/traverse/youaskm3-app/contracts/knowledge.infer.contract.json
@@ -1,0 +1,115 @@
+{
+  "kind": "capability_contract",
+  "schema_version": "1.0.0",
+  "id": "knowledge.infer",
+  "namespace": "knowledge",
+  "name": "infer",
+  "version": "0.1.0",
+  "lifecycle": "active",
+  "owner": {
+    "team": "youaskm3",
+    "contact": "maintainers@youaskm3.com"
+  },
+  "summary": "Inference dependency resolved and placed by Traverse.",
+  "description": "Declares model inference as a governed capability so youaskm3 does not hardcode local, server, or external providers.",
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "prompt": {
+          "type": "string",
+          "minLength": 1
+        },
+        "context": {
+          "type": "string"
+        },
+        "max_output_tokens": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 8192
+        }
+      },
+      "required": [
+        "prompt",
+        "context"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "text": {
+          "type": "string"
+        },
+        "selected_inference_capability": {
+          "type": "string"
+        },
+        "placement": {
+          "type": "string",
+          "enum": [
+            "local",
+            "server"
+          ]
+        },
+        "trace_id": {
+          "type": "string"
+        },
+        "failure": {
+          "$ref": "#/$defs/failure"
+        }
+      },
+      "required": [
+        "text",
+        "selected_inference_capability",
+        "placement",
+        "trace_id"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "preconditions": [],
+  "postconditions": [],
+  "side_effects": [
+    {
+      "kind": "none",
+      "description": "Pure governed WASM capability execution."
+    }
+  ],
+  "emits": [],
+  "consumes": [],
+  "permissions": [],
+  "execution": {
+    "binary_format": "wasm",
+    "entrypoint": {
+      "kind": "wasi-command",
+      "command": "run"
+    },
+    "preferred_targets": [
+      "local"
+    ],
+    "constraints": {
+      "host_api_access": "none",
+      "network_access": "forbidden",
+      "filesystem_access": "none"
+    }
+  },
+  "policies": [],
+  "dependencies": [],
+  "provenance": {
+    "source": "greenfield",
+    "author": "youaskm3",
+    "created_at": "2026-06-26T00:00:00Z",
+    "spec_ref": "openspec/specs/traverse-integration/spec.md",
+    "adr_refs": [],
+    "exception_refs": []
+  },
+  "evidence": [],
+  "service_type": "stateless",
+  "permitted_targets": [
+    "local",
+    "cloud"
+  ],
+  "artifact_type": "native"
+}

--- a/traverse/youaskm3-app/contracts/knowledge.query.answer.contract.json
+++ b/traverse/youaskm3-app/contracts/knowledge.query.answer.contract.json
@@ -1,0 +1,120 @@
+{
+  "kind": "capability_contract",
+  "schema_version": "1.0.0",
+  "id": "knowledge.query.answer",
+  "namespace": "knowledge.query",
+  "name": "answer",
+  "version": "0.1.0",
+  "lifecycle": "active",
+  "owner": {
+    "team": "youaskm3",
+    "contact": "maintainers@youaskm3.com"
+  },
+  "summary": "User-facing chat answer workflow entrypoint.",
+  "description": "Coordinates retrieval, graph expansion, context packing, inference, validation, and formatting behind the Traverse runtime boundary.",
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "minLength": 1
+        },
+        "conversation_id": {
+          "type": "string"
+        },
+        "artifact_scope": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "max_sources": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 20
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "answer": {
+          "type": "string"
+        },
+        "citations": {
+          "$ref": "#/$defs/citations"
+        },
+        "graph_evidence": {
+          "$ref": "#/$defs/graphEvidence"
+        },
+        "trace_id": {
+          "type": "string"
+        },
+        "validation": {
+          "$ref": "#/$defs/validation"
+        },
+        "failure": {
+          "$ref": "#/$defs/failure"
+        }
+      },
+      "required": [
+        "answer",
+        "citations",
+        "graph_evidence",
+        "trace_id",
+        "validation"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "preconditions": [],
+  "postconditions": [],
+  "side_effects": [
+    {
+      "kind": "none",
+      "description": "Pure governed WASM capability execution."
+    }
+  ],
+  "emits": [],
+  "consumes": [],
+  "permissions": [],
+  "execution": {
+    "binary_format": "wasm",
+    "entrypoint": {
+      "kind": "wasi-command",
+      "command": "run"
+    },
+    "preferred_targets": [
+      "local"
+    ],
+    "constraints": {
+      "host_api_access": "none",
+      "network_access": "forbidden",
+      "filesystem_access": "none"
+    }
+  },
+  "policies": [],
+  "dependencies": [],
+  "provenance": {
+    "source": "greenfield",
+    "author": "youaskm3",
+    "created_at": "2026-06-26T00:00:00Z",
+    "spec_ref": "openspec/specs/traverse-integration/spec.md",
+    "adr_refs": [],
+    "exception_refs": []
+  },
+  "evidence": [],
+  "service_type": "stateless",
+  "permitted_targets": [
+    "local",
+    "cloud"
+  ],
+  "artifact_type": "native"
+}

--- a/traverse/youaskm3-app/contracts/knowledge.retrieve.contract.json
+++ b/traverse/youaskm3-app/contracts/knowledge.retrieve.contract.json
@@ -1,0 +1,142 @@
+{
+  "kind": "capability_contract",
+  "schema_version": "1.0.0",
+  "id": "knowledge.retrieve",
+  "namespace": "knowledge",
+  "name": "retrieve",
+  "version": "0.1.0",
+  "lifecycle": "active",
+  "owner": {
+    "team": "youaskm3",
+    "contact": "maintainers@youaskm3.com"
+  },
+  "summary": "Source-aware retrieval over prepared knowledge artifacts.",
+  "description": "Returns ranked chunks from generated search and markdown artifacts without embedding retrieval behavior in the PWA.",
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "minLength": 1
+        },
+        "artifact_index_path": {
+          "type": "string"
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 50
+        }
+      },
+      "required": [
+        "query",
+        "artifact_index_path"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "results": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "artifact_id": {
+                "type": "string"
+              },
+              "chunk_id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "source_path": {
+                "type": "string"
+              },
+              "excerpt": {
+                "type": "string"
+              },
+              "score": {
+                "type": "number"
+              },
+              "score_basis": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "artifact_id",
+              "chunk_id",
+              "title",
+              "source_path",
+              "excerpt",
+              "score",
+              "score_basis"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "trace_id": {
+          "type": "string"
+        },
+        "failure": {
+          "$ref": "#/$defs/failure"
+        }
+      },
+      "required": [
+        "results",
+        "trace_id"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "preconditions": [],
+  "postconditions": [],
+  "side_effects": [
+    {
+      "kind": "none",
+      "description": "Pure governed WASM capability execution."
+    }
+  ],
+  "emits": [],
+  "consumes": [],
+  "permissions": [],
+  "execution": {
+    "binary_format": "wasm",
+    "entrypoint": {
+      "kind": "wasi-command",
+      "command": "run"
+    },
+    "preferred_targets": [
+      "local"
+    ],
+    "constraints": {
+      "host_api_access": "none",
+      "network_access": "forbidden",
+      "filesystem_access": "none"
+    }
+  },
+  "policies": [],
+  "dependencies": [],
+  "provenance": {
+    "source": "greenfield",
+    "author": "youaskm3",
+    "created_at": "2026-06-26T00:00:00Z",
+    "spec_ref": "openspec/specs/traverse-integration/spec.md",
+    "adr_refs": [],
+    "exception_refs": []
+  },
+  "evidence": [],
+  "service_type": "stateless",
+  "permitted_targets": [
+    "local",
+    "cloud"
+  ],
+  "artifact_type": "native"
+}


### PR DESCRIPTION
## Summary
- replace the old missing-public-surface terminal path in scripts/register-traverse-app.sh with real Traverse v0.5.0 CLI app validate/register calls
- return wrapped machine-readable validation, registration, workspace, app, workflow, digest, model-readiness, and failure evidence
- generate Traverse-compatible app-bundle contract wrappers while keeping product contracts as the source of truth
- update component manifests for Traverse v0.5.0 placement target names and concrete dependency digests
- update local/live smoke gates and docs for idempotent registered/already_registered evidence

Closes #130

## Spec Reference
- openspec/specs/traverse-integration/spec.md
- docs/traverse-mvp-requirements.md

## Validation
- PASS: PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh
- PASS: bash scripts/traverse-component-manifests.sh --check
- PASS: bash scripts/register-traverse-app-smoke.sh
- PASS: TRAVERSE_REPO=/private/tmp/traverse-v0.5.0-readiness bash scripts/register-traverse-app.sh --json
  - result: REGISTERED on first run, ALREADY_REGISTERED on repeat
  - workspace_id: youaskm3-local
  - app_id: youaskm3.knowledge-app
  - component ids: 7
  - workflow ids: 1
  - digest verification: all component WASM digests verified
- PASS: TRAVERSE_REPO=/private/tmp/traverse-v0.5.0-readiness bash scripts/traverse-answer-workflow-smoke.sh
  - Traverse tag: v0.5.0
  - Traverse commit: decc2d7
  - readiness areas passed: application bundle registration, WASM workflow execution, model dependency resolution, HTTP/JSON app path, MCP parity path
  - live local model conformance: optional skipped

## Notes
- Validation used an isolated Traverse v0.5.0 worktree at /private/tmp/traverse-v0.5.0-readiness so the active Traverse feature branch was not changed.