### PR TITLE
Define expanded second-brain MVP tranche

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -13,13 +13,13 @@
 
 ## 1. Vision
 
-youaskm3 is an open source, WASM-native, MCP-powered personal knowledge product. It ingests everything you write, read, and save — books, white papers, blog posts, YouTube transcripts, articles, notes — and turns those files into a local-first chat experience grounded in user-owned markdown, search, chunk, and graph artifacts.
+youaskm3 is an open source, WASM-native, MCP-powered personal knowledge product. It ingests everything you write, read, and save — books, white papers, blog posts, YouTube transcripts, articles, notes, and structured reasoning logs — and turns those files into a local-first chat experience grounded in user-owned markdown, search, chunk, and graph artifacts.
 
-The system answers as *you*: in your voice, from your accumulated thinking.
+The system answers as *you*: in your voice, from your accumulated thinking. Its core product loop is not only retrieval over files; it is a second-brain reasoning loop where a persona works with an assistant to clarify concepts, challenge assumptions, record decisions, turn the resulting decision log into durable knowledge, update the graph, and defer back to the human when knowledge is missing, uncertain, or conflicting.
 
 Anyone can fork it, fill it with their own knowledge, and run their own instance for free on GitHub Pages. Runtime business behavior is delegated to Traverse as governed WASM capabilities so the same application logic can run locally, on a server, or through MCP as Traverse placement improves. Instances can optionally federate through a shared registry, making knowledge discoverable across the network.
 
-**Core promise:** no mandatory hosted service, no database, no lock-in. Git is the infrastructure, the browser is the product surface, and Traverse is the portable business-logic runtime.
+**Core promise:** no mandatory hosted service, no database, no lock-in. Git and local files are the infrastructure, chat is the product surface, and Traverse is the portable business-logic runtime.
 
 ---
 
@@ -32,8 +32,9 @@ Anyone can fork it, fill it with their own knowledge, and run their own instance
 5. **Production quality from day one.** No prototype shortcuts in core paths. Quality standards apply from the first commit.
 6. **Open by default.** Apache-2.0 licensed. Designed to be forked, extended, and contributed to.
 7. **Git as infrastructure.** Knowledge store, registry, deployment, and history are all git-native. No mandatory external services required.
-8. **UI-only product shell.** The PWA renders chat, sources, graph context, and traces; it does not own retrieval, ranking, graph traversal, context packing, inference selection, answer validation, or response formatting.
-9. **CLI as artifact builder.** The CLI may convert files, normalize markdown, write artifacts, build, sync, serve, and register bundles; product semantics belong in Traverse-run capabilities.
+8. **UI-only product shell.** The PWA renders chat, sources, graph context, gaps, conflicts, and traces; it does not own retrieval, ranking, graph traversal, context packing, inference selection, answer validation, response formatting, gap lifecycle, graph extraction, or sync conflict policy.
+9. **CLI as artifact and setup manager.** The CLI may convert files, normalize markdown, ingest decision-log packages, write artifacts, build, sync, serve, and register bundles; product semantics belong in Traverse-run capabilities.
+10. **Reasoning logs are first-class knowledge.** Decision-log packages from LLM-agnostic reasoning skills are first-class inputs to the knowledge store and graph, with provenance, validation, and gap/conflict handling.
 
 ---
 
@@ -63,6 +64,7 @@ Anyone can fork it, fill it with their own knowledge, and run their own instance
 | Conversion | **MarkItDown** | Default source-to-markdown conversion layer for supported office, PDF, and document formats |
 | Chunks | **Static JSON + markdown refs** | Deterministic context units with source and section evidence |
 | Graph | **Static JSON graph artifact** | Source-aware nodes and edges for graph-backed context |
+| Reasoning packages | **Decision-log package directories** | `decision-log.md`, `knowledge-note.md`, and `metadata.json` from LLM-agnostic assistant reasoning sessions |
 | Diagrams | **Mermaid** | Plain text, renders in GitHub, LLM-readable |
 | Index | **Static JSON** | Generated at build time, no DB needed |
 | Search | **WASM retrieval capability** | Runs through Traverse locally or remotely based on placement |
@@ -136,6 +138,10 @@ youaskm3/
 │   ├── books/
 │   ├── papers/
 │   ├── blog/
+│   ├── gaps/                   ← structured markdown knowledge gaps
+│   ├── conflicts/              ← structured markdown sync/semantic conflicts
+│   ├── sources/decision-logs/  ← immutable imported reasoning packages
+│   ├── notes/                  ← normalized derived knowledge notes
 │   └── inputs/                 ← raw captures (transcripts, notes, links)
 │
 ├── scripts/
@@ -204,6 +210,18 @@ Roadmap work that touches runtime, MCP, browser hosting, model inference, or for
 
 The first-MVP personas, "As a..., I want..., so that..." stories, capability mappings, and demo acceptance path are maintained in [docs/mvp-user-stories.md](docs/mvp-user-stories.md). Runtime and UI work should map back to those stories when defining tickets, smoke tests, and demo evidence.
 
+### Expanded first-MVP second-brain scope
+
+The expanded first-MVP decisions are recorded in [docs/expanded-second-brain-mvp-decision-log.md](docs/expanded-second-brain-mvp-decision-log.md). These decisions are approved through the user's brainstorming process and define the first MVP as a reasoning-and-knowledge-cementing product, not generic chat over documents.
+
+The approved additional OpenSpec surfaces are:
+
+- [reasoning-assistant-skill](openspec/specs/reasoning-assistant-skill/spec.md): LLM-agnostic canonical skill and generated ChatGPT/Claude adapters.
+- [decision-log-package](openspec/specs/decision-log-package/spec.md): package format, validation, CLI ingestion, provenance, and offline staging rules.
+- [reasoning-graph](openspec/specs/reasoning-graph/spec.md): full reasoning graph extraction and answer-type context selection.
+- [knowledge-gap-lifecycle](openspec/specs/knowledge-gap-lifecycle/spec.md): gaps, conflicts, direct fact resolution, and gap visibility.
+- [local-runtime-sync](openspec/specs/local-runtime-sync/spec.md): `m3 init`, `m3 serve`, sync preflight, `m3 sync check`, and `m3 mvp-check`.
+
 ### Next product-led MVP tranche
 
 After Traverse `v0.5.0` readiness and the first youaskm3 WASM capability tranche, the next highest-ROI work is tracked as MVP-031 through MVP-040 in [docs/mvp-ticket-backlog.md](docs/mvp-ticket-backlog.md):
@@ -218,6 +236,8 @@ After Traverse `v0.5.0` readiness and the first youaskm3 WASM capability tranche
 - add the final first-MVP acceptance and release gate
 
 These tickets keep youaskm3 product-led while using concrete app evidence to drive Traverse requirements. They must not add downstream runtime/provider shortcuts that bypass Traverse-governed WASM capability execution.
+
+The expanded second-brain tranche is tracked as MVP-041 and later in [docs/mvp-ticket-backlog.md](docs/mvp-ticket-backlog.md). It does not replace MVP-031 through MVP-040; it layers the approved decision-log, reasoning graph, knowledge gap, sync, local runtime, and final expanded acceptance requirements on top of the existing Traverse-backed runtime baseline.
 
 ### Real runtime implementation rule
 

