### PR TITLE
Add MVP-046 graph-aware answer context selection

### DIFF
--- a/scripts/answer-context-selector-smoke.sh
+++ b/scripts/answer-context-selector-smoke.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+cd "$ROOT_DIR"
+
+ruby ./scripts/extract-reasoning-graph.rb fixtures/decision-log-packages/valid/gap_resolution >"$TEMP_DIR/reasoning-graph.json"
+
+declare -a cases=(
+  "List claim support for Traverse gaps:factual:claim,citation,source_artifact,validation_result"
+  "Why was the downstream shortcut rejected?:decision:decision,tradeoff,option,assumption,citation,validation_result"
+  "What remains uncertain about the runtime policy?:uncertainty:assumption,open_question,source_gap,confidence_assessment,validation_result"
+  "Explain the Traverse runtime concept:concept_explanation:concept,claim,citation,knowledge_note"
+  "What is still missing from me?:gap_oriented:source_gap,open_question,validation_result,knowledge_note"
+)
+
+for entry in "${cases[@]}"; do
+  query="${entry%%:*}"
+  rest="${entry#*:}"
+  expected_type="${rest%%:*}"
+  expected_nodes="${rest#*:}"
+  ruby ./scripts/answer-context-selector.rb --query "$query" --graph "$TEMP_DIR/reasoning-graph.json" --knowledge-root "$TEMP_DIR/knowledge" \
+    | ruby -rjson -e 'data=JSON.parse(STDIN.read); expected_type=ARGV[0]; expected_nodes=ARGV[1].split(","); trace=data.fetch("trace"); abort "wrong answer type" unless trace.fetch("deterministic_answer_type") == expected_type && trace.fetch("final_answer_type") == expected_type; abort "wrong node strategy" unless data.fetch("selected_node_types") == expected_nodes; abort "expected selected nodes" if data.fetch("selected_nodes").empty?' "$expected_type" "$expected_nodes"
+done
+
+ruby ./scripts/answer-context-selector.rb \
+  --query "Explain the Traverse runtime concept" \
+  --graph "$TEMP_DIR/reasoning-graph.json" \
+  --knowledge-root "$TEMP_DIR/knowledge" \
+  --agent-answer-type uncertainty \
+  | ruby -rjson -e 'data=JSON.parse(STDIN.read); trace=data.fetch("trace"); abort "expected agent override" unless trace.fetch("agent_answer_type") == "uncertainty" && trace.fetch("final_answer_type") == "uncertainty"'
+
+ruby ./scripts/knowledge-gap-lifecycle.rb create-conflict \
+  --knowledge-root "$TEMP_DIR/knowledge" \
+  --conflict-id conflict-runtime-shortcut \
+  --summary "Downstream shortcuts conflict with Traverse governed runtime acceptance." >/dev/null
+
+ruby ./scripts/answer-context-selector.rb \
+  --query "Does a runtime shortcut conflict with MVP acceptance?" \
+  --graph "$TEMP_DIR/reasoning-graph.json" \
+  --knowledge-root "$TEMP_DIR/knowledge" \
+  | ruby -rjson -e 'data=JSON.parse(STDIN.read); abort "expected conflict evidence" if data.fetch("conflicts").empty?; abort "expected gap creation" unless data.fetch("gap_created").fetch("gap_id") == "gap-conflict-affects-answer"'
+
+[[ -f "$TEMP_DIR/knowledge/gaps/open/gap-conflict-affects-answer.md" ]]
+
+echo "Answer context selector smoke passed."

