### PR TITLE
Add MVP-044 reasoning graph extraction

### DIFF
--- a/contracts/knowledge-graph.schema.json
+++ b/contracts/knowledge-graph.schema.json
@@ -20,7 +20,11 @@
           "type": { "type": "string" },
           "source_artifact_ids": { "type": "array", "items": { "type": "string" } },
           "source_chunk_ids": { "type": "array", "items": { "type": "string" } },
-          "source_paths": { "type": "array", "items": { "type": "string" } }
+          "source_paths": { "type": "array", "items": { "type": "string" } },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          }
         },
         "required": ["node_id", "label", "type", "source_artifact_ids", "source_chunk_ids", "source_paths"],
         "additionalProperties": false
@@ -39,7 +43,11 @@
           "source_chunk_ids": { "type": "array", "items": { "type": "string" } },
           "source_paths": { "type": "array", "items": { "type": "string" } },
           "extraction_method": { "type": "string" },
-          "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+          "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          }
         },
         "required": ["edge_id", "from_node_id", "to_node_id", "relationship", "source_artifact_ids", "source_chunk_ids", "source_paths", "extraction_method", "confidence"],
         "additionalProperties": false

--- a/scripts/extract-reasoning-graph.rb
+++ b/scripts/extract-reasoning-graph.rb
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require_relative "reasoning-graph-extractor"
+
+if ARGV.length != 1
+  warn "Usage: ruby scripts/extract-reasoning-graph.rb <decision-log-package-dir>"
+  exit 1
+end
+
+root = File.expand_path("..", __dir__)
+graph = ReasoningGraphExtractor.extract(ARGV.fetch(0), root)
+puts JSON.pretty_generate(graph)

--- a/scripts/generate-site-artifacts.rb
+++ b/scripts/generate-site-artifacts.rb
@@ -4,6 +4,7 @@
 require "digest"
 require "fileutils"
 require "json"
+require_relative "reasoning-graph-extractor"
 
 root = File.expand_path("..", __dir__)
 output_dir = File.expand_path(ARGV[0] || File.join(root, "app/site"), root)
@@ -60,6 +61,7 @@ author_instance = JSON.parse(File.read(author_instance_path))
 
 processed_document_paths = Dir.glob(File.join(knowledge_dir, "{books,papers,blog}/**/*.md")).sort
 pending_input_paths = Dir.glob(File.join(knowledge_dir, "inputs/**/*")).sort.select { |path| File.file?(path) }