--- a/docs/expanded-second-brain-mvp-decision-log.md
+++ b/docs/expanded-second-brain-mvp-decision-log.md
@@ -1,0 +1,110 @@
+# Expanded First MVP Decision Log
+
+Status: Approved by brainstorming
+Date: 2026-06-29
+Owner: youaskm3 product/spec alignment
+
+## Purpose
+
+This decision log records the approved first-MVP expansion from generic chat over documents into a second-brain reasoning product. The decisions below are approved through the user's brainstorming process: one question at a time, options with pros and cons, and a recommendation, ending when no planned product questions remained.
+
+## Product Definition
+
+youaskm3 is not only chat over files. It is a reasoning-and-knowledge-cementing loop.
+
+A persona works with an assistant in natural conversation to reason through a concept, challenge assumptions, clarify ambiguity, register decisions, and turn the resulting reasoning into durable personal knowledge. Future answers are only as good as the reasoning content captured into the knowledge store.
+
+## Approved Decisions
+
+1. The first MVP must use real knowledge artifacts, not placeholders.
+2. The acceptance fixture may use a real public/shareable document and may also be manually validated with private user documents.
+3. The system must support both supported-answer and human-in-the-loop defer paths.
+4. The defer path is part of the core product: unsupported or uncertain answers create or update knowledge gaps.
+5. A complete reasoning loop is in scope: the human supplies missing knowledge, the system updates context and graph, and later questions can use the new knowledge.
+6. The UI remains chat-only. It must not display rebuild or pipeline internals.
+7. Missing knowledge is handled conversationally. The assistant asks in chat when the answer is unavailable or uncertain.
+8. Knowledge gaps are markdown files with structured front matter.
+9. Gap clarification follows the same brainstorming process: one question at a time, options, pros and cons, and a recommendation.
+10. A ChatGPT/Claude-style assistant skill creates decision-log packages from reasoning conversations.
+11. The skill is a reasoning/capture surface. youaskm3 owns ingestion, validation, provenance, graph extraction, and answer behavior.
+12. The canonical assistant skill definition must be LLM-agnostic.
+13. ChatGPT and Claude adapters are generated from the canonical skill source.
+14. The canonical skill source uses markdown plus structured manifest/schema.
+15. The generated skill outputs a decision-log package, not only one markdown file.
+16. The package contains `decision-log.md`, `knowledge-note.md`, and `metadata.json`.
+17. Ingestion is CLI-managed only. There is no inbox watcher in the first MVP.
+18. The first MVP accepts package directories only, not zip/archive files.
+19. The CLI copies the package into the knowledge store and records the original import path as provenance.
+20. `knowledge-note.md` is validated against `decision-log.md` before ingestion.
+21. Deterministic validation is mandatory.
+22. Traverse-governed semantic validation is optional when available.
+23. If semantic validation is unavailable, deterministic validation can proceed.
+24. If semantic validation runs and fails, the package is not ingested as final knowledge; a knowledge gap is created or updated.
+25. For the first MVP, failed semantic validation blocks the whole package. Claim-level partial ingestion is future work.
+26. Full concept graph extraction from decision-log packages is mandatory for the first MVP.
+27. Graph extraction requires deterministic extraction from structured package sections, with optional Traverse agent enrichment when available.
+28. Mandatory graph elements are `concept`, `question`, `option`, `tradeoff`, `assumption`, `decision`, `claim`, `open_question`, `source_gap`, `knowledge_note`, `citation`, `source_artifact`, `confidence_assessment`, and `validation_result`.
+29. The reasoning graph requires a minimal formal schema plus executable fixtures with expected graph output.
+30. Answer generation uses full graph context with answer-type filtering.
+31. Answer-type classification has a deterministic baseline plus optional Traverse-governed agent override.
+32. Conflicting knowledge is not silently resolved. The answer summarizes the conflict and creates or updates a knowledge gap.
+33. Knowledge gaps can be created or updated during both question-time and ingestion/validation.
+34. Unresolved gaps are available through both CLI and chat query.
+35. Gap resolution can happen through direct chat for simple factual gaps and through decision-log packages for conceptual, strategic, architectural, or reasoning-heavy gaps.
+36. Gap complexity has a deterministic baseline plus optional Traverse-governed agent override.
+37. Direct chat gap resolution produces an internal mini decision-log package so every knowledge update follows one validation/provenance/graph path.
+38. Internal mini packages use the same package schema with mode-specific required sections.
+39. `conflict_resolution` is a first-MVP package mode.
+40. The CLI uses one generic ingestion command: `m3 ingest-decision-log /path/to/package/`.
+41. Generated skills include a generic CLI command template, not a hardcoded local path.
+42. Normal markdown/source document ingestion remains supported as source knowledge. Decision-log packages are first-class reasoning inputs.
+43. Answers cite provenance type, such as imported source document, decision log, knowledge note, human-provided direct fact, conflict resolution, or gap resolution.
+44. Every supported answer includes concise evidence/provenance by default.
+45. The MVP supports one active persona, with `persona_id` reserved in metadata/schema.
+46. The workspace `knowledge/` directory is the default knowledge root, with optional `--knowledge-root`.
+47. External knowledge roots require `m3 init --knowledge-root <path>` before writes.
+48. Built-in multi-machine sync is in scope through a file-system sync folder for the first MVP.
+49. youaskm3 does not build a hosted sync service in the first MVP.
+50. Sync support must detect/report conflicts in decision-log packages, knowledge notes, gaps, graph artifacts, and metadata/index state.
+51. Sync auto-merges safe append-only artifacts but stops and reports semantic conflicts.
+52. Knowledge-writing commands run sync/conflict preflight checks; `m3 sync check` exists for manual inspection.
+53. Chat discloses sync conflicts only when they affect the answer or confidence.
+54. The MVP includes CLI-managed ingestion/setup and a local server/runtime for chat and MCP.
+55. `m3 serve` tries to start or attach to Traverse and fails with a clear setup error if unavailable.
+56. Runtime configuration lives in project config with CLI overrides.
+57. `m3 init` is the first-run setup command.
+58. `m3 init` supports full Traverse validation mode and explicit offline mode.
+59. Offline mode can stage decision-log packages, but final validation, ingestion, and graph update require Traverse.
+60. MVP acceptance includes both real user workflow commands and a final gate: `m3 mvp-check`.
+61. The local runtime exposes HTTP JSON for the PWA and MCP backed by the same Traverse workflow.
+62. The minimum chat UI supports asking, answering, concise evidence/provenance, defer/gap response, and direct simple fact resolution.
+63. MCP parity includes answer question, list unresolved gaps, and resolve simple factual gaps.
+64. Sync conflicts are markdown reports with structured front matter.
+65. The expanded MVP is split into a new ticket tranche plus one final acceptance ticket.
+66. Existing tickets `#120`, `#122`, `#135`, and `#136` remain as the Traverse-backed runtime baseline.
+67. A new expanded final gate ticket links to `#136` instead of replacing it.
+
+## Non-Negotiable Acceptance Rules
+
+- No placeholders, fake workflow steps, skeleton manifests, all-zero digests, or browser fallback output can count as first-MVP acceptance.
+- Product/business behavior that runs at runtime must run through Traverse-governed WASM microservices or WASM agents.
+- The UI is a chat interface. It renders state returned by the runtime and does not own retrieval, graph traversal, context packing, inference selection, answer validation, response formatting, gap lifecycle, sync conflict policy, or graph extraction logic.
+- CLI may manage setup, package ingestion, artifact building, sync checks, local server startup, and final acceptance gates, but product semantics must remain Traverse-governed where runtime behavior is involved.
+- Missing Traverse public surfaces must become upstream Traverse requirements, not downstream shortcuts.
+
+## Resulting First-MVP Shape
+
+The expanded first MVP is a local-first second-brain product with:
+
+- LLM-agnostic reasoning skill source.
+- Generated ChatGPT and Claude skill adapters.
+- Decision-log package output from assistant reasoning conversations.
+- CLI ingestion of package directories.
+- Validated provenance from decision log to knowledge note.
+- Full reasoning graph extraction.
+- Knowledge gaps and sync conflicts as structured markdown records.
+- Chat answers using graph-aware answer-type filtering.
+- Direct simple fact resolution through internal mini packages.
+- Local HTTP JSON and MCP runtime surfaces backed by the same Traverse workflow.
+- File-system sync-folder support with conflict detection.
+- One final `m3 mvp-check` acceptance gate.

--- a/docs/mvp-ticket-backlog.md
+++ b/docs/mvp-ticket-backlog.md
@@ -1309,9 +1309,534 @@ Next highest-ROI tranche after MVP-030:
 - MVP-039 real `knowledge.infer` WASM agent
 - MVP-040 final first-MVP acceptance and release gate
 
-## First Ticket to Start
+Approved expanded second-brain tranche after the 2026-06-29 brainstorming session:
 