--- a/scripts/answer-context-selector.rb
+++ b/scripts/answer-context-selector.rb
@@ -1,0 +1,116 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "pathname"
+require "rbconfig"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
+DEFAULT_KNOWLEDGE_ROOT = ROOT.join("knowledge")
+
+STRATEGIES = {
+  "factual" => ["claim", "citation", "source_artifact", "validation_result"],
+  "decision" => ["decision", "tradeoff", "option", "assumption", "citation", "validation_result"],
+  "uncertainty" => ["assumption", "open_question", "source_gap", "confidence_assessment", "validation_result"],
+  "concept_explanation" => ["concept", "claim", "citation", "knowledge_note"],
+  "gap_oriented" => ["source_gap", "open_question", "validation_result", "knowledge_note"]
+}.freeze
+
+def usage
+  abort "Usage: ruby scripts/answer-context-selector.rb --query QUERY --graph PATH [--knowledge-root PATH] [--agent-answer-type TYPE]"
+end
+
+def parse_args(argv)
+  flags = { "knowledge_root" => DEFAULT_KNOWLEDGE_ROOT.to_s }
+  until argv.empty?
+    key = argv.shift
+    usage unless key.start_with?("--")
+    flags[key.delete_prefix("--").tr("-", "_")] = argv.shift || usage
+  end
+  usage unless flags["query"] && flags["graph"]
+  flags
+end
+
+def deterministic_type(query)
+  text = query.downcase
+  return "gap_oriented" if text.match?(/\b(missing|need from me|gap|unresolved|clarify)\b/)
+  return "decision" if text.match?(/\b(why|decision|decide|decided|choose|chosen|tradeoff)\b/)
+  return "uncertainty" if text.match?(/\b(unknown|uncertain|risk|assumption|confidence)\b/)
+  return "concept_explanation" if text.match?(/\b(what is|explain|concept|how does|describe)\b/)
+
+  "factual"
+end
+
+def front_matter(markdown)
+  lines = markdown.lines
+  return {} unless lines.first&.strip == "---"
+  closing = lines[1..].find_index { |line| line.strip == "---" }
+  return {} if closing.nil?
+
+  lines[1, closing].each_with_object({}) do |line, data|
+    key, value = line.split(":", 2)
+    data[key.strip] = value.strip if key && value
+  end
+end
+
+def open_conflicts(knowledge_root)
+  Dir.glob(Pathname.new(knowledge_root).join("conflicts", "open", "*.md")).sort.map do |path|
+    data = front_matter(File.read(path))
+    data.merge("path" => Pathname.new(path).to_s)
+  end
+end
+
+def relevant_conflicts(query, conflicts)
+  text = query.downcase
+  conflicts.select do |conflict|
+    summary = conflict.fetch("summary", "").downcase
+    text.include?("conflict") || summary.split(/\W+/).any? { |word| word.length > 5 && text.include?(word) }
+  end
+end
+
+def create_conflict_gap(query, knowledge_root, conflicts)
+  return nil if conflicts.empty?
+
+  first = conflicts.first
+  stdout, stderr, status = Open3.capture3(
+    RbConfig.ruby,
+    ROOT.join("scripts", "knowledge-gap-lifecycle.rb").to_s,
+    "create-gap",
+    "--knowledge-root", knowledge_root.to_s,
+    "--gap-id", "gap-conflict-affects-answer",
+    "--source-question", query,
+    "--confidence-reason", "conflict affects answer confidence: #{first.fetch("summary")}",
+    "--trace-id", "answer-context-selector",
+    "--deterministic-complexity", "reasoning_heavy"
+  )
+  raise stderr unless status.success?
+
+  JSON.parse(stdout)
+end
+
+flags = parse_args(ARGV)
+query = flags.fetch("query")
+graph = JSON.parse(File.read(flags.fetch("graph")))
+deterministic = deterministic_type(query)
+agent = flags["agent_answer_type"]
+final = agent && STRATEGIES.key?(agent) ? agent : deterministic
+selected_types = STRATEGIES.fetch(final)
+selected_nodes = graph.fetch("nodes").select { |node| selected_types.include?(node.fetch("type")) }
+conflicts = relevant_conflicts(query, open_conflicts(flags.fetch("knowledge_root")))
+gap = create_conflict_gap(query, flags.fetch("knowledge_root"), conflicts)
+
+result = {
+  "trace" => {
+    "deterministic_answer_type" => deterministic,
+    "agent_answer_type" => agent,
+    "final_answer_type" => final,
+    "context_strategy" => "#{final}:#{selected_types.join(",")}"
+  },
+  "selected_node_types" => selected_types,
+  "selected_nodes" => selected_nodes.map { |node| node.slice("node_id", "label", "type", "source_paths") },
+  "conflicts" => conflicts.map { |conflict| conflict.slice("conflict_id", "summary", "path") },
+  "gap_created" => gap
+}
+
+puts JSON.pretty_generate(result)

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -117,6 +117,9 @@ bash ./scripts/reasoning-graph-extraction-smoke.sh
 echo "Validating knowledge gap lifecycle..."
 bash ./scripts/knowledge-gap-lifecycle-smoke.sh
 
+echo "Validating answer context selection..."
+bash ./scripts/answer-context-selector-smoke.sh
+
 echo "Validating federation index generation..."
 bash ./scripts/federation-index-smoke.sh
 


### PR DESCRIPTION
## What this changes

Adds deterministic graph-aware answer context selection for MVP-046. The selector classifies answer type from the query, supports an optional agent answer-type override, selects reasoning graph node types by strategy, records trace fields, surfaces relevant open conflicts, and creates a gap when a conflict affects answer confidence.

## Spec reference

- `openspec/specs/reasoning-graph/spec.md` - Select graph context by answer type and record traceable answer type
- `openspec/specs/knowledge-gap-lifecycle/spec.md` - conflict disclosure and gap creation when confidence is affected
- `openspec/specs/traverse-integration/spec.md` - runtime-formatted evidence boundary

## Spec delta (if spec changed)

None in this PR.

## Test coverage

Added `scripts/answer-context-selector-smoke.sh`, covering:

- factual, decision, uncertainty, concept explanation, and gap-oriented deterministic classifications
- context node strategy for each answer type
- optional agent answer-type override
- relevant conflict surfacing
- gap creation when a conflict affects answer confidence

Validation:

```bash
PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
PYTHON=/opt/homebrew/bin/python3.14 \
bash scripts/smoke.sh
```

Result: passed.

## Lean ops / minimality

Added a runtime-side deterministic selector and smoke coverage without moving this behavior into the UI. Full Traverse agent refinement remains optional and later runtime integration can call the same selector output shape.

## Breaking changes

None.

Closes #143
