### PR TITLE
Add MVP-042 decision-log package validation

### DIFF
--- a/contracts/decision-log-package.metadata.schema.json
+++ b/contracts/decision-log-package.metadata.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://youaskm3.com/contracts/decision-log-package.metadata.schema.json",
+  "title": "youaskm3 decision-log package metadata",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "package_id",
+    "persona_id",
+    "mode",
+    "created_by",
+    "created_at",
+    "source_gap_id",
+    "required_files"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "package_id": {
+      "type": "string",
+      "pattern": "^decision-log-[0-9]{8}-[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "persona_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "mode": {
+      "enum": [
+        "knowledge_addition",
+        "gap_resolution",
+        "direct_fact_resolution",
+        "conflict_resolution"
+      ]
+    },
+    "created_by": {
+      "const": "youaskm3.reasoning-assistant"
+    },
+    "created_at": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+    },
+    "source_gap_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "required_files": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "decision-log.md",
+          "knowledge-note.md",
+          "metadata.json"
+        ]
+      },
+      "minItems": 3,
+      "maxItems": 3,
+      "uniqueItems": true
+    }
+  }
+}

--- a/fixtures/decision-log-packages/invalid/archive.zip
+++ b/fixtures/decision-log-packages/invalid/archive.zip
@@ -1,0 +1,1 @@
+archive inputs are intentionally rejected before archive inspection

--- a/fixtures/decision-log-packages/invalid/incomplete-sections/decision-log.md
+++ b/fixtures/decision-log-packages/invalid/incomplete-sections/decision-log.md
@@ -1,0 +1,10 @@
+# Incomplete Sections
+
+## Package ID
+decision-log-20260629-incomplete-sections
+
+## Persona ID
+default
+
+## Package Mode
+knowledge_addition

--- a/fixtures/decision-log-packages/invalid/incomplete-sections/knowledge-note.md
+++ b/fixtures/decision-log-packages/invalid/incomplete-sections/knowledge-note.md
@@ -1,0 +1,22 @@
+# Incomplete Sections Note
+
+## Package ID
+decision-log-20260629-incomplete-sections
+
+## Title
+Incomplete fixture
+
+## Summary
+This should fail.
+
+## Supported Claims
+- Incomplete decision logs fail deterministic validation.
+
+## Decisions To Remember
+- Reject incomplete packages.
+
+## Assumptions To Revisit
+- None.
+
+## Provenance
+Distilled from `decision-log.md`.

--- a/fixtures/decision-log-packages/invalid/incomplete-sections/metadata.json
+++ b/fixtures/decision-log-packages/invalid/incomplete-sections/metadata.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0.0",
+  "package_id": "decision-log-20260629-incomplete-sections",
+  "persona_id": "default",
+  "mode": "knowledge_addition",
+  "created_by": "youaskm3.reasoning-assistant",
+  "created_at": "2026-06-29T13:10:00Z",
+  "source_gap_id": null,
+  "required_files": [
+    "decision-log.md",
+    "knowledge-note.md",
+    "metadata.json"
+  ]
+}

--- a/fixtures/decision-log-packages/invalid/mismatched-id/decision-log.md
+++ b/fixtures/decision-log-packages/invalid/mismatched-id/decision-log.md
@@ -1,0 +1,52 @@
+# Mismatched ID
+
+## Package ID
+decision-log-20260629-other-id
+
+## Persona ID
+default
+
+## Package Mode
+knowledge_addition
+
+## Knowledge Addition
+Invalid package id mismatch.
+
+## Conversation Goal
+Check package id consistency.
+
+## Questions Asked
+- Should ids match?
+
+## Options Considered
+- Yes
+
+## Pros and Cons
+- Yes: stable provenance.
+
+## Recommendation
+Reject mismatches.
+
+## Assumptions
+- IDs are authoritative.
+
+## Challenged Assumptions
+- A note can carry a different id.
+
+## Decisions
+- Package ids must match.
+
+## Claims
+- Package ids must match across package files.
+
+## Confidence Assessment
+High.
+
+## Citations
+- openspec/specs/decision-log-package/spec.md
+
+## Remaining Non-Blocking Open Questions
+- None.
+
+## Blocking Clarifications
+None.

--- a/fixtures/decision-log-packages/invalid/mismatched-id/knowledge-note.md
+++ b/fixtures/decision-log-packages/invalid/mismatched-id/knowledge-note.md
@@ -1,0 +1,22 @@
+# Mismatched ID Note
+
+## Package ID
+decision-log-20260629-mismatched-id
+
+## Title
+Mismatched id fixture
+
+## Summary
+This should fail.
+
+## Supported Claims
+- Package ids must match across package files.
+
+## Decisions To Remember
+- Package ids must match.
+
+## Assumptions To Revisit
+- None.
+
+## Provenance
+Distilled from `decision-log.md`.