+decision_log_package_paths = Dir.glob(File.join(knowledge_dir, "sources/decision-logs/*")).sort.select { |path| File.directory?(path) && !File.basename(path).start_with?(".") }
 
 source_entries = [
   source_entry(author_instance_path, root, "instance-manifest")
@@ -67,6 +69,11 @@ source_entries = [
 
 source_entries.concat(processed_document_paths.map { |path| source_entry(path, root, "processed-knowledge") })
 source_entries.concat(pending_input_paths.map { |path| source_entry(path, root, "pending-input") })
+decision_log_package_paths.each do |package_path|
+  Dir.glob(File.join(package_path, "*")).sort.select { |path| File.file?(path) }.each do |path|
+    source_entries << source_entry(path, root, "decision-log-package")
+  end
+end
 
 source_fingerprint = Digest::SHA256.hexdigest(
   source_entries.map { |entry| [entry.fetch("path"), entry.fetch("kind"), entry.fetch("sha256")].join(":") }.join("\n")
@@ -131,12 +138,17 @@ graph_edges = knowledge_documents.map do |document|
   }
 end
 
+reasoning_graphs = decision_log_package_paths.map { |path| ReasoningGraphExtractor.extract(path, root) }
+reasoning_nodes = reasoning_graphs.flat_map { |graph| graph.fetch("nodes") }
+reasoning_edges = reasoning_graphs.flat_map { |graph| graph.fetch("edges") }
+reasoning_generated_from = reasoning_graphs.flat_map { |graph| graph.fetch("generated_from") }
+
 knowledge_graph = {
   "schema_version" => "0.1.0",
   "graph_id" => "#{author_instance.fetch("instanceId")}.knowledge-graph",
-  "generated_from" => knowledge_documents.map { |document| document.fetch("id") },
-  "nodes" => graph_nodes,
-  "edges" => graph_edges
+  "generated_from" => knowledge_documents.map { |document| document.fetch("id") } + reasoning_generated_from,
+  "nodes" => graph_nodes + reasoning_nodes,
+  "edges" => graph_edges + reasoning_edges
 }
 
 search_index = {

--- a/scripts/m3-decision-log-ingest-smoke.sh
+++ b/scripts/m3-decision-log-ingest-smoke.sh
@@ -19,6 +19,7 @@ cp "$ROOT_DIR/app/site/provider-config.json" "$TEMP_DIR/app/site/provider-config
 cp "$ROOT_DIR/scripts/m3.sh" "$TEMP_DIR/scripts/m3.sh"
 cp "$ROOT_DIR/scripts/m3-sync.sh" "$TEMP_DIR/scripts/m3-sync.sh"
 cp "$ROOT_DIR/scripts/generate-site-artifacts.rb" "$TEMP_DIR/scripts/generate-site-artifacts.rb"
+cp "$ROOT_DIR/scripts/reasoning-graph-extractor.rb" "$TEMP_DIR/scripts/reasoning-graph-extractor.rb"
 cp "$ROOT_DIR/scripts/validate-decision-log-package.rb" "$TEMP_DIR/scripts/validate-decision-log-package.rb"
 cp "$ROOT_DIR/scripts/ingest-decision-log.rb" "$TEMP_DIR/scripts/ingest-decision-log.rb"
 cp -R "$ROOT_DIR/fixtures/decision-log-packages/valid/knowledge_addition" "$TEMP_DIR/fixtures/decision-log-packages/valid/knowledge_addition"
@@ -41,6 +42,11 @@ ruby -rjson -e 'data=JSON.parse(STDIN.read); abort "expected accepted" unless da
 [[ -f "$TEMP_DIR/knowledge/notes/decision-logs/decision-log-20260629-portable-reasoning.md" ]]
 grep -q '"original_import_path"' "$TEMP_DIR/knowledge/sources/decision-logs/decision-log-20260629-portable-reasoning/ingestion-provenance.json"
 grep -q 'source_package: knowledge/sources/decision-logs/decision-log-20260629-portable-reasoning' "$TEMP_DIR/knowledge/notes/decision-logs/decision-log-20260629-portable-reasoning.md"
+
+(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh sync >/dev/null
+)
 
 mkdir -p "$TEMP_DIR/offline-knowledge"
 printf '{"schema_version":"1.0.0","offline":true}\n' >"$TEMP_DIR/offline-knowledge/.youaskm3-knowledge-root.json"

--- a/scripts/m3-sync-smoke.sh
+++ b/scripts/m3-sync-smoke.sh
@@ -18,6 +18,7 @@ cp "$ROOT_DIR/app/site/provider-config.json" "$TEMP_DIR/app/site/provider-config
 cp "$ROOT_DIR/scripts/m3.sh" "$TEMP_DIR/scripts/m3.sh"
 cp "$ROOT_DIR/scripts/m3-sync.sh" "$TEMP_DIR/scripts/m3-sync.sh"
 cp "$ROOT_DIR/scripts/generate-site-artifacts.rb" "$TEMP_DIR/scripts/generate-site-artifacts.rb"
+cp "$ROOT_DIR/scripts/reasoning-graph-extractor.rb" "$TEMP_DIR/scripts/reasoning-graph-extractor.rb"
 
 cat <<'EOF' > "$TEMP_DIR/knowledge/blog/first-note.md"
 # First Note

--- a/scripts/mvp-local-loop-smoke.sh
+++ b/scripts/mvp-local-loop-smoke.sh
@@ -26,6 +26,7 @@ mkdir -p \
 cp "$ROOT_DIR/scripts/m3.sh" "$TEMP_DIR/scripts/m3.sh"
 cp "$ROOT_DIR/scripts/m3-sync.sh" "$TEMP_DIR/scripts/m3-sync.sh"
 cp "$ROOT_DIR/scripts/generate-site-artifacts.rb" "$TEMP_DIR/scripts/generate-site-artifacts.rb"
+cp "$ROOT_DIR/scripts/reasoning-graph-extractor.rb" "$TEMP_DIR/scripts/reasoning-graph-extractor.rb"
 
 cat >"$TEMP_DIR/knowledge/blog/source-grounding.md" <<'EOF'
 # Source Grounding

--- a/scripts/reasoning-graph-extraction-smoke.sh
+++ b/scripts/reasoning-graph-extraction-smoke.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+cd "$ROOT_DIR"
+
+ruby ./scripts/extract-reasoning-graph.rb fixtures/decision-log-packages/valid/gap_resolution \
+  | ruby -rjson -e 'graph=JSON.parse(STDIN.read); types=graph.fetch("nodes").map { |node| node.fetch("type") }.uniq; required=%w[concept question option tradeoff assumption decision claim open_question source_gap knowledge_note citation source_artifact confidence_assessment validation_result]; missing=required-types; abort "missing reasoning node types: #{missing.inspect}" unless missing.empty?; abort "expected source gap" unless graph.fetch("nodes").any? { |node| node.fetch("type") == "source_gap" && node.fetch("label") == "gap-runtime-policy" }; abort "expected deterministic edges" unless graph.fetch("edges").all? { |edge| edge.fetch("extraction_method") == "deterministic-reasoning-graph-extractor" }'
+
+if ruby ./scripts/extract-reasoning-graph.rb fixtures/decision-log-packages/invalid/incomplete-sections >/tmp/reasoning-graph-invalid.json 2>/tmp/reasoning-graph-invalid.err; then
+  echo "Expected invalid decision-log package graph extraction to fail." >&2
+  exit 1
+fi
+grep -Eq 'Missing extractable|Missing label' /tmp/reasoning-graph-invalid.err
+
+mkdir -p \
+  "$TEMP_DIR/app/site" \
+  "$TEMP_DIR/knowledge/blog" \
+  "$TEMP_DIR/knowledge/books" \
+  "$TEMP_DIR/knowledge/papers" \
+  "$TEMP_DIR/knowledge/sources/decision-logs" \
+  "$TEMP_DIR/scripts"
+
+cp "$ROOT_DIR/app/site/author-instance.json" "$TEMP_DIR/app/site/author-instance.json"
+cp "$ROOT_DIR/app/site/provider-config.json" "$TEMP_DIR/app/site/provider-config.json"
+cp "$ROOT_DIR/scripts/generate-site-artifacts.rb" "$TEMP_DIR/scripts/generate-site-artifacts.rb"
+cp "$ROOT_DIR/scripts/reasoning-graph-extractor.rb" "$TEMP_DIR/scripts/reasoning-graph-extractor.rb"
+cp -R "$ROOT_DIR/fixtures/decision-log-packages/valid/gap_resolution" "$TEMP_DIR/knowledge/sources/decision-logs/decision-log-20260629-gap-resolution"
+
+(
+  cd "$TEMP_DIR"
+  ruby ./scripts/generate-site-artifacts.rb app/site
+)
+
+ruby -rjson -e 'graph=JSON.parse(File.read(ARGV[0])); abort "missing package in generated_from" unless graph.fetch("generated_from").include?("decision-log-20260629-gap-resolution"); abort "missing reasoning graph node" unless graph.fetch("nodes").any? { |node| node.fetch("type") == "validation_result" }; abort "missing reasoning graph edge" unless graph.fetch("edges").any? { |edge| edge.fetch("extraction_method") == "deterministic-reasoning-graph-extractor" }' "$TEMP_DIR/app/site/knowledge-graph.json"
+
+echo "Reasoning graph extraction smoke passed."

--- a/scripts/reasoning-graph-extractor.rb
+++ b/scripts/reasoning-graph-extractor.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require "json"
+require "pathname"
+
+module ReasoningGraphExtractor
+  REQUIRED_TYPES = [
+    "concept",
+    "question",
+    "option",
+    "tradeoff",
+    "assumption",
+    "decision",
+    "claim",
+    "open_question",
+    "source_gap",
+    "knowledge_note",
+    "citation",
+    "source_artifact",
+    "confidence_assessment",
+    "validation_result"
+  ].freeze
+
+  SECTION_BY_TYPE = {
+    "question" => "Questions Asked",
+    "option" => "Options Considered",
+    "tradeoff" => "Pros and Cons",
+    "assumption" => "Assumptions",
+    "decision" => "Decisions",
+    "claim" => "Claims",
+    "open_question" => "Remaining Non-Blocking Open Questions",
+    "citation" => "Citations"
+  }.freeze
+
+  def self.extract(package_dir, root)
+    package_path = Pathname.new(package_dir)
+    root_path = Pathname.new(root)
+    metadata = JSON.parse(package_path.join("metadata.json").read)
+    package_id = metadata.fetch("package_id")
+    decision = section_map(package_path.join("decision-log.md").read)
+    note = section_map(package_path.join("knowledge-note.md").read)
+    provenance_path = package_path.join("ingestion-provenance.json")
+    provenance = provenance_path.file? ? JSON.parse(provenance_path.read) : {}
+    validation = provenance.fetch("validation_evidence", { "deterministic" => "fixture", "semantic" => { "status" => "unavailable" } })
+
+    nodes = []
+    edges = []
+    source_paths = [
+      relative_path(package_path.join("decision-log.md"), root_path),
+      relative_path(package_path.join("knowledge-note.md"), root_path),
+      relative_path(package_path.join("metadata.json"), root_path)
+    ]
+    source_paths << relative_path(provenance_path, root_path) if provenance_path.file?
+
+    source_node_id = node_id(package_id, "source_artifact", 0)
+    nodes << node(source_node_id, package_id, "source_artifact", package_id, source_paths, { "mode" => metadata.fetch("mode") })
+
+    concept_label = first_line(decision.fetch("Conversation Goal", ""))
+    nodes << node(node_id(package_id, "concept", 0), concept_label, "concept", package_id, source_paths, { "mode" => metadata.fetch("mode") })
+
+    SECTION_BY_TYPE.each do |type, section|
+      values = bullets(decision.fetch(section, ""))
+      fail "Missing extractable #{type} in #{package_path}" if values.empty?
+
+      values.each_with_index do |value, index|
+        nodes << node(node_id(package_id, type, index), value, type, package_id, source_paths, { "section" => section })
+      end
+    end
+
+    source_gap_label = metadata["source_gap_id"] || "No linked source gap"
+    nodes << node(node_id(package_id, "source_gap", 0), source_gap_label, "source_gap", package_id, source_paths, { "source_gap_id" => metadata["source_gap_id"] })
+
+    nodes << node(node_id(package_id, "knowledge_note", 0), first_line(note.fetch("Title", "")), "knowledge_note", package_id, source_paths, { "note_path" => source_paths[1] })
+    nodes << node(node_id(package_id, "confidence_assessment", 0), first_line(decision.fetch("Confidence Assessment", "")), "confidence_assessment", package_id, source_paths, {})
+    nodes << node(node_id(package_id, "validation_result", 0), "Deterministic validation #{validation.fetch("deterministic", "unknown")}", "validation_result", package_id, source_paths, validation)
+
+    present_types = nodes.map { |entry| entry.fetch("type") }.uniq
+    missing_types = REQUIRED_TYPES - present_types
+    fail "Reasoning graph extraction missing node types: #{missing_types.join(", ")}" unless missing_types.empty?
+
+    nodes.reject { |entry| entry.fetch("node_id") == source_node_id }.each do |target|
+      edges << edge(
+        package_id,
+        source_node_id,
+        target.fetch("node_id"),
+        "contains_reasoning_element",
+        source_paths,
+        { "target_type" => target.fetch("type") }
+      )
+    end
+
+    {
+      "generated_from" => [package_id],
+      "nodes" => nodes.sort_by { |entry| entry.fetch("node_id") },
+      "edges" => edges.sort_by { |entry| entry.fetch("edge_id") }
+    }
+  end
+
+  def self.section_map(markdown)
+    sections = {}
+    current = nil
+
+    markdown.each_line do |line|
+      if (match = line.match(/\A##\s+(.+?)\s*\z/))
+        current = match[1]
+        sections[current] = +""
+      elsif current
+        sections[current] << line
+      end
+    end
+
+    sections.transform_values(&:strip)
+  end
+
+  def self.bullets(section)
+    section.each_line.each_with_object([]) do |line, values|
+      match = line.match(/\A-\s+(.+?)\s*\z/)
+      values << match[1].strip if match
+    end
+  end
+
+  def self.first_line(section)
+    section.each_line.map(&:strip).reject(&:empty?).first.to_s
+  end
+
+  def self.relative_path(path, root)
+    Pathname.new(path).relative_path_from(root).to_s
+  rescue ArgumentError
+    Pathname.new(path).to_s
+  end
+
+  def self.node_id(package_id, type, index)
+    "reasoning:#{package_id}:#{type}:#{index}"
+  end
+
+  def self.node(id, label, type, package_id, source_paths, metadata)
+    fail "Missing label for #{type}" if label.nil? || label.empty?
+
+    {
+      "node_id" => id,
+      "label" => label,
+      "type" => type,
+      "source_artifact_ids" => [package_id],
+      "source_chunk_ids" => [],
+      "source_paths" => source_paths,
+      "metadata" => metadata
+    }
+  end
+
+  def self.edge(package_id, from_node_id, to_node_id, relationship, source_paths, metadata)
+    {
+      "edge_id" => "edge:#{from_node_id}:#{relationship}:#{to_node_id}",
+      "from_node_id" => from_node_id,
+      "to_node_id" => to_node_id,
+      "relationship" => relationship,
+      "source_artifact_ids" => [package_id],
+      "source_chunk_ids" => [],
+      "source_paths" => source_paths,
+      "extraction_method" => "deterministic-reasoning-graph-extractor",
+      "confidence" => 1.0,
+      "metadata" => metadata
+    }
+  end
+end

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -111,6 +111,9 @@ bash ./scripts/decision-log-package-smoke.sh
 echo "Validating m3 decision-log package ingestion..."
 bash ./scripts/m3-decision-log-ingest-smoke.sh
 
+echo "Validating reasoning graph extraction..."
+bash ./scripts/reasoning-graph-extraction-smoke.sh
+
 echo "Validating federation index generation..."
 bash ./scripts/federation-index-smoke.sh
 


### PR DESCRIPTION
## What this changes

Adds deterministic reasoning graph extraction for decision-log packages and wires it into the site artifact generator. When packages exist under `knowledge/sources/decision-logs/`, the generated graph now includes reasoning nodes for concepts, questions, options, tradeoffs, assumptions, decisions, claims, open questions, source gaps, knowledge notes, citations, confidence, source artifacts, and validation results.

## Spec reference

- `openspec/specs/reasoning-graph/spec.md` - Extract a full reasoning graph from decision-log packages
- `openspec/specs/decision-log-package/spec.md` - package structure and validation provenance
- `openspec/specs/knowledge-graph/spec.md` - graph artifact shape and deterministic output

## Spec delta (if spec changed)

None in this PR.

## Test coverage

Added `scripts/reasoning-graph-extraction-smoke.sh`, covering:

- deterministic extraction from a valid gap-resolution package
- all mandatory reasoning node types
- stable deterministic extraction edges
- invalid extraction failure for incomplete package structure
- integration into `scripts/generate-site-artifacts.rb`
- existing source-document graph behavior through the existing graph smoke

Validation:

```bash
PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
PYTHON=/opt/homebrew/bin/python3.14 \
bash scripts/smoke.sh
```

Result: passed.

## Lean ops / minimality

Kept extraction deterministic and section-based, extended the existing graph generator, and added optional graph metadata without replacing the document graph path.

## Breaking changes

None.

Closes #141
