### PR TITLE
Add final first MVP missing tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 [![Spec Governed](https://img.shields.io/badge/spec-governed-blueviolet)](openspec/specs/)
 [![License](https://img.shields.io/badge/license-MIT%20%7C%20Apache--2.0-blue)](LICENSE-APACHE)
 [![Rust](https://img.shields.io/badge/rust-1.94%2B-orange)](https://www.rust-lang.org/)
-[![Built on Traverse](https://img.shields.io/badge/built%20on-Traverse-black)](https://github.com/enricopiovesan/Traverse)
+[![Built on Traverse](https://img.shields.io/badge/built%20on-Traverse-black)](https://github.com/traverse-framework/Traverse)
 
 
 **your knowledge, queryable**
 
 youaskm3 is an open source, WASM-native, MCP-powered personal knowledge product for turning your books, papers, notes, and source material into a local-first chat experience you can query, inspect, fork, and evolve in the open.
 
-It is designed on top of [Traverse](https://github.com/enricopiovesan/Traverse) and the broader [Universal Microservices Architecture](https://github.com/enricopiovesan/UMA-code-examples) direction: portable capability contracts, governed specs, and runtime surfaces that stay usable across tools and hosts.
+It is designed on top of [Traverse](https://github.com/traverse-framework/Traverse) and the broader [Universal Microservices Architecture](https://github.com/enricopiovesan/UMA-code-examples) direction: portable capability contracts, governed specs, and runtime surfaces that stay usable across tools and hosts.
 
 ## Why This Exists
 
@@ -173,7 +173,7 @@ This project is set up like a production-minded open source repository:
 
 youaskm3 is not an isolated experiment. It sits in a larger line of work:
 
-- [Traverse](https://github.com/enricopiovesan/Traverse) provides the portable runtime and integration baseline
+- [Traverse](https://github.com/traverse-framework/Traverse) provides the portable runtime and integration baseline
 - [UMA code examples](https://github.com/enricopiovesan/UMA-code-examples) provide the broader architectural direction and reference patterns
 
 Traverse answers the runtime question. youaskm3 applies that model to personal knowledge.
@@ -210,7 +210,7 @@ Dual licensed under [MIT](LICENSE-MIT) and [Apache-2.0](LICENSE-APACHE).
 
 ## Related Work
 
-- [Traverse](https://github.com/enricopiovesan/Traverse)
+- [Traverse](https://github.com/traverse-framework/Traverse)
 - [Universal Microservices Architecture — Book](https://www.amazon.com/dp/B0GTTTTQH4)
 - [Contract-Driven AI Development (C-DAD) — White Paper](https://drive.google.com/file/d/1HC_ZWJl9aYaMeN78qiL3ZYBVY7mAGl3f/view)
 - [Speaking](https://enricopiovesan.github.io/enricopiovesan/)

--- a/SPEC.md
+++ b/SPEC.md
@@ -206,7 +206,7 @@ The first-MVP personas, "As a..., I want..., so that..." stories, capability map
 
 ### Next product-led MVP tranche
 
-After Traverse `v0.5.0` readiness and the first youaskm3 WASM capability tranche, the next highest-ROI work is tracked as MVP-031 through MVP-038 in [docs/mvp-ticket-backlog.md](docs/mvp-ticket-backlog.md):
+After Traverse `v0.5.0` readiness and the first youaskm3 WASM capability tranche, the next highest-ROI work is tracked as MVP-031 through MVP-040 in [docs/mvp-ticket-backlog.md](docs/mvp-ticket-backlog.md):
 
 - prove the local Traverse-backed chat happy path
 - wire real WASM artifacts and component digests for implemented capabilities
@@ -214,6 +214,8 @@ After Traverse `v0.5.0` readiness and the first youaskm3 WASM capability tranche
 - enforce explicit Browser demo fallback semantics
 - create a Traverse blocker escalation template for confirmed upstream gaps
 - adopt the v0.5.0 public CLI app validation/registration baseline
+- implement `knowledge.infer` as a real Traverse-governed WASM agent capability
+- add the final first-MVP acceptance and release gate
 
 These tickets keep youaskm3 product-led while using concrete app evidence to drive Traverse requirements. They must not add downstream runtime/provider shortcuts that bypass Traverse-governed WASM capability execution.
 

--- a/docs/mvp-ticket-backlog.md
+++ b/docs/mvp-ticket-backlog.md
@@ -1151,6 +1151,125 @@ PYTHON=/opt/homebrew/bin/python3.14 \
 bash scripts/smoke.sh
 ```
 
+## Ticket MVP-039: Implement `knowledge.infer` as a Real Traverse-Governed WASM Agent
+
+### Objective
+
+Replace the current recording/validation-only inference behavior with a real Traverse-governed WASM agent capability for `knowledge.infer`.
+
+The first MVP requires real agent behavior for judgement, generation, planning, semantic interpretation, or model use. A capability that only records pre-generated model output is useful plumbing, but it does not satisfy MVP runtime acceptance.
+
+### Scope
+
+Implement or wire `knowledge.infer` so it can execute as a real WASM agent capability through Traverse:
+
+- accepts packed context and inference request data from the Traverse workflow
+- uses Traverse-governed model/capability dependency selection
+- performs the agent execution required to produce answer text
+- returns structured output matching `contracts/capabilities/knowledge.infer.json`
+- records selected dependency, placement, status, failure reason, and trace id
+- fails with governed missing-dependency evidence when no compatible model/capability is available
+
+### Out of Scope
+
+- hardcoding Ollama, WebLLM, llama.cpp, cloud APIs, or provider-specific routing in youaskm3
+- accepting deterministic summary code as a fake replacement for agent behavior
+- accepting pre-generated answer recording as MVP inference
+- changing Traverse internals except through a linked Traverse blocker when public surfaces are insufficient
+- production-quality model answer benchmarking
+
+### Definition of Done
+
+- `knowledge.infer` is implemented as a real WASM agent capability or is blocked by a linked Traverse requirement proving the missing public surface.
+- The implementation compiles for `wasm32-wasip1`.
+- The capability contract clearly identifies the agent behavior, input, output, dependency evidence, failure evidence, and trace fields.
+- Unit tests cover successful agent output, missing prompt/context, missing selected dependency, missing trace id, empty generated output, and governed dependency failure.
+- The Traverse component manifest identifies `knowledge.infer` as a real runtime artifact with a real digest.
+- `knowledge.query.answer` workflow uses the real `knowledge.infer` agent step, not a recording-only shim.
+- PWA, CLI, and tests do not hardcode model providers.
+- If Traverse cannot execute the real WASM agent shape, the youaskm3 issue is marked Blocked and a detailed Traverse blocker is created.
+- `cargo build --locked --workspace --target wasm32-wasip1` passes.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+cargo test --locked --package youaskm3-knowledge-infer
+
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+cargo build --locked --workspace --target wasm32-wasip1
+
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+
+TRAVERSE_REPO=/Users/enricopiovesan/Documents/repos/Traverse \
+bash scripts/traverse-answer-workflow-smoke.sh
+```
+
+## Ticket MVP-040: Add Final First-MVP Acceptance and Release Gate
+
+### Objective
+
+Create the final release gate that proves the entire first MVP end to end from a clean local setup.
+
+This ticket is the point where the project can honestly say the first MVP is complete. It must not count Browser demo, temporary harnesses, contract stubs, fake workflow steps, skeleton manifests, placeholder digests, or downstream provider shortcuts as acceptance evidence.
+
+### Scope
+
+Add a final acceptance command, checklist, or smoke path that proves:
+
+- local source input is converted or normalized into markdown artifacts
+- search and graph artifacts are generated from local knowledge
+- all MVP runtime capabilities build as real WASM microservices or real WASM agents
+- component manifests contain real digests
+- the app bundle validates and registers through Traverse v0.5.0 public CLI surfaces
+- the PWA path asks a question through the real Traverse `knowledge.query.answer` workflow
+- answer text, citations/source references, graph evidence, validation status, and trace reference are present
+- the MCP path exposes equivalent workflow evidence
+- failure cases are classified as setup, downstream implementation, or Traverse blocker
+
+### Out of Scope
+
+- federation discovery or cross-instance fan-out
+- hosted accounts, billing, teams, or databases
+- production hosted model service
+- claiming the model engine itself is WASM-native unless Traverse evidence proves it
+- accepting any placeholder/demo path as release evidence
+
+### Definition of Done
+
+- A single documented acceptance command or ordered checklist exists for the first MVP release gate.
+- The gate starts from a clean local setup and does not rely on pre-opened browser state.
+- The gate validates normal repo health with `bash scripts/smoke.sh`.
+- The gate validates Traverse v0.5.0 readiness or reports a clear setup failure.
+- The gate validates/registers the app bundle through public Traverse CLI surfaces.
+- The gate asks at least one imported-document question through the PWA/Traverse path.
+- The gate asserts non-empty answer text, citations/source references, graph evidence, validation status, and trace reference.
+- The gate exercises MCP parity for the same registered workflow.
+- The gate fails if Browser demo, temporary harnesses, contract stubs, fake workflow steps, skeleton manifests, placeholder digests, or all-zero component evidence are used as acceptance evidence.
+- The final docs list exact remaining caveats, including whether local model execution is optional and whether the model engine itself is WASM-native.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
+PYTHON=/opt/homebrew/bin/python3.14 \
+bash scripts/smoke.sh
+
+MIN_TRAVERSE_TAG=v0.5.0 \
+TRAVERSE_REPO=/Users/enricopiovesan/Documents/repos/Traverse \
+bash scripts/traverse-readiness.sh
+
+TRAVERSE_REPO=/Users/enricopiovesan/Documents/repos/Traverse \
+bash scripts/traverse-answer-workflow-smoke.sh
+
+TRAVERSE_REPO=/Users/enricopiovesan/Documents/repos/Traverse \
+bash scripts/traverse-mcp-answer-workflow-smoke.sh
+```
+
 ## Recommended Parallelization
 
 These tickets can start immediately and independently:
@@ -1187,6 +1306,8 @@ Next highest-ROI tranche after MVP-030:
 - MVP-036 Traverse v0.5.0 baseline adoption
 - MVP-037 public CLI app validate/register consumption
 - MVP-038 release-pinned v0.5.0 conformance evidence
+- MVP-039 real `knowledge.infer` WASM agent
+- MVP-040 final first-MVP acceptance and release gate
 
 ## First Ticket to Start
 

--- a/docs/mvp-user-stories.md
+++ b/docs/mvp-user-stories.md
@@ -2,7 +2,7 @@
 
 Status: First-MVP acceptance guide
 Owner: youaskm3 product/spec alignment
-Last updated: 2026-06-25
+Last updated: 2026-06-27
 
 ## Purpose
 
@@ -126,6 +126,7 @@ Capability and ticket map:
 - MVP-021 local inference readiness policy
 - MVP-030 `knowledge.infer` dependency failure and evidence tests
 - MVP-034 explicit Browser demo fallback semantics
+- MVP-039 real `knowledge.infer` WASM agent
 
 Acceptance criteria:
 
@@ -136,6 +137,7 @@ Acceptance criteria:
 - AND missing local inference capability fails clearly before or during governed execution
 - AND Traverse runtime failures remain visible instead of automatically switching to Browser demo
 - AND generation, judgement, planning, semantic interpretation, or model-use behavior is handled by a real Traverse-governed WASM agent capability
+- AND recording pre-generated model output does not count as real MVP inference
 
 ### MCP And Agent User
 
@@ -175,6 +177,7 @@ Capability and ticket map:
 - MVP-020 MCP parity smoke
 - MVP-028 end-to-end Traverse answer workflow smoke
 - MVP-035 Traverse blocker escalation template
+- MVP-040 final first-MVP acceptance and release gate
 
 Acceptance criteria:
 
@@ -184,6 +187,7 @@ Acceptance criteria:
 - AND readiness commands summarize pass/fail by capability area instead of requiring large log inspection
 - AND remaining gaps are represented as backlog tickets rather than undocumented assumptions
 - AND confirmed missing Traverse public surfaces are escalated upstream with reproduction evidence instead of hidden in downstream workaround code
+- AND first-MVP completion is declared only after the final acceptance gate passes
 
 ## Demo Acceptance Path
 
@@ -199,5 +203,6 @@ The first MVP demo is acceptable when these steps pass from a clean local setup:
 8. Exercise the same answer workflow through MCP parity validation.
 9. Explicitly select Browser demo only when validating the documented no-server fallback path.
 10. Treat any missing real Traverse workflow/capability support as a blocked youaskm3 ticket plus an upstream Traverse requirement, not as permission to add placeholders.
+11. Run the final first-MVP acceptance/release gate and record exact remaining caveats.
 
 The demo must not require a hosted account, hosted database, paid external model service, or product/business logic outside Traverse-governed capabilities.

--- a/docs/traverse-mvp-requirements.md
+++ b/docs/traverse-mvp-requirements.md
@@ -49,7 +49,7 @@ As of 2026-06-26, Traverse `v0.5.0` is the minimum approved first-MVP integratio
 Release:
 
 - Tag: `v0.5.0`
-- URL: https://github.com/enricopiovesan/Traverse/releases/tag/v0.5.0
+- URL: https://github.com/traverse-framework/Traverse/releases/tag/v0.5.0
 - Release date: 2026-06-26
 - Governing Traverse specs: `044-application-bundle-manifest`, `045-governed-model-dependency-resolution`, and `046-public-cli-app-registration`
 
@@ -489,6 +489,12 @@ Business logic:
 - enforce prompt/input contract
 - return structured model output
 
+MVP acceptance requirement:
+
+- `knowledge.infer` must be a real Traverse-governed WASM agent capability when the workflow requires judgement, generation, planning, semantic interpretation, or model use.
+- A downstream crate that only records pre-generated model output does not satisfy MVP inference acceptance.
+- If Traverse cannot execute the required real WASM agent shape through public surfaces, the downstream ticket must be blocked and linked to an upstream Traverse requirement.
+
 ### `knowledge.answer.validate`
 
 Purpose: verify answer grounding.
@@ -540,6 +546,7 @@ Traverse should provide or extend validation scripts that prove:
 6. Failure to satisfy a model dependency fails deterministically.
 7. Browser/PWA consumption works without private Traverse internals.
 8. The conformance suite can run from a pinned release tag.
+9. The downstream final first-MVP acceptance gate can classify failures as setup, downstream implementation, or Traverse blocker evidence.
 
 Required Traverse validation command:
 
@@ -669,6 +676,8 @@ Traverse should only care about these external tools if the downstream app wraps
 Traverse is ready for this downstream MVP when the downstream app can honestly say:
 
 > The UI sends a user request to Traverse. Traverse executes all product/business behavior as governed WASM capabilities, resolves the needed inference capability, selects placement, records a trace, and exposes the same behavior through HTTP/JSON and MCP. The downstream app does not contain alternate business logic paths.
+
+The downstream app is ready to call the first MVP complete only when a final acceptance/release gate proves the complete local setup, bundle validation/registration, PWA question path, source/citation evidence, graph evidence, validation status, trace evidence, and MCP parity without Browser demo, temporary harnesses, contract stubs, fake workflow steps, skeleton manifests, placeholder digests, or downstream runtime shortcuts.
 
 ## Summary
 

--- a/openspec/specs/pwa-shell/spec.md
+++ b/openspec/specs/pwa-shell/spec.md
@@ -69,3 +69,14 @@ The system SHALL support an acceptance path where a repo-safe fixture document i
 - THEN the PWA renders answer text with at least one source reference
 - AND the PWA renders graph or context evidence from the generated artifacts
 - AND the response includes validation status and trace evidence
+
+### Requirement: Support final first-MVP acceptance rendering
+
+The system SHALL render the final first-MVP acceptance response and evidence returned by Traverse without depending on Browser demo or hidden browser-side business logic.
+
+#### Scenario: Render final MVP acceptance evidence
+
+- GIVEN the final first-MVP acceptance gate has executed the real Traverse workflow
+- WHEN the PWA displays the result
+- THEN it renders the answer, citations, graph evidence, validation state, and trace reference from Traverse-owned response data
+- AND no browser-side fallback output is counted as release acceptance evidence

--- a/openspec/specs/traverse-integration/spec.md
+++ b/openspec/specs/traverse-integration/spec.md
@@ -96,6 +96,24 @@ The system SHALL implement `knowledge.infer` as a real Traverse-governed WASM ag
 - AND model dependency selection, placement, success, or failure is captured in governed trace evidence
 - AND deterministic microservice logic is not used as a fake replacement for the agent behavior
 
+#### Scenario: Reject recording-only inference as MVP acceptance
+
+- GIVEN `knowledge.infer` receives a packed context and a Traverse-selected inference dependency
+- WHEN the first-MVP workflow requires generated answer text
+- THEN the capability performs real agent execution through Traverse-governed WASM agent behavior
+- AND a crate that only records pre-generated model output does not satisfy MVP acceptance
+
+### Requirement: Prove final first-MVP acceptance end to end
+
+The system SHALL provide a final first-MVP acceptance gate that proves the complete local-first product path without Browser demo, placeholder manifests, contract stubs, fake workflow steps, or downstream runtime shortcuts.
+
+#### Scenario: Complete the first-MVP release gate
+
+- GIVEN a clean checkout with required local tools and a Traverse v0.5.0-or-newer runtime
+- WHEN the final MVP acceptance gate runs
+- THEN the CLI prepares artifacts, builds real WASM microservices and WASM agents, validates/registers the app bundle through public Traverse surfaces, asks an imported-document question through the PWA path, and verifies answer text, citations, graph evidence, validation status, trace evidence, and MCP parity
+- AND every failed prerequisite is reported as setup, downstream implementation, or Traverse blocker evidence
+
 ### Requirement: Escalate confirmed Traverse blockers upstream
 
 The system SHALL capture confirmed missing Traverse public surfaces as upstream Traverse requirements instead of adding downstream runtime shortcuts.

--- a/scripts/traverse-answer-workflow-smoke.sh
+++ b/scripts/traverse-answer-workflow-smoke.sh
@@ -7,7 +7,8 @@ REQUIRED="${TRAVERSE_ANSWER_WORKFLOW_REQUIRED:-0}"
 
 cd "$ROOT_DIR"
 
-if [[ -z "$TRAVERSE_REPO" && "$REQUIRED" == "1" && -d "$ROOT_DIR/../Traverse/.git" ]]; then
+if [[ -z "$TRAVERSE_REPO" && "$REQUIRED" == "1" ]] &&
+  git -C "$ROOT_DIR/../Traverse" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   TRAVERSE_REPO="$ROOT_DIR/../Traverse"
 fi
 

--- a/traverse/youaskm3-app/README.md
+++ b/traverse/youaskm3-app/README.md
@@ -13,7 +13,7 @@ validation and local workspace registration surfaces added in Traverse v0.5.0.
 
 - Minimum Traverse release: `v0.5.0`
 - Traverse release date: 2026-06-26
-- Traverse release: <https://github.com/enricopiovesan/Traverse/releases/tag/v0.5.0>
+- Traverse release: <https://github.com/traverse-framework/Traverse/releases/tag/v0.5.0>
 - Governing Traverse specs:
   - `044-application-bundle-manifest`
   - `045-governed-model-dependency-resolution`


### PR DESCRIPTION
## Summary
- Adds MVP-039 for implementing `knowledge.infer` as a real Traverse-governed WASM agent.
- Adds MVP-040 for the final first-MVP acceptance and release gate.
- Updates SPEC, OpenSpec, user stories, and Traverse requirements so recording-only inference and demo/placeholder paths cannot satisfy MVP acceptance.

## Spec Reference
- openspec/specs/traverse-integration/spec.md - real WASM agent inference and final first-MVP acceptance gate
- openspec/specs/pwa-shell/spec.md - final MVP acceptance rendering without Browser demo evidence

## Tickets Created
- #135 MVP-039: Implement knowledge.infer as a Real Traverse-Governed WASM Agent
- #136 MVP-040: Add Final First-MVP Acceptance and Release Gate

Both tickets are open, labeled `status:ready`, and set to Ready in Project 3.

## Validation
- `PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`
- Result: passed; frontend 5 files / 41 tests passed; OpenSpec validation passed.