### PR TITLE
Add MVP-045 knowledge gap lifecycle

### DIFF
--- a/contracts/knowledge-conflict.schema.json
+++ b/contracts/knowledge-conflict.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://youaskm3.com/contracts/knowledge-conflict.schema.json",
+  "title": "youaskm3 knowledge conflict markdown front matter",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "kind",
+    "conflict_id",
+    "status",
+    "persona_id",
+    "summary",
+    "resolution_package_mode",
+    "created_at",
+    "updated_at"
+  ],
+  "properties": {
+    "kind": { "const": "knowledge_conflict" },
+    "conflict_id": { "type": "string", "pattern": "^conflict-[a-z0-9]+(?:-[a-z0-9]+)*$" },
+    "status": { "enum": ["open", "resolved"] },
+    "persona_id": { "type": "string", "minLength": 1 },
+    "summary": { "type": "string", "minLength": 1 },
+    "resolution_package_mode": { "const": "conflict_resolution" },
+    "linked_package_id": { "type": ["string", "null"] }
+  }
+}

--- a/contracts/knowledge-gap.schema.json
+++ b/contracts/knowledge-gap.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://youaskm3.com/contracts/knowledge-gap.schema.json",
+  "title": "youaskm3 knowledge gap markdown front matter",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "kind",
+    "gap_id",
+    "status",
+    "persona_id",
+    "source_question",
+    "confidence_reason",
+    "trace_id",
+    "deterministic_complexity",
+    "final_complexity",
+    "allowed_resolution_path",
+    "created_at",
+    "updated_at"
+  ],
+  "properties": {
+    "kind": { "const": "knowledge_gap" },
+    "gap_id": { "type": "string", "pattern": "^gap-[a-z0-9]+(?:-[a-z0-9]+)*$" },
+    "status": { "enum": ["open", "resolved"] },
+    "persona_id": { "type": "string", "minLength": 1 },
+    "source_question": { "type": "string", "minLength": 1 },
+    "confidence_reason": { "type": "string", "minLength": 1 },
+    "trace_id": { "type": "string", "minLength": 1 },
+    "deterministic_complexity": { "enum": ["simple_factual", "reasoning_heavy"] },
+    "agent_complexity": { "type": ["string", "null"] },
+    "final_complexity": { "enum": ["simple_factual", "reasoning_heavy"] },
+    "allowed_resolution_path": { "enum": ["direct_chat", "decision_log_package"] },
+    "linked_package_id": { "type": ["string", "null"] },
+    "relevant_graph_nodes": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/scripts/ingest-decision-log.rb
+++ b/scripts/ingest-decision-log.rb
@@ -44,6 +44,23 @@ def stable_error(code, message)
   exit 1
 end
 
+def write_validation_gap(knowledge_root, validation, error)
+  package_id = validation["package_id"] || "unknown-package"
+  gap_id = "gap-#{package_id.gsub(/[^a-z0-9]+/, "-").gsub(/\A-+|-+\z/, "")}-validation"
+  system(
+    RbConfig.ruby,
+    ROOT.join("scripts", "knowledge-gap-lifecycle.rb").to_s,
+    "create-gap",
+    "--knowledge-root", knowledge_root.to_s,
+    "--gap-id", gap_id,
+    "--source-question", "Decision-log package validation failed for #{package_id}",
+    "--confidence-reason", error.fetch("message"),
+    "--trace-id", "decision-log-validation",
+    "--linked-package-id", package_id,
+    out: File::NULL
+  )
+end
+
 def archive_path?(path)
   ARCHIVE_EXTENSIONS.any? { |extension| path.to_s.end_with?(extension) }
 end
@@ -138,6 +155,7 @@ sync_preflight!(knowledge_root)
 validation, validator_stderr, ok = run_validator(package_path)
 unless ok && validation.fetch("valid")
   first_error = validation.fetch("errors").first || { "code" => "PACKAGE_VALIDATION_FAILED", "message" => validator_stderr }
+  write_validation_gap(knowledge_root, validation, first_error)
   stable_error(first_error.fetch("code"), first_error.fetch("message"))
 end
 

--- a/scripts/knowledge-gap-lifecycle-smoke.sh
+++ b/scripts/knowledge-gap-lifecycle-smoke.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+cd "$ROOT_DIR"
+
+ruby ./scripts/knowledge-gap-lifecycle.rb create-gap \
+  --knowledge-root "$TEMP_DIR/knowledge" \
+  --gap-id gap-question-time-source-grounding \
+  --source-question "What evidence supports source grounding?" \
+  --confidence-reason "unsupported answer from available knowledge" \
+  --trace-id trace-gap-smoke \
+  --relevant-graph-nodes node.source-grounding >/tmp/gap-create.json
+
+ruby ./scripts/knowledge-gap-lifecycle.rb create-gap \
+  --knowledge-root "$TEMP_DIR/knowledge" \
+  --gap-id gap-question-time-source-grounding \
+  --source-question "What evidence supports source grounding?" \
+  --confidence-reason "unsupported answer from available knowledge" \
+  --trace-id trace-gap-smoke-updated >/tmp/gap-update.json
+
+ruby ./scripts/knowledge-gap-lifecycle.rb create-gap \
+  --knowledge-root "$TEMP_DIR/knowledge" \
+  --gap-id gap-semantic-validation-failed \
+  --source-question "Package semantic validation failed" \
+  --confidence-reason "semantic validation rejected package" \
+  --trace-id trace-validation \
+  --linked-package-id decision-log-20260629-portable-reasoning >/tmp/gap-validation.json
+
+ruby ./scripts/knowledge-gap-lifecycle.rb create-conflict \
+  --knowledge-root "$TEMP_DIR/knowledge" \
+  --conflict-id conflict-runtime-boundary \
+  --summary "Two claims disagree about whether downstream shortcuts can count as MVP acceptance." >/tmp/conflict-create.json
+
+list_output="$(ruby ./scripts/knowledge-gap-lifecycle.rb list-gaps --knowledge-root "$TEMP_DIR/knowledge")"
+ruby -rjson -e 'gaps=JSON.parse(STDIN.read); abort "expected two open gaps" unless gaps.length == 2; abort "expected stable resolution path" unless gaps.any? { |gap| gap.fetch("gap_id") == "gap-semantic-validation-failed" && gap.fetch("allowed_resolution_path") == "decision_log_package" }' <<<"$list_output"
+
+ruby ./scripts/knowledge-gap-lifecycle.rb resolve-gap \
+  --knowledge-root "$TEMP_DIR/knowledge" \
+  --gap-id gap-question-time-source-grounding >/tmp/gap-resolve.json
+
+[[ -f "$TEMP_DIR/knowledge/gaps/resolved/gap-question-time-source-grounding.md" ]]
+[[ ! -e "$TEMP_DIR/knowledge/gaps/open/gap-question-time-source-grounding.md" ]]
+[[ -f "$TEMP_DIR/knowledge/conflicts/open/conflict-runtime-boundary.md" ]]
+grep -q 'resolution_package_mode: conflict_resolution' "$TEMP_DIR/knowledge/conflicts/open/conflict-runtime-boundary.md"
+
+mkdir -p "$TEMP_DIR/knowledge/gaps/open"
+cat >"$TEMP_DIR/knowledge/gaps/open/gap-invalid.md" <<'EOF'
+---
+kind: knowledge_gap
+gap_id: gap-invalid
+---
+
+# Invalid
+EOF
+
+if ruby ./scripts/knowledge-gap-lifecycle.rb list-gaps --knowledge-root "$TEMP_DIR/knowledge" >/tmp/gap-invalid-list.json 2>/tmp/gap-invalid-list.err; then
+  echo "Expected invalid gap front matter to fail." >&2
+  exit 1
+fi
+grep -q 'GAP_FRONT_MATTER_INVALID' /tmp/gap-invalid-list.err
+
+echo "Knowledge gap lifecycle smoke passed."

--- a/scripts/knowledge-gap-lifecycle.rb
+++ b/scripts/knowledge-gap-lifecycle.rb
@@ -1,0 +1,178 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "pathname"
+require "time"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
+DEFAULT_KNOWLEDGE_ROOT = ROOT.join("knowledge")
+REQUIRED_GAP_KEYS = ["kind", "gap_id", "status", "persona_id", "source_question", "confidence_reason", "trace_id", "deterministic_complexity", "final_complexity", "allowed_resolution_path", "created_at", "updated_at"].freeze
+
+def stable_error(code, message)
+  warn "#{code}: #{message}"
+  exit 1
+end
+
+def slug(value)
+  value.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-+|-+\z/, "")
+end
+
+def parse_flags(argv)
+  flags = {}
+  until argv.empty?
+    key = argv.shift
+    stable_error("INVALID_ARGUMENT", "Expected flag, got #{key}") unless key.start_with?("--")
+    flags[key.delete_prefix("--").tr("-", "_")] = argv.shift || stable_error("INVALID_ARGUMENT", "Missing value for #{key}")
+  end
+  flags
+end
+
+def front_matter(markdown)
+  lines = markdown.lines
+  stable_error("FRONT_MATTER_MISSING", "Markdown record is missing front matter.") unless lines.first&.strip == "---"
+  closing = lines[1..].find_index { |line| line.strip == "---" }
+  stable_error("FRONT_MATTER_MISSING", "Markdown record front matter is not closed.") if closing.nil?
+
+  lines[1, closing].each_with_object({}) do |line, data|
+    next if line.strip.empty?
+    key, value = line.split(":", 2)
+    stable_error("FRONT_MATTER_INVALID", "Invalid front matter line: #{line.strip}") if value.nil?
+    value = value.strip
+    data[key.strip] = if value == "null"
+                         nil
+                       elsif value.start_with?("[") && value.end_with?("]")
+                         value.delete_prefix("[").delete_suffix("]").split(",").map(&:strip).reject(&:empty?)
+                       else
+                         value
+                       end
+  end
+end
+
+def classify(reason, question)
+  text = "#{reason} #{question}".downcase
+  if text.match?(/\b(architecture|strategic|strategy|concept|conflict|ambiguous|semantic|tradeoff|assumption)\b/)
+    "reasoning_heavy"
+  else
+    "simple_factual"
+  end
+end
+
+def resolution_path(complexity)
+  complexity == "simple_factual" ? "direct_chat" : "decision_log_package"
+end
+
+def write_record(path, front, body)
+  FileUtils.mkdir_p(path.dirname)
+  serialized = front.map do |key, value|
+    rendered = value.is_a?(Array) ? "[#{value.join(", ")}]" : (value.nil? ? "null" : value)
+    "#{key}: #{rendered}"
+  end.join("\n")
+  path.write("---\n#{serialized}\n---\n\n#{body}\n")
+end
+
+def create_gap(flags)
+  knowledge_root = Pathname.new(flags.fetch("knowledge_root", DEFAULT_KNOWLEDGE_ROOT.to_s))
+  question = flags.fetch("source_question")
+  reason = flags.fetch("confidence_reason")
+  gap_id = flags["gap_id"] || "gap-#{slug(question)[0, 48].gsub(/-\z/, "")}"
+  path = knowledge_root.join("gaps", "open", "#{gap_id}.md")
+  now = Time.now.utc.iso8601
+  existing = path.file? ? front_matter(path.read) : {}
+  deterministic = flags["deterministic_complexity"] || classify(reason, question)
+  final = flags["final_complexity"] || flags["agent_complexity"] || deterministic
+
+  front = {
+    "kind" => "knowledge_gap",
+    "gap_id" => gap_id,
+    "status" => "open",
+    "persona_id" => flags.fetch("persona_id", "default"),
+    "source_question" => question,
+    "confidence_reason" => reason,
+    "trace_id" => flags.fetch("trace_id", "trace-unavailable"),
+    "deterministic_complexity" => deterministic,
+    "agent_complexity" => flags["agent_complexity"],
+    "final_complexity" => final,
+    "allowed_resolution_path" => flags["allowed_resolution_path"] || resolution_path(final),
+    "linked_package_id" => flags["linked_package_id"],
+    "relevant_graph_nodes" => Array(flags["relevant_graph_nodes"]).flat_map { |value| value.to_s.split(",") }.map(&:strip).reject(&:empty?),
+    "created_at" => existing["created_at"] || now,
+    "updated_at" => now
+  }
+
+  write_record(path, front, "## Clarification Need\n\n#{reason}\n")
+  puts JSON.pretty_generate({ "status" => "open", "gap_id" => gap_id, "path" => path.relative_path_from(ROOT).to_s })
+end
+
+def create_conflict(flags)
+  knowledge_root = Pathname.new(flags.fetch("knowledge_root", DEFAULT_KNOWLEDGE_ROOT.to_s))
+  summary = flags.fetch("summary")
+  conflict_id = flags["conflict_id"] || "conflict-#{slug(summary)[0, 48].gsub(/-\z/, "")}"
+  path = knowledge_root.join("conflicts", "open", "#{conflict_id}.md")
+  now = Time.now.utc.iso8601
+
+  front = {
+    "kind" => "knowledge_conflict",
+    "conflict_id" => conflict_id,
+    "status" => "open",
+    "persona_id" => flags.fetch("persona_id", "default"),
+    "summary" => summary,
+    "resolution_package_mode" => "conflict_resolution",
+    "linked_package_id" => flags["linked_package_id"],
+    "created_at" => now,
+    "updated_at" => now
+  }
+
+  write_record(path, front, "## Conflict\n\n#{summary}\n")
+  puts JSON.pretty_generate({ "status" => "open", "conflict_id" => conflict_id, "path" => path.relative_path_from(ROOT).to_s })
+end
+
+def resolve_gap(flags)
+  knowledge_root = Pathname.new(flags.fetch("knowledge_root", DEFAULT_KNOWLEDGE_ROOT.to_s))
+  gap_id = flags.fetch("gap_id")
+  open_path = knowledge_root.join("gaps", "open", "#{gap_id}.md")
+  stable_error("GAP_NOT_FOUND", "Open gap not found: #{gap_id}") unless open_path.file?
+  data = front_matter(open_path.read)
+  data["status"] = "resolved"
+  data["updated_at"] = Time.now.utc.iso8601
+  resolved_path = knowledge_root.join("gaps", "resolved", "#{gap_id}.md")
+  write_record(resolved_path, data, open_path.read.split("---", 3).fetch(2, "").strip)
+  open_path.delete
+  puts JSON.pretty_generate({ "status" => "resolved", "gap_id" => gap_id, "path" => resolved_path.relative_path_from(ROOT).to_s })
+end
+
+def list_gaps(flags)
+  knowledge_root = Pathname.new(flags.fetch("knowledge_root", DEFAULT_KNOWLEDGE_ROOT.to_s))
+  paths = Dir.glob(knowledge_root.join("gaps", "open", "*.md")).sort
+  records = paths.map do |path|
+    data = front_matter(File.read(path))
+    missing = REQUIRED_GAP_KEYS.reject { |key| data.key?(key) && !data[key].to_s.empty? }
+    stable_error("GAP_FRONT_MATTER_INVALID", "#{path} is missing #{missing.join(", ")}") unless missing.empty?
+    {
+      "gap_id" => data.fetch("gap_id"),
+      "status" => data.fetch("status"),
+      "source_question" => data.fetch("source_question"),
+      "allowed_resolution_path" => data.fetch("allowed_resolution_path"),
+      "final_complexity" => data.fetch("final_complexity"),
+      "path" => Pathname.new(path).relative_path_from(ROOT).to_s
+    }
+  end
+  puts JSON.pretty_generate(records)
+end
+
+command = ARGV.shift || stable_error("INVALID_ARGUMENT", "Missing lifecycle command.")
+flags = parse_flags(ARGV)
+
+case command
+when "create-gap"
+  create_gap(flags)
+when "create-conflict"
+  create_conflict(flags)
+when "resolve-gap"
+  resolve_gap(flags)
+when "list-gaps"
+  list_gaps(flags)
+else
+  stable_error("INVALID_ARGUMENT", "Unknown lifecycle command: #{command}")
+end