--- a/fixtures/decision-log-packages/invalid/mismatched-id/metadata.json
+++ b/fixtures/decision-log-packages/invalid/mismatched-id/metadata.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0.0",
+  "package_id": "decision-log-20260629-mismatched-id",
+  "persona_id": "default",
+  "mode": "knowledge_addition",
+  "created_by": "youaskm3.reasoning-assistant",
+  "created_at": "2026-06-29T13:15:00Z",
+  "source_gap_id": null,
+  "required_files": [
+    "decision-log.md",
+    "knowledge-note.md",
+    "metadata.json"
+  ]
+}

--- a/fixtures/decision-log-packages/invalid/missing-file/decision-log.md
+++ b/fixtures/decision-log-packages/invalid/missing-file/decision-log.md
@@ -1,0 +1,1 @@
+# Missing File

--- a/fixtures/decision-log-packages/invalid/missing-file/metadata.json
+++ b/fixtures/decision-log-packages/invalid/missing-file/metadata.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0.0",
+  "package_id": "decision-log-20260629-missing-file",
+  "persona_id": "default",
+  "mode": "knowledge_addition",
+  "created_by": "youaskm3.reasoning-assistant",
+  "created_at": "2026-06-29T13:00:00Z",
+  "source_gap_id": null,
+  "required_files": [
+    "decision-log.md",
+    "knowledge-note.md",
+    "metadata.json"
+  ]
+}

--- a/fixtures/decision-log-packages/invalid/unsupported-mode/decision-log.md
+++ b/fixtures/decision-log-packages/invalid/unsupported-mode/decision-log.md
@@ -1,0 +1,49 @@
+# Unsupported Mode
+
+## Package ID
+decision-log-20260629-unsupported-mode
+
+## Persona ID
+default
+
+## Package Mode
+brain_dump
+
+## Conversation Goal
+Invalid mode fixture.
+
+## Questions Asked
+- Is this valid?
+
+## Options Considered
+- No
+
+## Pros and Cons
+- No: unsupported mode.
+
+## Recommendation
+Reject it.
+
+## Assumptions
+- Modes are enumerated.
+
+## Challenged Assumptions
+- Any label is acceptable.
+
+## Decisions
+- Unsupported modes fail.
+
+## Claims
+- Unsupported modes fail deterministic validation.
+
+## Confidence Assessment
+High.
+
+## Citations
+- openspec/specs/decision-log-package/spec.md
+
+## Remaining Non-Blocking Open Questions
+- None.
+
+## Blocking Clarifications
+None.

--- a/fixtures/decision-log-packages/invalid/unsupported-mode/knowledge-note.md
+++ b/fixtures/decision-log-packages/invalid/unsupported-mode/knowledge-note.md
@@ -1,0 +1,22 @@
+# Unsupported Mode Note
+
+## Package ID
+decision-log-20260629-unsupported-mode
+
+## Title
+Unsupported mode fixture
+
+## Summary
+This should fail.
+
+## Supported Claims
+- Unsupported modes fail deterministic validation.
+
+## Decisions To Remember
+- Unsupported modes fail.
+
+## Assumptions To Revisit
+- None.
+
+## Provenance
+Distilled from `decision-log.md`.

--- a/fixtures/decision-log-packages/invalid/unsupported-mode/metadata.json
+++ b/fixtures/decision-log-packages/invalid/unsupported-mode/metadata.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0.0",
+  "package_id": "decision-log-20260629-unsupported-mode",
+  "persona_id": "default",
+  "mode": "brain_dump",
+  "created_by": "youaskm3.reasoning-assistant",
+  "created_at": "2026-06-29T13:05:00Z",
+  "source_gap_id": null,
+  "required_files": [
+    "decision-log.md",
+    "knowledge-note.md",
+    "metadata.json"
+  ]
+}

--- a/fixtures/decision-log-packages/invalid/unsupported-note-claim/decision-log.md
+++ b/fixtures/decision-log-packages/invalid/unsupported-note-claim/decision-log.md
@@ -1,0 +1,52 @@
+# Unsupported Note Claim
+
+## Package ID
+decision-log-20260629-unsupported-note
+
+## Persona ID
+default
+
+## Package Mode
+knowledge_addition
+
+## Knowledge Addition
+Invalid note claim fixture.
+
+## Conversation Goal
+Check that knowledge-note claims are supported by the decision log.
+
+## Questions Asked
+- Can the note add new claims?
+
+## Options Considered
+- No
+
+## Pros and Cons
+- No: keeps distilled knowledge traceable.
+
+## Recommendation
+Reject unsupported note claims.
+
+## Assumptions
+- Supported claims must be exact bullets.
+
+## Challenged Assumptions
+- Summaries can invent claims.
+
+## Decisions
+- Notes cannot introduce new claims.
+
+## Claims
+- Knowledge notes must only contain supported claims.
+
+## Confidence Assessment
+High.
+
+## Citations
+- openspec/specs/decision-log-package/spec.md
+
+## Remaining Non-Blocking Open Questions
+- None.
+
+## Blocking Clarifications
+None.

