### PR TITLE
Add MVP-043 decision-log package ingestion

### DIFF
--- a/scripts/ingest-decision-log.rb
+++ b/scripts/ingest-decision-log.rb
@@ -1,0 +1,160 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "open3"
+require "pathname"
+require "rbconfig"
+require "tmpdir"
+require "time"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
+DEFAULT_KNOWLEDGE_ROOT = ROOT.join("knowledge")
+REQUIRED_PACKAGE_FILES = ["decision-log.md", "knowledge-note.md", "metadata.json"].freeze
+ARCHIVE_EXTENSIONS = [".zip", ".tar", ".tgz", ".tar.gz", ".gz"].freeze
+
+def usage
+  abort "Usage: ./scripts/m3.sh ingest-decision-log <package-dir> [--knowledge-root PATH] [--offline]"
+end
+
+def parse_args(argv)
+  usage if argv.empty?
+  package_path = Pathname.new(argv.shift)
+  knowledge_root = DEFAULT_KNOWLEDGE_ROOT
+  offline = false
+
+  until argv.empty?
+    flag = argv.shift
+    case flag
+    when "--knowledge-root"
+      knowledge_root = Pathname.new(argv.shift || usage)
+    when "--offline"
+      offline = true
+    else
+      usage
+    end
+  end
+
+  [package_path.expand_path, knowledge_root.expand_path, offline]
+end
+
+def stable_error(code, message)
+  warn "#{code}: #{message}"
+  exit 1
+end
+
+def archive_path?(path)
+  ARCHIVE_EXTENSIONS.any? { |extension| path.to_s.end_with?(extension) }
+end
+
+def relative_to?(path, root)
+  path.ascend.any? { |ancestor| ancestor == root }
+end
+
+def validate_knowledge_root!(knowledge_root)
+  if knowledge_root == DEFAULT_KNOWLEDGE_ROOT
+    FileUtils.mkdir_p(knowledge_root)
+    return
+  end
+
+  marker = knowledge_root.join(".youaskm3-knowledge-root.json")
+  stable_error("EXTERNAL_KNOWLEDGE_ROOT_UNINITIALIZED", "External knowledge roots must be initialized before writes: #{knowledge_root}") unless marker.file?
+end
+
+def sync_preflight!(knowledge_root)
+  return unless knowledge_root == DEFAULT_KNOWLEDGE_ROOT
+
+  author_instance = ROOT.join("app", "site", "author-instance.json")
+  sync_state = ROOT.join("app", "site", "sync-state.json")
+  stable_error("INSTANCE_NOT_INITIALIZED", "Run ./scripts/m3.sh init before ingesting decision-log packages.") unless author_instance.file?
+  return unless sync_state.file?
+
+  Dir.mktmpdir do |tmpdir|
+    system(RbConfig.ruby, ROOT.join("scripts", "generate-site-artifacts.rb").to_s, tmpdir, out: File::NULL, err: File::NULL) ||
+      stable_error("SYNC_PREFLIGHT_FAILED", "Unable to compute sync preflight state.")
+    generated = Pathname.new(tmpdir).join("sync-state.json")
+    unless generated.read == sync_state.read
+      stable_error("SYNC_PREFLIGHT_DIRTY", "Current knowledge artifacts are stale. Run ./scripts/m3.sh sync before ingesting.")
+    end
+  end
+end
+
+def run_validator(package_path)
+  stdout, stderr, status = Open3.capture3(RbConfig.ruby, ROOT.join("scripts", "validate-decision-log-package.rb").to_s, package_path.to_s)
+  data = JSON.parse(stdout)
+  [data, stderr, status.success?]
+rescue JSON::ParserError => error
+  stable_error("VALIDATOR_OUTPUT_INVALID", "Decision-log package validator returned invalid JSON: #{error.message}")
+end
+
+def copy_required_package_files(source, destination)
+  FileUtils.mkdir_p(destination)
+  REQUIRED_PACKAGE_FILES.each do |file|
+    FileUtils.cp(source.join(file), destination.join(file))
+  end
+end
+
+def write_provenance(destination, package_path, validation, offline)
+  metadata = JSON.parse(destination.join("metadata.json").read)
+  provenance = {
+    "schema_version" => "1.0.0",
+    "package_id" => metadata.fetch("package_id"),
+    "persona_id" => metadata.fetch("persona_id"),
+    "mode" => metadata.fetch("mode"),
+    "original_import_path" => package_path.to_s,
+    "imported_at" => Time.now.utc.iso8601,
+    "ingestion_status" => offline ? "staged_offline" : "accepted",
+    "validation_evidence" => validation.fetch("validation"),
+    "traverse" => {
+      "semantic_validation" => validation.fetch("validation").fetch("semantic").fetch("status")
+    }
+  }
+  destination.join("ingestion-provenance.json").write(JSON.pretty_generate(provenance) + "\n")
+end
+
+def write_normalized_note(knowledge_root, package_id, package_destination)
+  notes_dir = knowledge_root.join("notes", "decision-logs")
+  FileUtils.mkdir_p(notes_dir)
+  note = package_destination.join("knowledge-note.md").read
+  notes_dir.join("#{package_id}.md").write(<<~MARKDOWN)
+    ---
+    source_package: knowledge/sources/decision-logs/#{package_id}
+    source_decision_log: knowledge/sources/decision-logs/#{package_id}/decision-log.md
+    provenance: decision-log-package
+    ---
+
+    #{note}
+  MARKDOWN
+end
+
+package_path, knowledge_root, offline = parse_args(ARGV)
+stable_error("ARCHIVE_INPUT_UNSUPPORTED", "Decision-log package input must be a directory, not an archive.") if archive_path?(package_path)
+stable_error("PACKAGE_NOT_DIRECTORY", "Decision-log package input must be a directory.") unless package_path.directory?
+
+validate_knowledge_root!(knowledge_root)
+sync_preflight!(knowledge_root)
+
+validation, validator_stderr, ok = run_validator(package_path)
+unless ok && validation.fetch("valid")
+  first_error = validation.fetch("errors").first || { "code" => "PACKAGE_VALIDATION_FAILED", "message" => validator_stderr }
+  stable_error(first_error.fetch("code"), first_error.fetch("message"))
+end
+
+package_id = validation.fetch("package_id")
+destination_root = offline ? knowledge_root.join("sources", "decision-logs", ".staged") : knowledge_root.join("sources", "decision-logs")
+destination = destination_root.join(package_id)
+stable_error("PACKAGE_ALREADY_EXISTS", "Decision-log package already exists: #{destination}") if destination.exist?
+
+copy_required_package_files(package_path, destination)
+write_provenance(destination, package_path, validation, offline)
+write_normalized_note(knowledge_root, package_id, destination) unless offline
+
+result = {
+  "status" => offline ? "staged_offline" : "accepted",
+  "package_id" => package_id,
+  "package_path" => destination.relative_path_from(ROOT).to_s,
+  "knowledge_note_path" => offline ? nil : knowledge_root.join("notes", "decision-logs", "#{package_id}.md").relative_path_from(ROOT).to_s
+}
+
+puts JSON.pretty_generate(result)