--- a/scripts/m3-decision-log-ingest-smoke.sh
+++ b/scripts/m3-decision-log-ingest-smoke.sh
@@ -22,6 +22,7 @@ cp "$ROOT_DIR/scripts/generate-site-artifacts.rb" "$TEMP_DIR/scripts/generate-si
 cp "$ROOT_DIR/scripts/reasoning-graph-extractor.rb" "$TEMP_DIR/scripts/reasoning-graph-extractor.rb"
 cp "$ROOT_DIR/scripts/validate-decision-log-package.rb" "$TEMP_DIR/scripts/validate-decision-log-package.rb"
 cp "$ROOT_DIR/scripts/ingest-decision-log.rb" "$TEMP_DIR/scripts/ingest-decision-log.rb"
+cp "$ROOT_DIR/scripts/knowledge-gap-lifecycle.rb" "$TEMP_DIR/scripts/knowledge-gap-lifecycle.rb"
 cp -R "$ROOT_DIR/fixtures/decision-log-packages/valid/knowledge_addition" "$TEMP_DIR/fixtures/decision-log-packages/valid/knowledge_addition"
 cp -R "$ROOT_DIR/fixtures/decision-log-packages/invalid/unsupported-note-claim" "$TEMP_DIR/fixtures/decision-log-packages/invalid/unsupported-note-claim"
 