--- a/fixtures/decision-log-packages/invalid/unsupported-note-claim/knowledge-note.md
+++ b/fixtures/decision-log-packages/invalid/unsupported-note-claim/knowledge-note.md
@@ -1,0 +1,22 @@
+# Unsupported Note Claim
+
+## Package ID
+decision-log-20260629-unsupported-note
+
+## Title
+Unsupported note fixture
+
+## Summary
+This should fail.
+
+## Supported Claims
+- Knowledge notes may invent unsupported claims.
+
+## Decisions To Remember
+- Notes cannot introduce new claims.
+
+## Assumptions To Revisit
+- None.
+
+## Provenance
+Distilled from `decision-log.md`.

--- a/fixtures/decision-log-packages/invalid/unsupported-note-claim/metadata.json
+++ b/fixtures/decision-log-packages/invalid/unsupported-note-claim/metadata.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0.0",
+  "package_id": "decision-log-20260629-unsupported-note",
+  "persona_id": "default",
+  "mode": "knowledge_addition",
+  "created_by": "youaskm3.reasoning-assistant",
+  "created_at": "2026-06-29T13:20:00Z",
+  "source_gap_id": null,
+  "required_files": [
+    "decision-log.md",
+    "knowledge-note.md",
+    "metadata.json"
+  ]
+}

--- a/fixtures/decision-log-packages/valid/conflict_resolution/decision-log.md
+++ b/fixtures/decision-log-packages/valid/conflict_resolution/decision-log.md
@@ -1,0 +1,54 @@
+# Conflict Resolution Decision Log
+
+## Package ID
+decision-log-20260629-conflict-resolution
+
+## Persona ID
+default
+
+## Package Mode
+conflict_resolution
+
+## Conflict Resolution
+Resolved a conflict between generic document chat and second-brain positioning.
+
+## Conversation Goal
+Choose the durable product framing for the first MVP.
+
+## Questions Asked
+- Is the first MVP generic document chat or a second-brain reasoning loop?
+
+## Options Considered
+- Generic document chat
+- Second-brain reasoning loop
+
+## Pros and Cons
+- Generic document chat: familiar; misses the product promise.
+- Second-brain reasoning loop: sharper; requires package and graph follow-through.
+
+## Recommendation
+Frame the product as a second-brain reasoning loop.
+
+## Assumptions
+- Durable reasoning capture is part of product value.
+
+## Challenged Assumptions
+- Retrieval over files is sufficient.
+
+## Decisions
+- youaskm3 is a second-brain reasoning product, not generic document chat.
+
+## Claims
+- The first MVP is a second-brain reasoning loop rather than generic document chat.
+
+## Confidence Assessment
+High; this follows the approved expanded MVP.
+
+## Citations
+- SPEC.md
+
+## Remaining Non-Blocking Open Questions
+- Later federation scope remains separate.
+
+## Blocking Clarifications
+None.

--- a/fixtures/decision-log-packages/valid/conflict_resolution/knowledge-note.md
+++ b/fixtures/decision-log-packages/valid/conflict_resolution/knowledge-note.md
@@ -1,0 +1,22 @@
+# Conflict Resolution Knowledge Note
+
+## Package ID
+decision-log-20260629-conflict-resolution
+
+## Title
+youaskm3 is a second-brain reasoning product.
+
+## Summary
+The first MVP should be framed around reasoning capture and durable knowledge, not generic chat over files.
+
+## Supported Claims
+- The first MVP is a second-brain reasoning loop rather than generic document chat.
+
+## Decisions To Remember
+- youaskm3 is a second-brain reasoning product, not generic document chat.
+
+## Assumptions To Revisit
+- Later federation scope remains separate.
+
+## Provenance
+Distilled from `decision-log.md`.

--- a/fixtures/decision-log-packages/valid/conflict_resolution/metadata.json
+++ b/fixtures/decision-log-packages/valid/conflict_resolution/metadata.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0.0",
+  "package_id": "decision-log-20260629-conflict-resolution",
+  "persona_id": "default",
+  "mode": "conflict_resolution",
+  "created_by": "youaskm3.reasoning-assistant",
+  "created_at": "2026-06-29T12:15:00Z",
+  "source_gap_id": null,
+  "required_files": [
+    "decision-log.md",
+    "knowledge-note.md",
+    "metadata.json"
+  ]
+}

