### PR TITLE
Document Traverse v0.5 readiness evidence

### DIFF
--- a/docs/traverse-mvp-requirements.md
+++ b/docs/traverse-mvp-requirements.md
@@ -559,6 +559,7 @@ The wrapper looks for a local Traverse checkout at `../Traverse` by default. Use
 Traverse readiness passed.
 Capability areas:
 - application bundle registration: passed
+- public CLI app registration: passed
 - WASM workflow execution: passed
 - model dependency resolution: passed
 - HTTP/JSON app path: passed
@@ -582,7 +583,7 @@ the first-MVP Traverse baseline is satisfied:
 1. Confirm the local Traverse checkout path:
 
    ```bash
-   test -d ../Traverse/.git || test -d "$TRAVERSE_REPO/.git"
+   git -C "${TRAVERSE_REPO:-../Traverse}" rev-parse --is-inside-work-tree
    ```
 
 2. Confirm the checkout contains and is not older than the pinned baseline:
@@ -602,10 +603,15 @@ the first-MVP Traverse baseline is satisfied:
 4. Verify the summary reports these areas as passed:
 
    - application bundle registration
+   - public CLI app registration
    - WASM workflow execution
    - model dependency resolution
    - HTTP/JSON app path
    - MCP parity path
+
+   If the checkout is stale, the wrapper must fail as setup evidence with a
+   message such as `Traverse checkout <commit> is older than v0.5.0`, not as a
+   downstream runtime blocker.
 
 5. Treat live local Ollama model conformance as opt-in evidence only:
 

--- a/scripts/traverse-readiness.sh
+++ b/scripts/traverse-readiness.sh
@@ -6,7 +6,7 @@ MIN_TRAVERSE_TAG="${MIN_TRAVERSE_TAG:-v0.5.0}"
 TRAVERSE_REPO="${TRAVERSE_REPO:-${TRAVERSE_CHECKOUT:-}}"
 
 if [[ -z "$TRAVERSE_REPO" ]]; then
-  if [[ -d "$ROOT_DIR/../Traverse/.git" ]]; then
+  if git -C "$ROOT_DIR/../Traverse" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     TRAVERSE_REPO="$ROOT_DIR/../Traverse"
   else
     echo "Traverse readiness failed: set TRAVERSE_REPO to a local Traverse checkout." >&2
@@ -47,6 +47,7 @@ print_area_summary() {
   echo "Traverse readiness ${status}."
   echo "Capability areas:"
   summarize_area "$log_file" "application bundle registration" "downstream app bundle registration smoke passed."
+  summarize_area "$log_file" "public CLI app registration" "downstream public app registration smoke passed."
   summarize_area "$log_file" "WASM workflow execution" "downstream WASM workflow smoke passed."
   summarize_area "$log_file" "model dependency resolution" "downstream model dependency smoke passed."
   summarize_area "$log_file" "HTTP/JSON app path" "downstream HTTP/JSON smoke passed."


### PR DESCRIPTION
Closes #131

Spec reference: openspec/specs/traverse-integration/spec.md

Summary:
- Adds the public CLI app registration area to the Traverse readiness summary.
- Makes the MVP readiness checklist work with Git worktrees.
- Documents the stale-checkout failure as setup evidence instead of a runtime blocker.

Validation:
- MIN_TRAVERSE_TAG=v0.5.0 TRAVERSE_REPO=/Users/enricopiovesan/Documents/repos/Traverse bash scripts/traverse-readiness.sh failed as expected with stale checkout 0716c05 older than v0.5.0.
- MIN_TRAVERSE_TAG=v0.5.0 TRAVERSE_REPO=/private/tmp/traverse-v0.5.0-readiness bash scripts/traverse-readiness.sh passed against Traverse v0.5.0 commit decc2d7, including application bundle registration, public CLI app registration, WASM workflow execution, model dependency resolution, HTTP/JSON app path, and MCP parity path.
- bash scripts/smoke.sh passed.