@@ -67,6 +68,7 @@ if (
   exit 1
 fi
 grep -q 'UNSUPPORTED_KNOWLEDGE_NOTE_CLAIM' /tmp/decision-log-invalid-ingest.txt
+[[ -f "$TEMP_DIR/knowledge/gaps/open/gap-decision-log-20260629-unsupported-note-validation.md" ]]
 
 if (
   cd "$TEMP_DIR"

--- a/scripts/m3.sh
+++ b/scripts/m3.sh
@@ -96,6 +96,19 @@ case "$COMMAND" in
     shift
     ruby ./scripts/m3-search.rb "$@"
     ;;
+  gaps)
+    shift
+    case "${1:-}" in
+      list)
+        shift
+        ruby ./scripts/knowledge-gap-lifecycle.rb list-gaps "$@"
+        ;;
+      *)
+        echo "Usage: ./scripts/m3.sh gaps list [--knowledge-root PATH]" >&2
+        exit 1
+        ;;
+    esac
+    ;;
   serve)
     shift
     bash ./scripts/m3-serve.sh "$@"

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -114,6 +114,9 @@ bash ./scripts/m3-decision-log-ingest-smoke.sh
 echo "Validating reasoning graph extraction..."
 bash ./scripts/reasoning-graph-extraction-smoke.sh
 