--- a/fixtures/decision-log-packages/valid/direct_fact_resolution/decision-log.md
+++ b/fixtures/decision-log-packages/valid/direct_fact_resolution/decision-log.md
@@ -1,0 +1,54 @@
+# Direct Fact Decision Log
+
+## Package ID
+decision-log-20260629-direct-fact
+
+## Persona ID
+default
+
+## Package Mode
+direct_fact_resolution
+
+## Direct Fact Resolution
+Captured a simple factual preference from chat.
+
+## Conversation Goal
+Record the preferred CLI command for importing reasoning packages.
+
+## Questions Asked
+- What command should users run to import a package?
+
+## Options Considered
+- `m3 ingest-decision-log /path/to/decision-log-package/`
+- A watched inbox folder
+
+## Pros and Cons
+- CLI command: explicit and auditable; requires user action.
+- Watched inbox folder: automatic; out of scope for the first MVP.
+
+## Recommendation
+Use the explicit CLI command.
+
+## Assumptions
+- The first MVP keeps ingestion CLI-managed.
+
+## Challenged Assumptions
+- Automation is always better than explicit import.
+
+## Decisions
+- First-MVP decision-log ingestion is CLI-managed.
+
+## Claims
+- The first MVP uses CLI-managed decision-log ingestion.
+
+## Confidence Assessment
+High; this is an approved decision.
+
+## Citations
+- docs/expanded-second-brain-mvp-decision-log.md
+
+## Remaining Non-Blocking Open Questions
+- Later inbox automation can be reconsidered after the first MVP.
+
+## Blocking Clarifications
+None.

--- a/fixtures/decision-log-packages/valid/direct_fact_resolution/knowledge-note.md
+++ b/fixtures/decision-log-packages/valid/direct_fact_resolution/knowledge-note.md
@@ -1,0 +1,22 @@
+# Direct Fact Knowledge Note
+
+## Package ID
+decision-log-20260629-direct-fact
+
+## Title
+Decision-log ingestion is CLI-managed.
+
+## Summary
+The first MVP imports decision-log packages through an explicit CLI command.
+
+## Supported Claims
+- The first MVP uses CLI-managed decision-log ingestion.
+
+## Decisions To Remember
+- First-MVP decision-log ingestion is CLI-managed.
+
+## Assumptions To Revisit
+- Later inbox automation can be reconsidered after the first MVP.
+
+## Provenance
+Distilled from `decision-log.md`.

--- a/fixtures/decision-log-packages/valid/direct_fact_resolution/metadata.json
+++ b/fixtures/decision-log-packages/valid/direct_fact_resolution/metadata.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0.0",
+  "package_id": "decision-log-20260629-direct-fact",
+  "persona_id": "default",
+  "mode": "direct_fact_resolution",
+  "created_by": "youaskm3.reasoning-assistant",
+  "created_at": "2026-06-29T12:10:00Z",
+  "source_gap_id": null,
+  "required_files": [
+    "decision-log.md",
+    "knowledge-note.md",
+    "metadata.json"
+  ]
+}

--- a/fixtures/decision-log-packages/valid/gap_resolution/decision-log.md
+++ b/fixtures/decision-log-packages/valid/gap_resolution/decision-log.md
@@ -1,0 +1,54 @@
+# Gap Resolution Decision Log
+
+## Package ID
+decision-log-20260629-gap-resolution
+
+## Persona ID
+default
+
+## Package Mode
+gap_resolution
+
+## Gap Resolution
+Resolved source gap `gap-runtime-policy`.
+
+## Conversation Goal
+Clarify whether missing runtime capability should create a downstream workaround.
+
+## Questions Asked
+- Should a missing Traverse surface be bypassed downstream?
+
+## Options Considered
+- Add a downstream shortcut
+- Keep the downstream issue blocked and raise an upstream requirement
+
+## Pros and Cons
+- Downstream shortcut: faster demo; violates runtime boundary.
+- Upstream requirement: slower; preserves governed execution.
+
+## Recommendation
+Keep the downstream issue blocked and raise an upstream requirement.
+
+## Assumptions
+- Runtime business behavior belongs in Traverse-governed WASM.
+
+## Challenged Assumptions
+- A local shortcut can count as MVP acceptance.
+
+## Decisions
+- Missing Traverse public surfaces become upstream requirements.
+
+## Claims
+- Missing Traverse public surfaces must not be hidden by downstream shortcuts.
+
+## Confidence Assessment
+High; this follows the blocker escalation rule.
+
+## Citations
+- docs/traverse-blocker-escalation.md
+
+## Remaining Non-Blocking Open Questions
+- Exact upstream release placement can be decided later.
+
+## Blocking Clarifications
+None.