--- a/scripts/m3-decision-log-ingest-smoke.sh
+++ b/scripts/m3-decision-log-ingest-smoke.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+mkdir -p \
+  "$TEMP_DIR/app/site" \
+  "$TEMP_DIR/knowledge/blog" \
+  "$TEMP_DIR/knowledge/books" \
+  "$TEMP_DIR/knowledge/papers" \
+  "$TEMP_DIR/scripts" \
+  "$TEMP_DIR/fixtures/decision-log-packages/valid" \
+  "$TEMP_DIR/fixtures/decision-log-packages/invalid"
+
+cp "$ROOT_DIR/app/site/author-instance.json" "$TEMP_DIR/app/site/author-instance.json"
+cp "$ROOT_DIR/app/site/provider-config.json" "$TEMP_DIR/app/site/provider-config.json"
+cp "$ROOT_DIR/scripts/m3.sh" "$TEMP_DIR/scripts/m3.sh"
+cp "$ROOT_DIR/scripts/m3-sync.sh" "$TEMP_DIR/scripts/m3-sync.sh"
+cp "$ROOT_DIR/scripts/generate-site-artifacts.rb" "$TEMP_DIR/scripts/generate-site-artifacts.rb"
+cp "$ROOT_DIR/scripts/validate-decision-log-package.rb" "$TEMP_DIR/scripts/validate-decision-log-package.rb"
+cp "$ROOT_DIR/scripts/ingest-decision-log.rb" "$TEMP_DIR/scripts/ingest-decision-log.rb"
+cp -R "$ROOT_DIR/fixtures/decision-log-packages/valid/knowledge_addition" "$TEMP_DIR/fixtures/decision-log-packages/valid/knowledge_addition"
+cp -R "$ROOT_DIR/fixtures/decision-log-packages/invalid/unsupported-note-claim" "$TEMP_DIR/fixtures/decision-log-packages/invalid/unsupported-note-claim"
+
+(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh sync >/dev/null
+)
+
+ingest_output="$(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh ingest-decision-log fixtures/decision-log-packages/valid/knowledge_addition
+)"
+
+ruby -rjson -e 'data=JSON.parse(STDIN.read); abort "expected accepted" unless data.fetch("status") == "accepted" && data.fetch("package_id") == "decision-log-20260629-portable-reasoning"' <<<"$ingest_output"
+
+[[ -f "$TEMP_DIR/knowledge/sources/decision-logs/decision-log-20260629-portable-reasoning/decision-log.md" ]]
+[[ -f "$TEMP_DIR/knowledge/sources/decision-logs/decision-log-20260629-portable-reasoning/ingestion-provenance.json" ]]
+[[ -f "$TEMP_DIR/knowledge/notes/decision-logs/decision-log-20260629-portable-reasoning.md" ]]
+grep -q '"original_import_path"' "$TEMP_DIR/knowledge/sources/decision-logs/decision-log-20260629-portable-reasoning/ingestion-provenance.json"
+grep -q 'source_package: knowledge/sources/decision-logs/decision-log-20260629-portable-reasoning' "$TEMP_DIR/knowledge/notes/decision-logs/decision-log-20260629-portable-reasoning.md"
+
+mkdir -p "$TEMP_DIR/offline-knowledge"
+printf '{"schema_version":"1.0.0","offline":true}\n' >"$TEMP_DIR/offline-knowledge/.youaskm3-knowledge-root.json"
+offline_output="$(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh ingest-decision-log fixtures/decision-log-packages/valid/knowledge_addition --offline --knowledge-root "$TEMP_DIR/offline-knowledge"
+)"
+
+ruby -rjson -e 'data=JSON.parse(STDIN.read); abort "expected staged offline" unless data.fetch("status") == "staged_offline" && data.fetch("knowledge_note_path").nil?' <<<"$offline_output"
+[[ -f "$TEMP_DIR/offline-knowledge/sources/decision-logs/.staged/decision-log-20260629-portable-reasoning/ingestion-provenance.json" ]]
+[[ ! -e "$TEMP_DIR/offline-knowledge/notes/decision-logs/decision-log-20260629-portable-reasoning.md" ]]
+
+if (
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh ingest-decision-log fixtures/decision-log-packages/invalid/unsupported-note-claim >/tmp/decision-log-invalid-ingest.txt 2>&1
+); then
+  echo "Expected invalid decision-log package to fail ingestion." >&2
+  exit 1
+fi
+grep -q 'UNSUPPORTED_KNOWLEDGE_NOTE_CLAIM' /tmp/decision-log-invalid-ingest.txt
+
+if (
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh ingest-decision-log fixtures/decision-log-packages/valid/knowledge_addition --knowledge-root "$TEMP_DIR/external-knowledge" >/tmp/decision-log-external-root.txt 2>&1
+); then
+  echo "Expected uninitialized external knowledge root to fail." >&2
+  exit 1
+fi
+grep -q 'EXTERNAL_KNOWLEDGE_ROOT_UNINITIALIZED' /tmp/decision-log-external-root.txt
+
+if (
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh ingest-decision-log fixtures/decision-log-packages/invalid/archive.zip >/tmp/decision-log-archive-ingest.txt 2>&1
+); then
+  echo "Expected archive decision-log package to fail ingestion." >&2
+  exit 1
+fi
+grep -q 'ARCHIVE_INPUT_UNSUPPORTED' /tmp/decision-log-archive-ingest.txt
+
+echo "m3 decision-log ingest smoke passed."