+echo "Validating knowledge gap lifecycle..."
+bash ./scripts/knowledge-gap-lifecycle-smoke.sh
+
 echo "Validating federation index generation..."
 bash ./scripts/federation-index-smoke.sh
 


### PR DESCRIPTION
## What this changes

Adds the MVP-045 knowledge gap and conflict lifecycle layer: structured markdown schemas, deterministic gap/conflict record creation, gap resolution movement, `m3 gaps list`, and validation-failure gap creation during decision-log ingestion.

## Spec reference

- `openspec/specs/knowledge-gap-lifecycle/spec.md` - structured gaps/conflicts, complexity classification, CLI listing
- `openspec/specs/reasoning-graph/spec.md` - graph-linked gap/conflict provenance
- `openspec/specs/local-runtime-sync/spec.md` - sync/conflict lifecycle boundary

## Spec delta (if spec changed)

None in this PR.

## Test coverage

Added `scripts/knowledge-gap-lifecycle-smoke.sh`, covering:

- question-time gap creation and update
- validation-failure gap creation
- conflict report creation with `conflict_resolution` mode
- `m3 gaps list` stable JSON output
- resolved gap movement from open to resolved
- invalid gap front matter rejection
- decision-log ingestion failure creating an open validation gap

Validation:

```bash
PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
PYTHON=/opt/homebrew/bin/python3.14 \
bash scripts/smoke.sh
```

Result: passed.

## Lean ops / minimality

Kept this slice to deterministic file lifecycle primitives and CLI listing. Runtime answer-time use and richer graph-aware conflict disclosure remain in later tickets.

## Breaking changes

None.

Closes #142