--- a/fixtures/decision-log-packages/valid/gap_resolution/knowledge-note.md
+++ b/fixtures/decision-log-packages/valid/gap_resolution/knowledge-note.md
@@ -1,0 +1,22 @@
+# Gap Resolution Knowledge Note
+
+## Package ID
+decision-log-20260629-gap-resolution
+
+## Title
+Traverse gaps stay explicit.
+
+## Summary
+Missing Traverse public surfaces should remain visible as upstream requirements.
+
+## Supported Claims
+- Missing Traverse public surfaces must not be hidden by downstream shortcuts.
+
+## Decisions To Remember
+- Missing Traverse public surfaces become upstream requirements.
+
+## Assumptions To Revisit
+- Exact upstream release placement can be decided later.
+
+## Provenance
+Distilled from `decision-log.md`.

--- a/fixtures/decision-log-packages/valid/gap_resolution/metadata.json
+++ b/fixtures/decision-log-packages/valid/gap_resolution/metadata.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0.0",
+  "package_id": "decision-log-20260629-gap-resolution",
+  "persona_id": "default",
+  "mode": "gap_resolution",
+  "created_by": "youaskm3.reasoning-assistant",
+  "created_at": "2026-06-29T12:05:00Z",
+  "source_gap_id": "gap-runtime-policy",
+  "required_files": [
+    "decision-log.md",
+    "knowledge-note.md",
+    "metadata.json"
+  ]
+}

--- a/fixtures/decision-log-packages/valid/knowledge_addition/decision-log.md
+++ b/fixtures/decision-log-packages/valid/knowledge_addition/decision-log.md
@@ -1,0 +1,55 @@
+# Portable Reasoning Decision Log
+
+## Package ID
+decision-log-20260629-portable-reasoning
+
+## Persona ID
+default
+
+## Package Mode
+knowledge_addition
+
+## Knowledge Addition
+Capture a reusable principle for treating reasoning conversations as durable knowledge inputs.
+
+## Conversation Goal
+Decide how a reasoning assistant should preserve product decisions for later youaskm3 ingestion.
+
+## Questions Asked
+- Should the assistant produce one markdown file or a package?
+
+## Options Considered
+- One markdown file
+- Package with decision log, knowledge note, and metadata
+
+## Pros and Cons
+- One markdown file: simple to copy; weak provenance.
+- Package with decision log, knowledge note, and metadata: more structure; easier deterministic validation.
+
+## Recommendation
+Use a package with explicit metadata and separate distilled knowledge.
+
+## Assumptions
+- Deterministic validation should run before ingestion.
+
+## Challenged Assumptions
+- A single markdown file is enough for provenance.
+
+## Decisions
+- Decision-log packages are the first-class reasoning input.
+
+## Claims
+- Decision-log packages preserve provenance better than single markdown notes.
+- Deterministic validation should run before Traverse semantic validation.
+
+## Confidence Assessment
+High; this follows the approved expanded MVP decision log.
+
+## Citations
+- docs/expanded-second-brain-mvp-decision-log.md
+
+## Remaining Non-Blocking Open Questions
+- Future package compression can be considered after the first MVP.
+
+## Blocking Clarifications
+None.

--- a/fixtures/decision-log-packages/valid/knowledge_addition/knowledge-note.md
+++ b/fixtures/decision-log-packages/valid/knowledge_addition/knowledge-note.md
@@ -1,0 +1,23 @@
+# Portable Reasoning Knowledge Note
+
+## Package ID
+decision-log-20260629-portable-reasoning
+
+## Title
+Decision-log packages preserve reasoning provenance.
+
+## Summary
+Reasoning conversations should be captured as package directories so ingestion can validate provenance and supported claims.
+
+## Supported Claims
+- Decision-log packages preserve provenance better than single markdown notes.
+- Deterministic validation should run before Traverse semantic validation.
+
+## Decisions To Remember
+- Decision-log packages are the first-class reasoning input.
+
+## Assumptions To Revisit
+- Future package compression can be considered after the first MVP.
+
+## Provenance
+Distilled from `decision-log.md`.

--- a/fixtures/decision-log-packages/valid/knowledge_addition/metadata.json
+++ b/fixtures/decision-log-packages/valid/knowledge_addition/metadata.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0.0",
+  "package_id": "decision-log-20260629-portable-reasoning",
+  "persona_id": "default",
+  "mode": "knowledge_addition",
+  "created_by": "youaskm3.reasoning-assistant",
+  "created_at": "2026-06-29T12:00:00Z",
+  "source_gap_id": null,
+  "required_files": [
+    "decision-log.md",
+    "knowledge-note.md",
+    "metadata.json"
+  ]
+}