--- a/scripts/m3.sh
+++ b/scripts/m3.sh
@@ -7,7 +7,7 @@ COMMAND="${1:-}"
 cd "$ROOT_DIR"
 
 usage() {
-  echo "Usage: ./scripts/m3.sh {init|add|build|sync|search|serve|test|lint|smoke|status}" >&2
+  echo "Usage: ./scripts/m3.sh {init|add|ingest-decision-log|build|sync|search|serve|test|lint|smoke|status}" >&2
 }
 
 slugify_url() {
@@ -81,6 +81,10 @@ case "$COMMAND" in
   add)
     shift
     run_add "$@"
+    ;;
+  ingest-decision-log)
+    shift
+    ruby ./scripts/ingest-decision-log.rb "$@"
     ;;
   build)
     bash ./scripts/build.sh

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -108,6 +108,9 @@ bash ./scripts/reasoning-skill-adapters-smoke.sh
 echo "Validating decision-log package contract..."
 bash ./scripts/decision-log-package-smoke.sh
 
+echo "Validating m3 decision-log package ingestion..."
+bash ./scripts/m3-decision-log-ingest-smoke.sh
+
 echo "Validating federation index generation..."
 bash ./scripts/federation-index-smoke.sh
 


### PR DESCRIPTION
## What this changes

Adds `m3 ingest-decision-log <package-dir>` for MVP-043. The command validates package directories through the MVP-042 validator, runs a sync preflight, copies accepted packages into `knowledge/sources/decision-logs/<package-id>/`, writes ingestion provenance, creates normalized knowledge notes, and supports offline staging without final note creation.

## Spec reference

- `openspec/specs/decision-log-package/spec.md` - Preserve source package provenance and validate package structure
- `openspec/specs/local-runtime-sync/spec.md` - knowledge-write sync preflight and offline staging boundary
- `openspec/specs/reasoning-graph/spec.md` - downstream package provenance consumed by MVP-044 graph extraction

## Spec delta (if spec changed)

None in this PR.

## Test coverage

Added `scripts/m3-decision-log-ingest-smoke.sh`, covering:

- accepted package copy into `knowledge/sources/decision-logs/<package-id>/`
- ingestion provenance with original import path and validation evidence
- normalized note creation under `knowledge/notes/decision-logs/`
- offline staging under `.staged/` without final note creation
- invalid package rejection
- archive rejection
- uninitialized external knowledge-root rejection

Validation:

```bash
PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
PYTHON=/opt/homebrew/bin/python3.14 \
bash scripts/smoke.sh
```

Result: passed.

## Lean ops / minimality

Reused the MVP-042 validator and existing artifact sync preflight. Did not add reasoning graph extraction or full external-root initialization here; those are owned by later tickets.

## Breaking changes

None.

Closes #140