-Recommended first implementation ticket:
+- MVP-041 canonical LLM-agnostic reasoning skill and generated ChatGPT/Claude adapters ([#138](https://github.com/enricopiovesan/youaskm3/issues/138))
+- MVP-042 decision-log package schema, validator, and executable fixtures ([#139](https://github.com/enricopiovesan/youaskm3/issues/139))
+- MVP-043 CLI decision-log package ingestion and provenance preservation ([#140](https://github.com/enricopiovesan/youaskm3/issues/140))
+- MVP-044 full reasoning graph schema and deterministic extraction ([#141](https://github.com/enricopiovesan/youaskm3/issues/141))
+- MVP-045 knowledge gap and conflict lifecycle ([#142](https://github.com/enricopiovesan/youaskm3/issues/142))
+- MVP-046 graph-aware answer classification and context selection ([#143](https://github.com/enricopiovesan/youaskm3/issues/143))
+- MVP-047 direct chat simple fact resolution through internal mini packages ([#144](https://github.com/enricopiovesan/youaskm3/issues/144))
+- MVP-048 local HTTP JSON runtime and Traverse-backed MCP parity ([#145](https://github.com/enricopiovesan/youaskm3/issues/145))
+- MVP-049 `m3 init` first-run setup, external knowledge roots, and runtime config ([#146](https://github.com/enricopiovesan/youaskm3/issues/146))
+- MVP-050 file-system sync preflight and conflict detection ([#147](https://github.com/enricopiovesan/youaskm3/issues/147))
+- MVP-051 `m3 serve` Traverse start/attach orchestration ([#148](https://github.com/enricopiovesan/youaskm3/issues/148))
+- MVP-052 chat-only PWA UX for evidence, gaps, conflicts, and direct fact resolution ([#149](https://github.com/enricopiovesan/youaskm3/issues/149))
+- MVP-053 MCP answer, gaps, and simple fact resolution tools ([#150](https://github.com/enricopiovesan/youaskm3/issues/150))
+- MVP-054 expanded first-MVP acceptance gate with `m3 mvp-check` ([#151](https://github.com/enricopiovesan/youaskm3/issues/151))
+
+## Ticket MVP-041: Build the Canonical Reasoning Skill and Generated Adapters
+
+### Objective
+
+Create the LLM-agnostic reasoning skill source and generated ChatGPT and Claude adapters that help a persona reason through concepts and produce valid decision-log packages.
+
+### Governing Specs
+
+- `docs/expanded-second-brain-mvp-decision-log.md`
+- `openspec/specs/reasoning-assistant-skill/spec.md`
+- `openspec/specs/decision-log-package/spec.md`
+
+### Scope
+
+- Add canonical skill source with provider-neutral interview rules.
+- Add structured manifest metadata for generation.
+- Generate ChatGPT and Claude adapter outputs from the canonical source.
+- Add a drift check so generated adapters cannot fall behind the canonical source.
+- Include generic CLI handoff instructions: `m3 ingest-decision-log /path/to/decision-log-package/`.
+
+### Definition of Done
+
+- Canonical skill source exists in the repo and is provider-neutral.
+- ChatGPT and Claude generated adapter artifacts exist and are generated from the same source.
+- Generated adapters preserve one-question-at-a-time brainstorming, options, pros, cons, recommendation, assumption challenge, and no-finalization-until-clear rules.
+- Generated adapters require output package files: `decision-log.md`, `knowledge-note.md`, `metadata.json`.
+- A drift check fails when generated artifacts are stale.
+- No generated adapter contains hardcoded local user paths.
+- `bash scripts/smoke.sh` or a focused documented validation gate passes.
+
+### Validation
+
+```bash
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-042: Define Decision-Log Package Schema, Validator, and Fixtures
+
+### Objective
+
+Define and validate the decision-log package contract used by external assistant-generated packages and internal mini packages.
+
+### Governing Specs
+
+- `openspec/specs/decision-log-package/spec.md`
+- `openspec/specs/reasoning-assistant-skill/spec.md`
+- `openspec/specs/knowledge-gap-lifecycle/spec.md`
+
+### Scope
+
+- Add package schema for `metadata.json`.
+- Add structural rules for `decision-log.md` and `knowledge-note.md`.
+- Support modes: `knowledge_addition`, `gap_resolution`, `direct_fact_resolution`, `conflict_resolution`.
+- Add valid and invalid fixture packages.
+- Add deterministic validation for required files, ids, mode-specific sections, no blocking clarifications, provenance, and knowledge-note consistency.
+
+### Definition of Done
+
+- Package schema and fixture packages exist.
+- Validator rejects missing files, unsupported modes, incomplete required sections, and mismatched ids.
+- Validator rejects `knowledge-note.md` claims not represented in `decision-log.md`.
+- Validator records semantic validation as optional and distinguishes unavailable from failed.
+- Failed semantic validation blocks the whole package and emits gap creation data.
+- Archive/zip inputs are explicitly out of scope and rejected.
+- Tests cover all first-MVP package modes and at least one invalid package per failure class.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-043: Implement CLI Decision-Log Package Ingestion and Provenance
+
+### Objective
+
+Implement `m3 ingest-decision-log /path/to/package/` so package directories become durable personal knowledge with traceable provenance.
+
+### Governing Specs
+
+- `openspec/specs/decision-log-package/spec.md`
+- `openspec/specs/local-runtime-sync/spec.md`
+- `openspec/specs/reasoning-graph/spec.md`
+
+### Scope
+
+- Add the generic CLI ingest command.
+- Accept package directories only.
+- Copy accepted packages into `knowledge/sources/decision-logs/<package-id>/`.
+- Record original import path, package id, persona id, mode, timestamps, validation evidence, and Traverse availability.
+- Create normalized knowledge notes from accepted packages.
+- Support offline staging only; final ingestion and graph update require Traverse.
+
+### Definition of Done
+
+- `m3 ingest-decision-log /path/to/package/` exists.
+- The command rejects archive files and missing package directories with stable errors.
+- The command runs sync/conflict preflight before writes.
+- The command validates package structure before copying or writing final knowledge.
+- Accepted packages are copied into the knowledge store and preserve original path provenance.
+- Normalized notes are written with links back to the source package.
+- Offline mode can stage packages but cannot mark them as final ingested knowledge.
+- Tests prove success, deterministic validation failure, offline staging, and uninitialized external knowledge root failure.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-044: Implement Full Reasoning Graph Schema and Deterministic Extraction
+
+### Objective
+
+Extend the graph contract and generator so decision-log packages produce full reasoning graph elements required by the expanded first MVP.
+
+### Governing Specs
+
+- `openspec/specs/reasoning-graph/spec.md`
+- `openspec/specs/decision-log-package/spec.md`
+- `openspec/specs/knowledge-graph/spec.md`
+
+### Scope
+
+- Extend graph schema for required reasoning node and edge types.
+- Add deterministic extraction from structured decision-log package sections.
+- Add executable fixture package and expected graph output.
+- Preserve provenance to package, decision log, knowledge note, source gap, citations, confidence, and validation results.
+- Record optional Traverse agent enrichment as unavailable, passed, or failed without making it mandatory.
+
+### Definition of Done
+
+- Graph schema supports `concept`, `question`, `option`, `tradeoff`, `assumption`, `decision`, `claim`, `open_question`, `source_gap`, `knowledge_note`, `citation`, `source_artifact`, `confidence_assessment`, and `validation_result`.
+- Deterministic extraction produces stable node and edge ids and ordering.
+- Expected graph fixture output is checked in and validated.
+- Graph extraction fails when required package sections cannot produce mandatory graph elements.
+- Existing source-document graph behavior still works.
+- Tests cover at least one full reasoning package and one invalid extraction package.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-045: Implement Knowledge Gap and Conflict Lifecycle
+
+### Objective
+
+Create structured gap and conflict records for missing, uncertain, ambiguous, and conflicting knowledge discovered during answers, ingestion, validation, and sync.
+
+### Governing Specs
+
+- `openspec/specs/knowledge-gap-lifecycle/spec.md`
+- `openspec/specs/reasoning-graph/spec.md`
+- `openspec/specs/local-runtime-sync/spec.md`
+
+### Scope
+
+- Store gaps as `knowledge/gaps/open/<gap-id>.md` and resolved gaps as `knowledge/gaps/resolved/<gap-id>.md`.
+- Store conflicts as `knowledge/conflicts/open/<conflict-id>.md` and resolved conflicts as `knowledge/conflicts/resolved/<conflict-id>.md`.
+- Use structured front matter for status, persona, trace, source question, reason, linked package, linked graph nodes, and allowed resolution path.
+- Create/update gaps from question-time failures and ingestion/validation failures.
+- Classify gap complexity with deterministic baseline and optional Traverse agent override.
+
+### Definition of Done
+
+- Gap and conflict markdown schemas are documented and validated.
+- Question-time unsupported/uncertain answers create or update open gaps.
+- Ingestion validation failures create or update gaps without final knowledge ingestion.
+- Semantic conflicts create conflict reports and do not silently merge.
+- Gap complexity classification records deterministic result, optional agent result, final result, and allowed resolution path.
+- `m3 gaps list` can list unresolved gaps with stable output.
+- Tests cover gap creation, gap update, conflict creation, resolved movement, and invalid front matter.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-046: Add Graph-Aware Answer Classification and Context Selection
+
+### Objective
+
+Make the answer workflow select reasoning graph context based on answer type and disclose conflicts or uncertainty when relevant.
+
+### Governing Specs
+
+- `openspec/specs/reasoning-graph/spec.md`
+- `openspec/specs/knowledge-gap-lifecycle/spec.md`
+- `openspec/specs/traverse-integration/spec.md`
+
+### Scope
+
+- Add deterministic answer-type classification for factual, decision, uncertainty, concept explanation, and gap-oriented questions.
+- Allow optional Traverse-governed agent refinement when available.
+- Select graph context according to final answer type.
+- Record deterministic answer type, optional agent-refined answer type, final answer type, and context strategy in trace/evidence.
+- Summarize conflicts and create/update gaps when conflicts affect the answer.
+
+### Definition of Done
+
+- Answer-type classifier has deterministic tests for all MVP answer types.
+- Context selection uses claims/citations for factual answers, decisions/rationale/tradeoffs/options for decision answers, assumptions/open questions/confidence for uncertainty answers, and gaps/conflicts when relevant.
+- Trace output includes all required classification and context-strategy fields.
+- Conflicting relevant knowledge is surfaced with evidence and creates/updates a gap.
+- The UI receives formatted evidence from the runtime and does not implement classification or context selection.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-047: Implement Direct Chat Fact Resolution Through Internal Mini Packages
+
+### Objective
+
+Allow simple factual gaps to be resolved directly in chat while preserving the same package validation, provenance, graph extraction, and gap update path as external decision-log packages.
+
+### Governing Specs
+
+- `openspec/specs/knowledge-gap-lifecycle/spec.md`
+- `openspec/specs/decision-log-package/spec.md`
+- `openspec/specs/reasoning-graph/spec.md`
+
+### Scope
+
+- Detect when an open gap allows direct factual resolution.
+- Convert the user's chat answer into an internal mini package using the shared package schema.
+- Validate, ingest, extract graph elements, and resolve/update the gap through the same pipeline as external packages.
+- Reject direct chat resolution for reasoning-heavy gaps and direct the user to decision-log package flow.
+
+### Definition of Done
+
+- Direct simple fact resolution produces an internal package artifact with provenance.
+- Internal packages use the same schema with mode-specific required sections.
+- Successful direct resolution updates knowledge, graph, and gap status.
+- Reasoning-heavy gaps cannot be resolved through direct chat.
+- Trace records the internal package id and linked gap id.
+- Tests cover simple fact success, reasoning-heavy rejection, invalid direct answer, and graph update.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-048: Build Local HTTP JSON Runtime and Traverse-Backed MCP Parity
+
+### Objective
+
+Provide local runtime surfaces for PWA chat and MCP that call the same Traverse-backed workflows.
+
+### Governing Specs
+
+- `openspec/specs/local-runtime-sync/spec.md`
+- `openspec/specs/mcp-interface/spec.md`
+- `openspec/specs/traverse-integration/spec.md`
+
+### Scope
+
+- Add HTTP JSON endpoints for answer, gaps list, and direct simple fact resolution.
+- Add or extend MCP tools for the same operations.
+- Ensure HTTP and MCP share the same Traverse workflow and do not duplicate business logic.
+- Return equivalent trace, evidence, provenance, gap, and conflict fields.
+
+### Definition of Done
+
+- Local HTTP JSON answer endpoint exists and calls Traverse-backed workflow.
+- Local HTTP JSON gaps list and simple fact resolution endpoints exist.
+- MCP exposes answer, gaps list, and simple fact resolution tools.
+- HTTP and MCP parity tests prove equivalent behavior for the same fixture workspace.
+- Neither surface implements retrieval, graph traversal, context packing, inference selection, validation, formatting, gap lifecycle, or conflict policy outside Traverse-governed capabilities.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-049: Extend `m3 init` for First-Run Setup and Knowledge Roots
+
+### Objective
+
+Make `m3 init` the first-run setup command for workspace defaults, external knowledge roots, Traverse configuration, and offline mode.
+
+### Governing Specs
+
+- `openspec/specs/local-runtime-sync/spec.md`
+- `openspec/specs/decision-log-package/spec.md`
+
+### Scope
+
+- Support `m3 init --knowledge-root <path> --traverse-repo <path>`.
+- Support `m3 init --offline --knowledge-root <path>`.
+- Create/validate external knowledge-root markers before writes.
+- Write project config and allow CLI override for runtime commands.
+- Validate Traverse baseline when provided.
+- Mark runtime readiness unavailable in offline mode.
+
+### Definition of Done
+
+- `m3 init` initializes default workspace knowledge root and external roots.
+- External roots require a marker before any write command can mutate them.
+- Project config records Traverse path/config and knowledge-root defaults.
+- CLI overrides take precedence over config.
+- Offline mode can prepare storage but cannot final-ingest packages or run runtime acceptance.
+- Stable setup errors guide the user to the next command.
+- Tests cover workspace root, external root, offline mode, Traverse unavailable, and CLI override behavior.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-050: Add File-System Sync Preflight and Conflict Detection
+
+### Objective
+
+Support multi-machine local usage through file-system sync folders with safe preflight checks and conflict reports.
+
+### Governing Specs
+
+- `openspec/specs/local-runtime-sync/spec.md`
+- `openspec/specs/knowledge-gap-lifecycle/spec.md`
+
+### Scope
+
+- Add sync state metadata for decision-log packages, knowledge notes, gaps, conflicts, graph artifacts, and index metadata.
+- Run sync/conflict preflight before knowledge-writing commands.
+- Provide `m3 sync check`.
+- Auto-merge only safe append-only artifacts.
+- Stop and create structured conflict reports for semantic conflicts.
+
+### Definition of Done
+
+- `m3 sync check` reports clean, auto-merged, open conflict, and blocked states.
+- Knowledge-writing commands run preflight before mutation.
+- Safe append-only merge is narrowly defined and tested.
+- Semantic conflicts stop writes and create `knowledge/conflicts/open/<conflict-id>.md`.
+- Chat only discloses sync conflicts when they affect answer or confidence.
+- Tests cover clean sync, append-only merge, semantic conflict, metadata/index conflict, and blocked write.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-051: Implement `m3 serve` Traverse Start/Attach Runtime Orchestration
+
+### Objective
+
+Provide `m3 serve` as the local runtime command that starts or attaches to Traverse and powers HTTP JSON plus MCP surfaces.
+
+### Governing Specs
+
+- `openspec/specs/local-runtime-sync/spec.md`
+- `openspec/specs/traverse-integration/spec.md`
+
+### Scope
+
+- Read Traverse and knowledge-root configuration from project config with CLI overrides.
+- Try to start or attach to Traverse.
+- Validate the registered app bundle or fail with actionable setup errors.
+- Start local HTTP JSON and MCP surfaces only after runtime readiness is established.
+
+### Definition of Done
+
+- `m3 serve` exists and reads config plus CLI overrides.
+- Traverse unavailable errors are stable and actionable.
+- The command does not silently fall back to Browser demo or local fake runtime.
+- The command exposes local HTTP JSON and MCP surfaces when Traverse is ready.
+- The command reports runtime URL, MCP endpoint, workspace id, and trace/evidence mode.
+- Tests cover config read, CLI override, Traverse unavailable, and successful attach/start using the repo's available test harness.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-052: Implement Chat-Only PWA UX for Evidence, Gaps, Conflicts, and Direct Fact Resolution
+
+### Objective
+
+Make the PWA behave like a chat interface while rendering runtime-provided answers, evidence, deferrals, gaps, conflicts, and simple fact resolution states.
+
+### Governing Specs
+
+- `openspec/specs/pwa-shell/spec.md`
+- `openspec/specs/knowledge-gap-lifecycle/spec.md`
+- `openspec/specs/reasoning-graph/spec.md`
+
+### Scope
+
+- Render supported answers with concise provenance/evidence by default.
+- Render unsupported/uncertain deferral responses.
+- Let the user answer a simple factual gap in chat.
+- Display conflict summaries only when they affect the answer.
+- Keep rebuild, extraction, sync, and pipeline internals out of the UI.
+
+### Definition of Done
+
+- PWA renders answer, provenance type, citations, graph evidence, validation status, and trace reference from runtime response data.
+- PWA renders deferral and gap request states without implementing gap lifecycle logic.
+- PWA can submit direct simple fact resolution only when runtime marks it allowed.
+- PWA surfaces relevant conflicts without becoming a task dashboard.
+- PWA does not implement retrieval, graph traversal, context packing, inference selection, validation, formatting, gap lifecycle, sync conflict policy, or graph extraction.
+- Frontend tests cover supported answer, unsupported deferral, direct fact resolution prompt, relevant conflict disclosure, and no Browser demo acceptance path.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-053: Add MCP Answer, Gaps, and Simple Fact Resolution Tools
+
+### Objective
+
+Expose the expanded first-MVP chat loop through MCP with parity to the local HTTP JSON path.
+
+### Governing Specs
+
+- `openspec/specs/mcp-interface/spec.md`
+- `openspec/specs/local-runtime-sync/spec.md`
+- `openspec/specs/knowledge-gap-lifecycle/spec.md`
+
+### Scope
+
+- Add or update MCP contracts for answer, gaps list, and direct simple fact resolution.
+- Ensure tools invoke the same Traverse-backed workflow as HTTP/PWA.
+- Return equivalent provenance, evidence, trace, gap, and conflict data.
+
+### Definition of Done
+
+- MCP tool contracts exist for answer, gaps list, and simple fact resolution.
+- MCP implementation does not duplicate business logic outside Traverse-governed capabilities.
+- MCP parity smoke covers the same fixture workspace as HTTP/PWA tests.
+- MCP responses include trace ids, provenance type, citations/evidence, gap ids, and conflict ids when relevant.
+- MCP rejects unsupported direct resolution attempts for reasoning-heavy gaps.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+bash scripts/smoke.sh
+```
+
+## Ticket MVP-054: Add Expanded First-MVP Acceptance Gate
+
+### Objective
+
+Create `m3 mvp-check` as the final expanded first-MVP acceptance gate that proves the full second-brain product loop without placeholders.
+
+### Governing Specs
+
+- `docs/expanded-second-brain-mvp-decision-log.md`
+- `docs/mvp-user-stories.md`
+- `openspec/specs/reasoning-assistant-skill/spec.md`
+- `openspec/specs/decision-log-package/spec.md`
+- `openspec/specs/reasoning-graph/spec.md`
+- `openspec/specs/knowledge-gap-lifecycle/spec.md`
+- `openspec/specs/local-runtime-sync/spec.md`
+- `openspec/specs/traverse-integration/spec.md`
+
+### Scope
+
+- Add `m3 mvp-check --traverse-repo <path> --knowledge-root <path>`.
+- Run or orchestrate the real acceptance workflow from clean setup.
+- Validate assistant skill generation, package ingestion, reasoning graph extraction, gap lifecycle, sync preflight, local serve, PWA/HTTP answer, MCP parity, direct fact resolution, and provenance/evidence.
+- Link to baseline final gate issue `#136` and existing runtime baseline tickets `#120`, `#122`, and `#135`.
+
+### Definition of Done
+
+- `m3 mvp-check` exists and documents the real first-MVP acceptance path.
+- The gate validates normal repo health and Traverse readiness.
+- The gate fails if Browser demo, temporary harnesses, fake workflow steps, skeleton manifests, placeholder digests, all-zero evidence, or downstream runtime shortcuts are used as acceptance evidence.
+- The gate validates ChatGPT and Claude adapter generation drift.
+- The gate ingests at least one real decision-log package fixture.
+- The gate validates full reasoning graph extraction and expected graph output.
+- The gate validates gap creation, gap listing, direct simple fact resolution, and conflict report behavior.
+- The gate validates local HTTP JSON and MCP parity against the same Traverse-backed workflow.
+- The gate records exact remaining caveats, including optional semantic validation availability and WASM-native model-engine caveat.
+- `bash scripts/smoke.sh` passes.
+
+### Validation
+
+```bash
+bash scripts/smoke.sh
+m3 mvp-check --traverse-repo /path/to/Traverse --knowledge-root /path/to/root
+```
+
+## First Tickets to Start
+
+Recommended first implementation ticket for the Traverse-backed runtime baseline:
 
 > MVP-031: Prove the Local Traverse-Backed Chat Happy Path
 
@@ -1321,3 +1846,13 @@ Reason:
 - It validates the user-facing product with real runtime pressure.
 - It exposes any remaining Traverse gaps through concrete evidence.
 - It keeps youaskm3 from drifting into downstream runtime shortcuts.
+
+Recommended first implementation ticket for the expanded second-brain tranche:
+
+> MVP-041: Build the Canonical Reasoning Skill and Generated Adapters
+
+Reason:
+
+- It defines the quality of the reasoning content that future answers depend on.
+- It produces the decision-log package source that downstream ingestion, graph extraction, gaps, and final acceptance need.
+- It validates the LLM-agnostic adapter generation rule before ChatGPT/Claude-specific behavior can drift.

--- a/docs/mvp-user-stories.md
+++ b/docs/mvp-user-stories.md
@@ -2,13 +2,15 @@
 
 Status: First-MVP acceptance guide
 Owner: youaskm3 product/spec alignment
-Last updated: 2026-06-27
+Last updated: 2026-06-29
 
 ## Purpose
 
 This document names the first-MVP personas and user-facing stories that guide specs, tickets, tests, and demos.
 
-The first MVP is a local-first PWA chat experience over user-owned knowledge artifacts. The CLI prepares markdown, search, graph, and bundle artifacts. Traverse executes product/business behavior as governed portable WASM microservice capabilities or WASM agent capabilities. The UI renders the experience and must not contain alternate retrieval, graph traversal, context packing, inference selection, answer validation, or answer formatting logic.
+The first MVP is a local-first second-brain chat experience over user-owned knowledge artifacts and structured reasoning logs. The CLI prepares markdown, decision-log packages, search, graph, sync, and bundle artifacts. Traverse executes product/business behavior as governed portable WASM microservice capabilities or WASM agent capabilities. The UI renders the chat experience and must not contain alternate retrieval, graph traversal, context packing, inference selection, answer validation, response formatting, gap lifecycle, sync conflict policy, or reasoning graph extraction logic.
+
+The expanded product goal is a reasoning-and-knowledge-cementing loop. A persona uses a ChatGPT/Claude-style skill to reason through concepts in natural conversation, challenge assumptions, clarify ambiguity, and produce a decision-log package. youaskm3 ingests that package, updates personal knowledge and the graph, and later answers open questions from that cemented reasoning. When information is unavailable, uncertain, or conflicting, the system defers to the human and records a knowledge gap instead of guessing.
 
 MVP runtime acceptance requires the real implementation. Browser demo, temporary harnesses, contract stubs, fake workflow steps, skeleton manifests, placeholder digests, and all-zero component evidence are developer aids only and do not count as acceptance evidence.
 
@@ -17,6 +19,13 @@ MVP runtime acceptance requires the real implementation. Browser demo, temporary
 ### In The First MVP
 
 - Local source files can be converted or normalized into markdown artifacts.
+- A persona can create a decision-log package through an LLM-agnostic assistant skill generated for ChatGPT and Claude.
+- The CLI can ingest decision-log package directories, validate them, preserve provenance, and update knowledge.
+- Full reasoning graph extraction captures concepts, questions, options, tradeoffs, assumptions, decisions, claims, gaps, citations, confidence, and validation evidence.
+- Unsupported, uncertain, or conflicting answers create or update knowledge gaps.
+- Simple factual gaps can be resolved in chat through internal mini packages; reasoning-heavy gaps require decision-log packages.
+- File-system sync-folder usage is supported with conflict detection and safe append-only merge behavior.
+- A local server powers chat and MCP runtime through the same Traverse-backed workflow.
 - Static search and graph artifacts can be generated from the local knowledge folder.
 - A browser/PWA chat surface can ask a question and display an answer with source and graph evidence.
 - Runtime product/business behavior is represented by explicit capability contracts and routed through Traverse-compatible boundaries.
@@ -29,6 +38,10 @@ MVP runtime acceptance requires the real implementation. Browser demo, temporary
 - Cross-instance search fan-out as a required path.
 - Production-quality hosted model service.
 - Claims that the local model engine itself is WASM-native before Traverse exposes that evidence.
+- Hosted youaskm3 sync service, user accounts, or cloud storage control plane.
+- Zip/archive decision-log package ingestion.
+- Automatic inbox watcher for decision-log packages.
+- Claim-level partial ingestion after failed semantic validation.
 
 ## Personas And Stories
 
@@ -139,6 +152,99 @@ Acceptance criteria:
 - AND generation, judgement, planning, semantic interpretation, or model-use behavior is handled by a real Traverse-governed WASM agent capability
 - AND recording pre-generated model output does not count as real MVP inference
 
+### Reasoning Persona
+
+As a reasoning persona, I want an assistant skill to help me reason through a concept, challenge assumptions, ask one clarifying question at a time, and produce a structured decision-log package, so that my reasoning becomes durable personal knowledge instead of disappearing in chat history.
+
+Capability and ticket map:
+
+- `reasoning-assistant-skill`
+- `decision-log-package`
+- `reasoning-graph`
+- MVP-041 LLM-agnostic reasoning skill generator and adapters
+- MVP-042 decision-log package schema and fixtures
+
+Acceptance criteria:
+
+- GIVEN a persona starts a reasoning conversation in a generated ChatGPT or Claude adapter
+- WHEN the concept has unresolved ambiguity
+- THEN the adapter asks one question at a time with options, pros, cons, and a recommendation when useful
+- AND it challenges weak assumptions respectfully
+- AND it does not finalize the package while blocking clarifications remain
+- AND the resulting package contains `decision-log.md`, `knowledge-note.md`, and `metadata.json`
+- AND the generated adapter includes the generic CLI command `m3 ingest-decision-log /path/to/decision-log-package/`
+
+### Second-Brain Knowledge Curator
+
+As a second-brain knowledge curator, I want decision-log packages to be validated, preserved, transformed into notes, and extracted into a reasoning graph, so that future answers can use my actual decisions, assumptions, tradeoffs, and confidence evidence.
+
+Capability and ticket map:
+
+- `decision-log-package`
+- `reasoning-graph`
+- `knowledge-gap-lifecycle`
+- MVP-043 CLI decision-log package ingestion
+- MVP-044 reasoning graph schema and extraction
+- MVP-045 knowledge gap and conflict lifecycle
+
+Acceptance criteria:
+
+- GIVEN a valid decision-log package directory
+- WHEN `m3 ingest-decision-log /path/to/package/` runs with Traverse available
+- THEN deterministic validation passes
+- AND the package is copied into `knowledge/sources/decision-logs/<package-id>/`
+- AND original import path provenance is recorded
+- AND `knowledge-note.md` is validated against `decision-log.md`
+- AND a normalized knowledge note is available in the knowledge store
+- AND the reasoning graph contains required nodes and edges for concepts, questions, options, tradeoffs, assumptions, decisions, claims, gaps, citations, confidence, source artifacts, and validation results
+
+### Human-In-The-Loop Teacher
+
+As a human-in-the-loop teacher, I want youaskm3 to ask me when knowledge is missing, uncertain, or conflicting, so that the second brain improves instead of hallucinating.
+
+Capability and ticket map:
+
+- `knowledge-gap-lifecycle`
+- `reasoning-graph`
+- `knowledge.query.answer`
+- MVP-045 knowledge gap and conflict lifecycle
+- MVP-046 graph-aware answer classification and context selection
+- MVP-047 direct chat fact resolution
+- MVP-052 chat-only gap and evidence UX
+
+Acceptance criteria:
+
+- GIVEN the user asks a question unsupported by current knowledge
+- WHEN the answer workflow cannot produce a grounded answer
+- THEN the chat defers instead of guessing
+- AND a structured gap is created or updated
+- AND simple factual gaps can be resolved directly in chat
+- AND direct chat resolutions create internal mini decision-log packages
+- AND reasoning-heavy gaps require an external decision-log package
+- AND conflicting knowledge is summarized with evidence and creates or updates a conflict/gap record
+
+### Multi-Device Local User
+
+As a multi-device local user, I want my knowledge root to work in a file-system sync folder with conflict detection, so that I can use the same second brain across machines without a hosted youaskm3 service.
+
+Capability and ticket map:
+
+- `local-runtime-sync`
+- `knowledge-gap-lifecycle`
+- `reasoning-graph`
+- MVP-049 first-run setup and knowledge-root configuration
+- MVP-050 sync preflight and conflict detection
+- MVP-051 local runtime serve/start-attach
+
+Acceptance criteria:
+
+- GIVEN a knowledge root is inside a file-system sync folder
+- WHEN a knowledge-writing command runs
+- THEN sync/conflict preflight runs first
+- AND safe append-only changes can auto-merge
+- AND semantic conflicts stop writes and create structured markdown conflict reports
+- AND chat only discloses sync conflicts when they affect the answer or confidence
+
 ### MCP And Agent User
 
 As an MCP and agent user, I want the same knowledge capabilities exposed through Traverse MCP, so that agents can query my knowledge through the same governed workflow as the browser.
@@ -154,6 +260,8 @@ Capability and ticket map:
 - MVP-020 Traverse MCP parity smoke
 - MVP-028 end-to-end Traverse answer workflow smoke
 - MVP-031 local Traverse-backed chat happy path
+- MVP-048 local HTTP JSON and MCP runtime
+- MVP-053 MCP answer/gaps/resolve parity
 
 Acceptance criteria:
 
@@ -162,6 +270,7 @@ Acceptance criteria:
 - THEN the capability contracts and execution evidence match the app-facing workflow
 - AND MCP does not use a separate implementation path for retrieval, graph context, validation, or formatting
 - AND the app-facing and MCP-facing paths expose equivalent grounding and trace evidence for the same workflow
+- AND MCP can list unresolved gaps and resolve simple factual gaps through the same Traverse-backed workflow as chat
 
 ### Product Maintainer Validating Traverse Integration
 
@@ -178,6 +287,7 @@ Capability and ticket map:
 - MVP-028 end-to-end Traverse answer workflow smoke
 - MVP-035 Traverse blocker escalation template
 - MVP-040 final first-MVP acceptance and release gate
+- MVP-054 expanded first-MVP acceptance gate
 
 Acceptance criteria:
 
@@ -191,7 +301,25 @@ Acceptance criteria:
 
 ## Demo Acceptance Path
 
-The first MVP demo is acceptable when these steps pass from a clean local setup:
+The expanded first MVP demo is acceptable when these steps pass from a clean local setup:
+
+1. Generate ChatGPT and Claude assistant-skill adapters from the canonical LLM-agnostic skill source and verify no drift.
+2. Produce or use a real decision-log package directory containing `decision-log.md`, `knowledge-note.md`, and `metadata.json`.
+3. Run `m3 init --knowledge-root <path> --traverse-repo <path>` or an equivalent configured setup.
+4. Run `m3 ingest-decision-log /path/to/decision-log-package/`.
+5. Prepare or refresh markdown, search, and graph artifacts from local knowledge files and ingested reasoning packages.
+6. Validate reasoning graph extraction with required node/edge types and provenance.
+7. Validate knowledge gap and conflict lifecycle behavior.
+8. Validate sync preflight with a clean state and at least one conflict fixture.
+9. Start local runtime with `m3 serve`, which starts or attaches to Traverse or fails with clear setup guidance.
+10. Ask one supported question through the PWA.
+11. Ask one unsupported or uncertain question through the PWA and verify gap creation/update.
+12. Resolve one simple factual gap through chat and verify an internal mini package is produced.
+13. Inspect answer text, concise provenance type, citations, graph/source evidence, selected inference dependency, and trace.
+14. Exercise the same answer, gap list, and simple fact resolution workflow through MCP parity validation.
+15. Run `m3 mvp-check --traverse-repo <path> --knowledge-root <path>` and record exact remaining caveats.
+
+The earlier Traverse-backed runtime baseline remains valid when these steps pass:
 
 1. Prepare or refresh markdown, search, and graph artifacts from local knowledge files.
 2. Validate normal repo health with `bash scripts/smoke.sh`.
@@ -203,6 +331,6 @@ The first MVP demo is acceptable when these steps pass from a clean local setup:
 8. Exercise the same answer workflow through MCP parity validation.
 9. Explicitly select Browser demo only when validating the documented no-server fallback path.
 10. Treat any missing real Traverse workflow/capability support as a blocked youaskm3 ticket plus an upstream Traverse requirement, not as permission to add placeholders.
-11. Run the final first-MVP acceptance/release gate and record exact remaining caveats.
+11. Run the baseline first-MVP acceptance/release gate and record exact remaining caveats.
 
 The demo must not require a hosted account, hosted database, paid external model service, or product/business logic outside Traverse-governed capabilities.

--- a/openspec/specs/decision-log-package/spec.md
+++ b/openspec/specs/decision-log-package/spec.md
@@ -1,0 +1,74 @@
+# decision-log-package Specification
+
+Status: Approved by brainstorming on 2026-06-29
+
+## Purpose
+
+The decision-log-package capability defines the portable artifact produced by assistant reasoning sessions and consumed by the youaskm3 CLI to update personal knowledge, gaps, provenance, and the reasoning graph.
+
+## Requirements
+
+### Requirement: Validate package structure
+
+The system SHALL accept a package directory containing `decision-log.md`, `knowledge-note.md`, and `metadata.json`.
+
+#### Scenario: Ingest a package directory
+
+- GIVEN a local package directory exists
+- WHEN `m3 ingest-decision-log /path/to/package/` runs
+- THEN the CLI validates that all required package files exist
+- AND archive files are rejected for the first MVP
+- AND the package mode is one of `knowledge_addition`, `gap_resolution`, `direct_fact_resolution`, or `conflict_resolution`
+
+### Requirement: Preserve source package provenance
+
+The system SHALL copy accepted packages into the knowledge store and record the original import path.
+
+#### Scenario: Store an imported package
+
+- GIVEN deterministic validation passes
+- WHEN final ingestion proceeds through Traverse-governed validation and graph update
+- THEN the package is copied to `knowledge/sources/decision-logs/<package-id>/`
+- AND provenance records the original import path, import timestamp, persona id, package id, package mode, and validation evidence
+
+### Requirement: Validate knowledge note consistency
+
+The system SHALL validate `knowledge-note.md` against `decision-log.md` before final ingestion.
+
+#### Scenario: Detect unsupported distilled knowledge
+
+- GIVEN `knowledge-note.md` introduces a claim not supported by the decision log
+- WHEN deterministic package validation runs
+- THEN ingestion fails with a stable validation error
+- AND no final knowledge note or graph update is produced
+
+### Requirement: Use deterministic validation as the required baseline
+
+The system SHALL require deterministic validation and MAY run optional Traverse-governed semantic validation when available.
+
+#### Scenario: Semantic validation unavailable
+
+- GIVEN deterministic validation passes
+- AND Traverse semantic validation is unavailable
+- WHEN final ingestion runs
+- THEN ingestion may continue
+- AND metadata records that semantic validation was unavailable
+
+#### Scenario: Semantic validation fails
+
+- GIVEN deterministic validation passes
+- AND Traverse semantic validation runs and rejects the package
+- WHEN ingestion handles the result
+- THEN the whole package is not ingested as final knowledge
+- AND a knowledge gap is created or updated for clarification
+
+### Requirement: Support offline staging only
+
+The system SHALL allow offline mode to stage package metadata but not perform final ingestion, graph extraction, or knowledge update.
+
+#### Scenario: Stage while offline
+
+- GIVEN the workspace was initialized with `m3 init --offline`
+- WHEN the user stages a decision-log package
+- THEN the package is recorded as pending Traverse-backed ingestion
+- AND final validation, knowledge update, and graph extraction remain blocked until Traverse is available

--- a/openspec/specs/knowledge-gap-lifecycle/spec.md
+++ b/openspec/specs/knowledge-gap-lifecycle/spec.md
@@ -1,0 +1,77 @@
+# knowledge-gap-lifecycle Specification
+
+Status: Approved by brainstorming on 2026-06-29
+
+## Purpose
+
+The knowledge-gap-lifecycle capability defines how youaskm3 records missing, uncertain, ambiguous, or conflicting knowledge so the persona can improve the second brain instead of receiving unsupported answers.
+
+## Requirements
+
+### Requirement: Store gaps as structured markdown
+
+The system SHALL store knowledge gaps as markdown files with structured front matter.
+
+#### Scenario: Create a question-time gap
+
+- GIVEN the answer workflow cannot answer from supported knowledge with sufficient confidence
+- WHEN the user asks the question
+- THEN the workflow creates or updates `knowledge/gaps/open/<gap-id>.md`
+- AND the gap front matter records status, source question, persona id, trace id, confidence reason, timestamps, relevant graph nodes, and allowed resolution path
+
+### Requirement: Create gaps during ingestion and validation
+
+The system SHALL create or update gaps when decision-log package ingestion or validation detects missing, ambiguous, conflicting, or semantically rejected knowledge.
+
+#### Scenario: Package semantic validation fails
+
+- GIVEN optional semantic validation runs and rejects a package
+- WHEN ingestion handles the failure
+- THEN no final knowledge is ingested
+- AND a gap records the validation result, package id, failed reason, and clarification need
+
+### Requirement: Classify gap complexity
+
+The system SHALL classify gaps using a deterministic baseline and MAY use a Traverse-governed agent override when available.
+
+#### Scenario: Select the resolution path
+
+- GIVEN a new or updated gap exists
+- WHEN the workflow classifies its complexity
+- THEN simple factual gaps allow direct chat resolution
+- AND conceptual, strategic, architectural, or reasoning-heavy gaps require a decision-log package
+- AND the trace records deterministic complexity, optional agent refinement, final complexity, and allowed resolution path
+
+### Requirement: Resolve simple factual gaps through internal packages
+
+The system SHALL convert direct chat factual resolutions into internal mini decision-log packages.
+
+#### Scenario: Resolve a simple fact in chat
+
+- GIVEN a gap is classified as a simple factual gap
+- WHEN the user supplies the answer in chat
+- THEN the runtime creates an internal package using the decision-log package schema with mode-specific required sections
+- AND that package follows the same validation, provenance, graph extraction, and gap update path as external packages
+
+### Requirement: Track conflicts as structured markdown
+
+The system SHALL store sync and semantic conflict reports as markdown files with structured front matter.
+
+#### Scenario: Detect a semantic conflict
+
+- GIVEN sync or graph validation finds conflicting decisions or claims
+- WHEN the conflict cannot be safely merged
+- THEN the system writes `knowledge/conflicts/open/<conflict-id>.md`
+- AND chat discloses the conflict only when it affects the answer or confidence
+- AND resolution requires the `conflict_resolution` package mode
+
+### Requirement: Expose unresolved gaps through CLI and chat
+
+The system SHALL expose unresolved gaps through both `m3 gaps list` and the chat workflow.
+
+#### Scenario: Ask what is missing
+
+- GIVEN unresolved gaps exist
+- WHEN the user asks "what do you still need from me?"
+- THEN the chat answer summarizes relevant open gaps with provenance and resolution path
+- AND the same gap set is available through `m3 gaps list`

--- a/openspec/specs/knowledge-graph/spec.md
+++ b/openspec/specs/knowledge-graph/spec.md
@@ -4,6 +4,8 @@
 
 The knowledge-graph capability defines how youaskm3 represents graph context derived from normalized knowledge artifacts so chat answers can include source-backed relationships rather than isolated text snippets.
 
+The expanded first MVP also includes a reasoning graph defined in `openspec/specs/reasoning-graph/spec.md`. Source-document graph behavior remains valid, and decision-log packages add structured reasoning nodes and edges on top of this base graph artifact.
+
 ## Requirements
 
 ### Requirement: Produce a deterministic graph artifact
@@ -35,3 +37,14 @@ The system SHALL expose graph expansion through the `knowledge.graph.expand` cap
 - GIVEN retrieval returned source chunks for a prompt
 - WHEN the answer workflow needs nearby graph context
 - THEN Traverse executes `knowledge.graph.expand` and returns bounded graph evidence to the workflow
+
+### Requirement: Preserve reasoning graph compatibility
+
+The system SHALL allow the graph artifact to include reasoning graph node and edge types produced from decision-log packages without breaking existing source-document graph behavior.
+
+#### Scenario: Include decision-log reasoning in graph context
+
+- GIVEN a decision-log package has been ingested and extracted into graph elements
+- WHEN graph context is generated
+- THEN the artifact can include reasoning nodes and edges with provenance to the decision-log package and derived knowledge note
+- AND existing source artifact and chunk evidence remains available for imported documents

--- a/openspec/specs/local-runtime-sync/spec.md
+++ b/openspec/specs/local-runtime-sync/spec.md
@@ -1,0 +1,87 @@
+# local-runtime-sync Specification
+
+Status: Approved by brainstorming on 2026-06-29
+
+## Purpose
+
+The local-runtime-sync capability defines first-run setup, local serving, Traverse startup/attachment, external knowledge roots, file-system sync-folder support, conflict preflight, and the final expanded MVP acceptance gate.
+
+## Requirements
+
+### Requirement: Initialize workspace and knowledge roots
+
+The system SHALL use `m3 init` as the first-run setup command.
+
+#### Scenario: Initialize with Traverse
+
+- GIVEN the user provides a Traverse checkout or configured Traverse command
+- WHEN `m3 init --knowledge-root <path> --traverse-repo <path>` runs
+- THEN the CLI creates or validates the knowledge-root marker
+- AND writes project configuration
+- AND validates the Traverse baseline
+- AND initializes local metadata
+- AND reports the next command to run
+
+#### Scenario: Initialize offline
+
+- GIVEN Traverse is not available
+- WHEN `m3 init --offline --knowledge-root <path>` runs
+- THEN the CLI initializes knowledge storage only
+- AND marks runtime readiness as unavailable
+- AND final decision-log ingestion, graph update, chat runtime, and MVP acceptance remain blocked until Traverse is available
+
+### Requirement: Protect external knowledge roots
+
+The system SHALL require external knowledge roots to contain a youaskm3 marker before writes.
+
+#### Scenario: Reject uninitialized external root
+
+- GIVEN `--knowledge-root` points outside the workspace
+- AND the target has no youaskm3 marker
+- WHEN a knowledge-writing command runs
+- THEN the command fails with a clear setup error directing the user to run `m3 init --knowledge-root <path>`
+
+### Requirement: Serve local chat and MCP runtime
+
+The system SHALL provide `m3 serve` to power the local HTTP JSON chat API and MCP parity surface.
+
+#### Scenario: Start or attach to Traverse
+
+- GIVEN project config or CLI overrides identify Traverse runtime configuration
+- WHEN `m3 serve` runs
+- THEN it tries to start or attach to Traverse
+- AND fails with a clear setup error when Traverse is unavailable
+- AND exposes HTTP JSON for the PWA and MCP backed by the same Traverse workflow
+
+### Requirement: Run sync conflict preflight
+
+The system SHALL support file-system sync-folder usage and run sync/conflict checks before knowledge writes.
+
+#### Scenario: Preflight before package ingestion
+
+- GIVEN the knowledge root may be synchronized by iCloud Drive, Dropbox, Syncthing, or a similar file-system sync tool
+- WHEN a knowledge-writing command runs
+- THEN the command runs conflict preflight
+- AND safely auto-merges append-only artifacts when possible
+- AND stops and writes conflict reports for semantic conflicts
+
+### Requirement: Provide manual sync inspection
+
+The system SHALL provide `m3 sync check`.
+
+#### Scenario: Inspect sync state
+
+- GIVEN a user wants to inspect sync health
+- WHEN `m3 sync check` runs
+- THEN it reports clean, auto-merged, open conflict, or blocked states for decision-log packages, knowledge notes, gaps, graph artifacts, and metadata/index state
+
+### Requirement: Provide expanded first-MVP acceptance gate
+
+The system SHALL provide a final acceptance gate for the expanded first MVP.
+
+#### Scenario: Run expanded MVP check
+
+- GIVEN a clean local setup with Traverse available
+- WHEN `m3 mvp-check --traverse-repo <path> --knowledge-root <path>` runs
+- THEN it validates repo health, Traverse readiness, assistant skill generation drift, decision-log package ingestion, reasoning graph extraction, gap lifecycle, sync preflight, local HTTP JSON chat, MCP parity, evidence/provenance rendering, and no-placeholder acceptance rules
+- AND it fails if Browser demo, fake workflow steps, skeleton manifests, placeholder digests, or downstream runtime shortcuts are used as acceptance evidence

--- a/openspec/specs/mcp-interface/spec.md
+++ b/openspec/specs/mcp-interface/spec.md
@@ -36,6 +36,12 @@ The system SHALL expose the MVP knowledge capabilities through Traverse MCP usin
 - WHEN an MCP client discovers the available youaskm3 capabilities
 - THEN it can inspect and execute the same `knowledge.query.answer` contract used by the PWA
 
+#### Scenario: Use expanded second-brain tools from MCP
+
+- GIVEN the local runtime exposes expanded first-MVP operations
+- WHEN an MCP client discovers youaskm3 tools
+- THEN it can call the answer workflow, list unresolved gaps, and resolve simple factual gaps through the same Traverse-backed workflow used by HTTP/PWA
+
 ### Requirement: Preserve trace and evidence references in MCP responses
 
 The system SHALL return machine-readable trace, source, and graph evidence references through MCP responses when a capability produces an answer.
@@ -45,3 +51,9 @@ The system SHALL return machine-readable trace, source, and graph evidence refer
 - GIVEN an MCP client calls the answer workflow
 - WHEN the workflow completes
 - THEN the response includes answer text, citations, validation status, and trace identifiers equivalent to the app-facing response
+
+#### Scenario: Inspect gap and conflict evidence from MCP
+
+- GIVEN an MCP client calls an answer or gap operation
+- WHEN the response includes a gap, direct resolution, or relevant conflict
+- THEN the response includes machine-readable gap ids, conflict ids, provenance type, validation status, and trace identifiers equivalent to the app-facing response

--- a/openspec/specs/pwa-shell/spec.md
+++ b/openspec/specs/pwa-shell/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The pwa-shell capability defines the installable, offline-capable browser shell that hosts the user-facing chat experience, presents sources and graph evidence, and delegates product/business behavior to Traverse-run WASM microservice and WASM agent capabilities.
+The pwa-shell capability defines the installable, offline-capable browser shell that hosts the user-facing chat experience, presents sources, graph evidence, gaps, conflicts, and traces, and delegates product/business behavior to Traverse-run WASM microservice and WASM agent capabilities.
 
 ## Requirements
 
@@ -28,7 +28,7 @@ The system SHALL reserve UI surfaces for chat responses and source attribution s
 
 ### Requirement: Keep the PWA as a UI-only application
 
-The system SHALL keep retrieval ranking, graph traversal, context packing, inference selection, answer validation, and answer formatting outside the PWA and behind real Traverse-run WASM microservice or WASM agent capability contracts.
+The system SHALL keep retrieval ranking, graph traversal, context packing, inference selection, answer validation, answer formatting, gap lifecycle, direct fact resolution policy, sync conflict policy, and reasoning graph extraction outside the PWA and behind real Traverse-run WASM microservice or WASM agent capability contracts.
 
 #### Scenario: Submit a chat prompt
 
@@ -80,3 +80,22 @@ The system SHALL render the final first-MVP acceptance response and evidence ret
 - WHEN the PWA displays the result
 - THEN it renders the answer, citations, graph evidence, validation state, and trace reference from Traverse-owned response data
 - AND no browser-side fallback output is counted as release acceptance evidence
+
+### Requirement: Render chat-native gap and conflict states
+
+The system SHALL render unsupported, uncertain, and conflicting knowledge states as chat responses using runtime-provided data.
+
+#### Scenario: Runtime defers to the human
+
+- GIVEN the runtime reports that a question cannot be answered from supported knowledge
+- WHEN the PWA renders the response
+- THEN it shows a chat-native deferral and request for missing information
+- AND it may submit a direct factual resolution only when the runtime marks that resolution path as allowed
+- AND it does not display rebuild, extraction, sync, or pipeline internals
+
+#### Scenario: Runtime reports relevant conflict
+
+- GIVEN the runtime reports a conflict that affects the answer or confidence
+- WHEN the PWA renders the response
+- THEN it shows the conflict summary and concise provenance returned by the runtime
+- AND it does not become a separate task dashboard

--- a/openspec/specs/reasoning-assistant-skill/spec.md
+++ b/openspec/specs/reasoning-assistant-skill/spec.md
@@ -1,0 +1,57 @@
+# reasoning-assistant-skill Specification
+
+Status: Approved by brainstorming on 2026-06-29
+
+## Purpose
+
+The reasoning-assistant-skill capability defines the LLM-agnostic assistant instructions used to help a persona reason through concepts, challenge assumptions, clarify ambiguity, and produce a decision-log package that youaskm3 can ingest as first-class personal knowledge.
+
+## Requirements
+
+### Requirement: Maintain an LLM-agnostic canonical skill
+
+The system SHALL keep the canonical reasoning skill in provider-neutral source files with machine-readable metadata so generated ChatGPT, Claude, and future adapters stay consistent.
+
+#### Scenario: Generate platform adapters
+
+- GIVEN the canonical reasoning skill source has changed
+- WHEN the assistant-skill generator runs
+- THEN it renders ChatGPT and Claude adapter artifacts from the same source
+- AND generated artifacts preserve the required interview protocol, package schema expectations, and CLI handoff instructions
+- AND a drift check fails when generated adapters are stale
+
+### Requirement: Conduct a natural reasoning interview
+
+The skill SHALL behave as a conversational reasoning partner, not as a form or approval gate.
+
+#### Scenario: Clarify a concept
+
+- GIVEN the persona wants to reason through a concept
+- WHEN the skill detects ambiguity, missing assumptions, or unresolved tradeoffs
+- THEN it asks one question at a time
+- AND each question presents options with pros, cons, and a recommendation when options are useful
+- AND the skill challenges weak assumptions respectfully
+- AND the skill continues until no blocking clarification remains
+
+### Requirement: Produce a decision-log package
+
+The skill SHALL produce a package directory containing `decision-log.md`, `knowledge-note.md`, and `metadata.json`.
+
+#### Scenario: Finalize a reasoning session
+
+- GIVEN the conversation has no open blocking clarifications
+- WHEN the skill finalizes the session
+- THEN it emits a decision-log package conforming to the decision-log package spec
+- AND the package includes the generic next-step command `m3 ingest-decision-log /path/to/decision-log-package/`
+- AND the package does not claim approval by a separate approver
+
+### Requirement: Support package modes
+
+The skill SHALL support first-MVP package modes for `knowledge_addition`, `gap_resolution`, `direct_fact_resolution`, and `conflict_resolution`.
+
+#### Scenario: Resolve a reasoning-heavy gap
+
+- GIVEN a gap requires conceptual, strategic, architectural, or reasoning-heavy clarification
+- WHEN the skill produces a package
+- THEN `metadata.json` records the mode and any linked `source_gap_id`
+- AND the decision log records questions, options, tradeoffs, assumptions, decisions, claims, confidence, citations, and remaining non-blocking open questions

--- a/openspec/specs/reasoning-graph/spec.md
+++ b/openspec/specs/reasoning-graph/spec.md
@@ -1,0 +1,69 @@
+# reasoning-graph Specification
+
+Status: Approved by brainstorming on 2026-06-29
+
+## Purpose
+
+The reasoning-graph capability extends the knowledge graph from source-document relationships into a structured second-brain graph that preserves concepts, questions, options, tradeoffs, assumptions, decisions, claims, gaps, citations, confidence, and validation evidence.
+
+## Requirements
+
+### Requirement: Extract a full reasoning graph from decision-log packages
+
+The system SHALL deterministically extract full reasoning graph elements from structured decision-log packages.
+
+#### Scenario: Build graph from a package
+
+- GIVEN a validated decision-log package contains structured reasoning sections
+- WHEN the graph update workflow runs
+- THEN the graph contains nodes for `concept`, `question`, `option`, `tradeoff`, `assumption`, `decision`, `claim`, `open_question`, `source_gap`, `knowledge_note`, `citation`, `source_artifact`, `confidence_assessment`, and `validation_result`
+- AND edges preserve provenance back to the package, decision log, knowledge note, and source gap when present
+
+### Requirement: Use deterministic extraction as the required baseline
+
+The system SHALL make deterministic extraction sufficient for first-MVP graph correctness and MAY add Traverse-governed agent enrichment when available.
+
+#### Scenario: Agent enrichment unavailable
+
+- GIVEN deterministic extraction succeeds
+- AND agent enrichment is unavailable
+- WHEN the graph update completes
+- THEN the graph is valid for MVP acceptance
+- AND metadata records that optional enrichment did not run
+
+### Requirement: Select graph context by answer type
+
+The answer workflow SHALL select reasoning graph context according to the final answer type.
+
+#### Scenario: Answer a decision question
+
+- GIVEN the user asks why a decision was made
+- WHEN the answer workflow classifies the answer type as decision-oriented
+- THEN context selection prioritizes decisions, rationale, tradeoffs, options, assumptions, citations, and validation results
+
+#### Scenario: Answer an uncertainty question
+
+- GIVEN the user asks what is unknown or risky
+- WHEN the answer workflow classifies the answer type as uncertainty-oriented
+- THEN context selection prioritizes assumptions, open questions, source gaps, confidence assessments, conflicting claims, and validation results
+
+### Requirement: Classify answer type with traceable evidence
+
+The system SHALL provide deterministic answer-type classification and MAY allow a Traverse-governed agent override when available.
+
+#### Scenario: Record final answer type
+
+- GIVEN a user asks a question
+- WHEN the workflow selects graph context
+- THEN the trace records deterministic answer type, optional agent-refined answer type, final selected answer type, and graph-context strategy
+
+### Requirement: Handle conflicting graph knowledge transparently
+
+The system SHALL not silently choose one side of conflicting knowledge.
+
+#### Scenario: Conflict affects an answer
+
+- GIVEN the reasoning graph contains conflicting claims or decisions relevant to the question
+- WHEN the user asks a related question
+- THEN the answer summarizes the conflict with evidence
+- AND the workflow creates or updates a knowledge gap for conflict resolution


### PR DESCRIPTION
## Summary

- Record the approved expanded first-MVP decision log from the brainstorming session.
- Add approved OpenSpec surfaces for reasoning assistant skills, decision-log packages, reasoning graph extraction, knowledge gaps/conflicts, and local runtime/sync.
- Add MVP-041 through MVP-054 backlog entries with DoD and link the created GitHub issues #138-#151.

## Spec References

- openspec/specs/reasoning-assistant-skill/spec.md
- openspec/specs/decision-log-package/spec.md
- openspec/specs/reasoning-graph/spec.md
- openspec/specs/knowledge-gap-lifecycle/spec.md
- openspec/specs/local-runtime-sync/spec.md
- openspec/specs/knowledge-graph/spec.md
- openspec/specs/pwa-shell/spec.md
- openspec/specs/mcp-interface/spec.md

## Validation

```bash
PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
PYTHON=/opt/homebrew/bin/python3.14 \
bash scripts/smoke.sh
```

Result: passed.

## GitHub Project

- Created #138-#151.
- Added all to Project 3 as Ready.