--- a/scripts/decision-log-package-smoke.sh
+++ b/scripts/decision-log-package-smoke.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VALIDATOR="ruby ./scripts/validate-decision-log-package.rb"
+
+cd "$ROOT_DIR"
+
+for mode in knowledge_addition gap_resolution direct_fact_resolution conflict_resolution; do
+  $VALIDATOR "fixtures/decision-log-packages/valid/${mode}" --semantic-validation unavailable \
+    | ruby -rjson -e 'data=JSON.parse(STDIN.read); abort "expected valid package" unless data.fetch("valid") && data.dig("validation", "semantic", "status") == "unavailable"'
+done
+
+$VALIDATOR fixtures/decision-log-packages/valid/knowledge_addition --semantic-validation passed \
+  | ruby -rjson -e 'data=JSON.parse(STDIN.read); abort "expected semantic pass" unless data.fetch("valid") && data.dig("validation", "semantic", "status") == "passed"'
+
+if $VALIDATOR fixtures/decision-log-packages/valid/knowledge_addition --semantic-validation failed >/tmp/decision-log-semantic-failed.json; then
+  echo "Expected semantic validation failure to exit non-zero." >&2
+  exit 1
+fi
+ruby -rjson -e 'data=JSON.parse(File.read("/tmp/decision-log-semantic-failed.json")); abort "expected semantic gap creation" unless !data.fetch("valid") && data.fetch("gap_creation").fetch("reason") == "semantic_validation_failed"'
+
+invalid_expectations=(
+  "missing-file:MISSING_REQUIRED_FILE"
+  "unsupported-mode:UNSUPPORTED_PACKAGE_MODE"
+  "incomplete-sections:DECISION_SECTION_MISSING"
+  "mismatched-id:PACKAGE_ID_MISMATCH"
+  "unsupported-note-claim:UNSUPPORTED_KNOWLEDGE_NOTE_CLAIM"
+)
+
+for pair in "${invalid_expectations[@]}"; do
+  fixture="${pair%%:*}"
+  expected="${pair#*:}"
+  output="/tmp/decision-log-${fixture}.json"
+  if $VALIDATOR "fixtures/decision-log-packages/invalid/${fixture}" >"$output"; then
+    echo "Expected invalid fixture to fail: ${fixture}" >&2
+    exit 1
+  fi
+  ruby -rjson -e 'data=JSON.parse(File.read(ARGV[0])); expected=ARGV[1]; codes=data.fetch("errors").map { |error| error.fetch("code") }; abort "missing expected error #{expected}: #{codes.inspect}" unless codes.include?(expected)' "$output" "$expected"
+done
+
+if $VALIDATOR fixtures/decision-log-packages/invalid/archive.zip >/tmp/decision-log-archive.json; then
+  echo "Expected archive input to fail." >&2
+  exit 1
+fi
+ruby -rjson -e 'data=JSON.parse(File.read("/tmp/decision-log-archive.json")); codes=data.fetch("errors").map { |error| error.fetch("code") }; abort "missing archive rejection" unless codes.include?("ARCHIVE_INPUT_UNSUPPORTED")'
+
+echo "Decision-log package smoke passed."

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -105,6 +105,9 @@ bash ./scripts/mvp-graph-artifact-smoke.sh
 echo "Validating reasoning skill adapter generation..."
 bash ./scripts/reasoning-skill-adapters-smoke.sh
 
+echo "Validating decision-log package contract..."
+bash ./scripts/decision-log-package-smoke.sh
+
 echo "Validating federation index generation..."
 bash ./scripts/federation-index-smoke.sh
 

--- a/scripts/validate-decision-log-package.rb
+++ b/scripts/validate-decision-log-package.rb
@@ -1,0 +1,215 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "pathname"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
+REQUIRED_FILES = ["decision-log.md", "knowledge-note.md", "metadata.json"].freeze
+ALLOWED_MODES = ["knowledge_addition", "gap_resolution", "direct_fact_resolution", "conflict_resolution"].freeze
+ARCHIVE_EXTENSIONS = [".zip", ".tar", ".tgz", ".tar.gz", ".gz"].freeze
+PACKAGE_ID_PATTERN = /\Adecision-log-\d{8}-[a-z0-9]+(?:-[a-z0-9]+)*\z/
+SEMANTIC_STATES = ["unavailable", "passed", "failed"].freeze
+
+DECISION_SECTIONS = [
+  "Package ID",
+  "Persona ID",
+  "Package Mode",
+  "Conversation Goal",
+  "Questions Asked",
+  "Options Considered",
+  "Pros and Cons",
+  "Recommendation",
+  "Assumptions",
+  "Challenged Assumptions",
+  "Decisions",
+  "Claims",
+  "Confidence Assessment",
+  "Citations",
+  "Remaining Non-Blocking Open Questions",
+  "Blocking Clarifications"
+].freeze
+
+NOTE_SECTIONS = [
+  "Package ID",
+  "Title",
+  "Summary",
+  "Supported Claims",
+  "Decisions To Remember",
+  "Assumptions To Revisit",
+  "Provenance"
+].freeze
+
+MODE_SECTION = {
+  "knowledge_addition" => "Knowledge Addition",
+  "gap_resolution" => "Gap Resolution",
+  "direct_fact_resolution" => "Direct Fact Resolution",
+  "conflict_resolution" => "Conflict Resolution"
+}.freeze
+
+def usage
+  abort "Usage: ruby scripts/validate-decision-log-package.rb <package-dir> [--semantic-validation unavailable|passed|failed]"
+end
+
+def parse_args(argv)
+  usage if argv.empty?
+  path = argv.shift
+  semantic = "unavailable"
+
+  until argv.empty?
+    flag = argv.shift
+    case flag
+    when "--semantic-validation"
+      semantic = argv.shift || usage
+    else
+      usage
+    end
+  end
+
+  usage unless SEMANTIC_STATES.include?(semantic)
+  [Pathname.new(path), semantic]
+end
+
+def section_map(markdown)
+  sections = {}
+  current = nil
+
+  markdown.each_line do |line|
+    if (match = line.match(/\A##\s+(.+?)\s*\z/))
+      current = match[1]
+      sections[current] = +""
+    elsif current
+      sections[current] << line
+    end
+  end
+
+  sections.transform_values(&:strip)
+end
+
+def bullets(section)
+  section.each_line.each_with_object([]) do |line, values|
+    match = line.match(/\A-\s+(.+?)\s*\z/)
+    values << match[1].strip if match
+  end
+end
+
+def json_result(ok:, package_id: nil, mode: nil, errors: [], semantic: "unavailable")
+  result = {
+    "valid" => ok,
+    "package_id" => package_id,
+    "mode" => mode,
+    "errors" => errors,
+    "validation" => {
+      "deterministic" => ok && semantic != "failed" ? "passed" : "failed",
+      "semantic" => {
+        "status" => semantic
+      }
+    }
+  }
+
+  if semantic == "failed"
+    result["valid"] = false
+    result["errors"] << {
+      "code" => "SEMANTIC_VALIDATION_FAILED",
+      "message" => "Traverse semantic validation rejected the decision-log package."
+    }
+    result["gap_creation"] = {
+      "kind" => "knowledge_gap",
+      "source_package_id" => package_id,
+      "reason" => "semantic_validation_failed"
+    }
+  end
+
+  result
+end
+
+def add_error(errors, code, message)
+  errors << { "code" => code, "message" => message }
+end
+
+package_path, semantic = parse_args(ARGV)
+errors = []
+
+if ARCHIVE_EXTENSIONS.any? { |ext| package_path.to_s.end_with?(ext) }
+  result = json_result(ok: false, errors: [{ "code" => "ARCHIVE_INPUT_UNSUPPORTED", "message" => "Decision-log package input must be a directory, not an archive." }], semantic: semantic)
+  puts JSON.pretty_generate(result)
+  exit 1
+end
+
+unless package_path.directory?
+  result = json_result(ok: false, errors: [{ "code" => "PACKAGE_NOT_DIRECTORY", "message" => "Decision-log package input must be a directory." }], semantic: semantic)
+  puts JSON.pretty_generate(result)
+  exit 1
+end
+
+missing_files = REQUIRED_FILES.reject { |file| package_path.join(file).file? }
+unless missing_files.empty?
+  missing_files.each { |file| add_error(errors, "MISSING_REQUIRED_FILE", "Missing required package file: #{file}") }
+  puts JSON.pretty_generate(json_result(ok: false, errors: errors, semantic: semantic))
+  exit 1
+end
+
+metadata = nil
+begin
+  metadata = JSON.parse(package_path.join("metadata.json").read)
+rescue JSON::ParserError => error
+  add_error(errors, "INVALID_METADATA_JSON", "metadata.json is not valid JSON: #{error.message}")
+end
+
+if metadata
+  required_metadata = ["schema_version", "package_id", "persona_id", "mode", "created_by", "created_at", "source_gap_id", "required_files"]
+  (required_metadata - metadata.keys).each { |key| add_error(errors, "METADATA_FIELD_MISSING", "metadata.json is missing #{key}") }
+
+  package_id = metadata["package_id"]
+  mode = metadata["mode"]
+  add_error(errors, "UNSUPPORTED_PACKAGE_ID", "metadata.json package_id must match #{PACKAGE_ID_PATTERN.inspect}") unless package_id.is_a?(String) && package_id.match?(PACKAGE_ID_PATTERN)
+  add_error(errors, "UNSUPPORTED_PACKAGE_MODE", "metadata.json mode must be one of #{ALLOWED_MODES.join(", ")}") unless ALLOWED_MODES.include?(mode)
+  add_error(errors, "UNSUPPORTED_SCHEMA_VERSION", "metadata.json schema_version must be 1.0.0") unless metadata["schema_version"] == "1.0.0"
+  add_error(errors, "UNSUPPORTED_CREATED_BY", "metadata.json created_by must be youaskm3.reasoning-assistant") unless metadata["created_by"] == "youaskm3.reasoning-assistant"
+
+  unless metadata["required_files"].is_a?(Array) && metadata["required_files"].sort == REQUIRED_FILES.sort
+    add_error(errors, "REQUIRED_FILES_MISMATCH", "metadata.json required_files must contain decision-log.md, knowledge-note.md, and metadata.json")
+  end
+
+  if mode == "gap_resolution" && (!metadata["source_gap_id"].is_a?(String) || metadata["source_gap_id"].empty?)
+    add_error(errors, "SOURCE_GAP_ID_REQUIRED", "gap_resolution packages require source_gap_id")
+  end
+end
+
+decision = section_map(package_path.join("decision-log.md").read)
+note = section_map(package_path.join("knowledge-note.md").read)
+
+DECISION_SECTIONS.each do |section|
+  value = decision[section]
+  add_error(errors, "DECISION_SECTION_MISSING", "decision-log.md is missing ## #{section}") if value.nil? || value.empty?
+end
+
+NOTE_SECTIONS.each do |section|
+  value = note[section]
+  add_error(errors, "NOTE_SECTION_MISSING", "knowledge-note.md is missing ## #{section}") if value.nil? || value.empty?
+end
+
+if metadata
+  package_id = metadata["package_id"]
+  mode = metadata["mode"]
+  mode_section = MODE_SECTION[mode]
+
+  add_error(errors, "MODE_SECTION_MISSING", "decision-log.md is missing ## #{mode_section}") if mode_section && decision[mode_section].to_s.empty?
+  add_error(errors, "PACKAGE_ID_MISMATCH", "decision-log.md package id does not match metadata.json") unless decision["Package ID"].to_s.include?(package_id.to_s)
+  add_error(errors, "PACKAGE_ID_MISMATCH", "knowledge-note.md package id does not match metadata.json") unless note["Package ID"].to_s.include?(package_id.to_s)
+  add_error(errors, "MODE_MISMATCH", "decision-log.md package mode does not match metadata.json") unless decision["Package Mode"].to_s.include?(mode.to_s)
+
+  if !decision["Blocking Clarifications"].to_s.match?(/\b[Nn]one\b/)
+    add_error(errors, "BLOCKING_CLARIFICATIONS_OPEN", "decision-log.md must state that no blocking clarifications remain")
+  end
+
+  decision_claims = bullets(decision["Claims"].to_s)
+  note_claims = bullets(note["Supported Claims"].to_s)
+  unsupported = note_claims - decision_claims
+  unsupported.each { |claim| add_error(errors, "UNSUPPORTED_KNOWLEDGE_NOTE_CLAIM", "knowledge-note.md claim is not supported by decision-log.md: #{claim}") }
+end
+
+ok = errors.empty?
+result = json_result(ok: ok, package_id: metadata && metadata["package_id"], mode: metadata && metadata["mode"], errors: errors, semantic: semantic)
+puts JSON.pretty_generate(result)
+exit(ok && semantic != "failed" ? 0 : 1)


### PR DESCRIPTION
## What this changes

Adds the MVP-042 decision-log package contract layer: metadata schema, deterministic package validator, valid/invalid fixture packages, and smoke coverage for package modes and failure classes.

## Spec reference

- `openspec/specs/decision-log-package/spec.md` - Validate package structure, provenance, note consistency, semantic validation states, and offline staging boundary
- `openspec/specs/reasoning-assistant-skill/spec.md` - Produce a decision-log package
- `openspec/specs/knowledge-gap-lifecycle/spec.md` - gap creation path for failed validation

## Spec delta (if spec changed)

None in this PR.

## Test coverage

Added `scripts/decision-log-package-smoke.sh`, covering:

- all four package modes
- deterministic valid package checks
- semantic validation `unavailable`, `passed`, and `failed`
- gap creation output for failed semantic validation
- missing file, unsupported mode, incomplete sections, mismatched id, unsupported note claim, and archive rejection

Validation:

```bash
PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
PYTHON=/opt/homebrew/bin/python3.14 \
bash scripts/smoke.sh
```

Result: passed.

## Lean ops / minimality

Kept this slice to schema, deterministic validation, fixtures, and smoke wiring. No ingestion/write path was added; MVP-043 owns CLI ingestion and provenance storage.

## Breaking changes

None.

Closes #139
