### PR TITLE
MVP-047: Implement direct fact gap resolution

### DIFF
--- a/scripts/direct-fact-resolution-smoke.sh
+++ b/scripts/direct-fact-resolution-smoke.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+mkdir -p \
+  "$TEMP_DIR/app/site" \
+  "$TEMP_DIR/knowledge/blog" \
+  "$TEMP_DIR/knowledge/books" \
+  "$TEMP_DIR/knowledge/papers" \
+  "$TEMP_DIR/scripts"
+
+cp "$ROOT_DIR/app/site/author-instance.json" "$TEMP_DIR/app/site/author-instance.json"
+cp "$ROOT_DIR/app/site/provider-config.json" "$TEMP_DIR/app/site/provider-config.json"
+cp "$ROOT_DIR/scripts/m3.sh" "$TEMP_DIR/scripts/m3.sh"
+cp "$ROOT_DIR/scripts/m3-sync.sh" "$TEMP_DIR/scripts/m3-sync.sh"
+cp "$ROOT_DIR/scripts/generate-site-artifacts.rb" "$TEMP_DIR/scripts/generate-site-artifacts.rb"
+cp "$ROOT_DIR/scripts/reasoning-graph-extractor.rb" "$TEMP_DIR/scripts/reasoning-graph-extractor.rb"
+cp "$ROOT_DIR/scripts/validate-decision-log-package.rb" "$TEMP_DIR/scripts/validate-decision-log-package.rb"
+cp "$ROOT_DIR/scripts/ingest-decision-log.rb" "$TEMP_DIR/scripts/ingest-decision-log.rb"
+cp "$ROOT_DIR/scripts/knowledge-gap-lifecycle.rb" "$TEMP_DIR/scripts/knowledge-gap-lifecycle.rb"
+cp "$ROOT_DIR/scripts/resolve-direct-fact-gap.rb" "$TEMP_DIR/scripts/resolve-direct-fact-gap.rb"
+
+(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh sync >/dev/null
+)
+
+ruby "$TEMP_DIR/scripts/knowledge-gap-lifecycle.rb" create-gap \
+  --knowledge-root "$TEMP_DIR/knowledge" \
+  --gap-id gap-author-name \
+  --source-question "What is the author name?" \
+  --confidence-reason "missing simple fact" \
+  --trace-id trace-direct-fact \
+  --deterministic-complexity simple_factual >/tmp/direct-fact-gap-create.json
+
+resolve_output="$(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh gaps resolve-fact gap-author-name \
+    --answer "The author name is Enrico Piovesan." \
+    --package-id decision-log-20260630-gap-author-name-direct-fact
+)"
+
+ruby -rjson -e 'data=JSON.parse(STDIN.read); abort "expected direct fact resolved" unless data.fetch("status") == "direct_fact_resolved" && data.fetch("gap_id") == "gap-author-name" && data.fetch("package_id") == "decision-log-20260630-gap-author-name-direct-fact"' <<<"$resolve_output"
+
+[[ -f "$TEMP_DIR/knowledge/sources/decision-logs/decision-log-20260630-gap-author-name-direct-fact/decision-log.md" ]]
+[[ -f "$TEMP_DIR/knowledge/sources/decision-logs/decision-log-20260630-gap-author-name-direct-fact/ingestion-provenance.json" ]]
+[[ -f "$TEMP_DIR/knowledge/notes/decision-logs/decision-log-20260630-gap-author-name-direct-fact.md" ]]
+[[ -f "$TEMP_DIR/knowledge/gaps/resolved/gap-author-name.md" ]]
+[[ ! -e "$TEMP_DIR/knowledge/gaps/open/gap-author-name.md" ]]
+
+grep -q 'linked_package_id: decision-log-20260630-gap-author-name-direct-fact' "$TEMP_DIR/knowledge/gaps/resolved/gap-author-name.md"
+grep -q '"mode": "direct_fact_resolution"' "$TEMP_DIR/knowledge/sources/decision-logs/decision-log-20260630-gap-author-name-direct-fact/ingestion-provenance.json"
+
+ruby -rjson -e 'graph=JSON.parse(File.read(ARGV[0])); abort "missing graph package provenance" unless graph.fetch("generated_from").include?("decision-log-20260630-gap-author-name-direct-fact"); labels=graph.fetch("nodes").map { |node| node.fetch("label") }; abort "missing direct fact claim node" unless labels.include?("The author name is Enrico Piovesan.")' "$TEMP_DIR/app/site/knowledge-graph.json"
+
+ruby "$TEMP_DIR/scripts/knowledge-gap-lifecycle.rb" create-gap \
+  --knowledge-root "$TEMP_DIR/knowledge" \
+  --gap-id gap-runtime-strategy \
+  --source-question "What should the runtime strategy be?" \
+  --confidence-reason "requires architecture tradeoff" \
+  --trace-id trace-heavy \
+  --deterministic-complexity reasoning_heavy >/tmp/direct-fact-heavy-gap.json
+
+if (
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh gaps resolve-fact gap-runtime-strategy --answer "Use a shortcut." >/tmp/direct-fact-heavy-out.json 2>/tmp/direct-fact-heavy-err.txt
+); then
+  echo "Expected reasoning-heavy gap to reject direct fact resolution." >&2
+  exit 1
+fi
+grep -q 'GAP_REQUIRES_DECISION_LOG_PACKAGE' /tmp/direct-fact-heavy-err.txt
+
+if (
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh gaps resolve-fact gap-runtime-strategy --answer "" >/tmp/direct-fact-empty-out.json 2>/tmp/direct-fact-empty-err.txt
+); then
+  echo "Expected empty direct answer to fail." >&2
+  exit 1
+fi
+grep -q 'DIRECT_FACT_ANSWER_REQUIRED' /tmp/direct-fact-empty-err.txt
+
+echo "Direct fact resolution smoke passed."

--- a/scripts/knowledge-gap-lifecycle.rb
+++ b/scripts/knowledge-gap-lifecycle.rb
@@ -135,6 +135,7 @@ def resolve_gap(flags)
   stable_error("GAP_NOT_FOUND", "Open gap not found: #{gap_id}") unless open_path.file?
   data = front_matter(open_path.read)
   data["status"] = "resolved"
+  data["linked_package_id"] = flags["linked_package_id"] if flags["linked_package_id"]
   data["updated_at"] = Time.now.utc.iso8601
   resolved_path = knowledge_root.join("gaps", "resolved", "#{gap_id}.md")
   write_record(resolved_path, data, open_path.read.split("---", 3).fetch(2, "").strip)

--- a/scripts/m3.sh
+++ b/scripts/m3.sh
@@ -103,8 +103,12 @@ case "$COMMAND" in
         shift
         ruby ./scripts/knowledge-gap-lifecycle.rb list-gaps "$@"
         ;;
+      resolve-fact)
+        shift
+        ruby ./scripts/resolve-direct-fact-gap.rb "$@"
+        ;;
       *)
-        echo "Usage: ./scripts/m3.sh gaps list [--knowledge-root PATH]" >&2
+        echo "Usage: ./scripts/m3.sh gaps {list|resolve-fact} ..." >&2
         exit 1
         ;;
     esac

--- a/scripts/resolve-direct-fact-gap.rb
+++ b/scripts/resolve-direct-fact-gap.rb
@@ -1,0 +1,213 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "open3"
+require "pathname"
+require "rbconfig"
+require "tmpdir"
+require "time"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
+DEFAULT_KNOWLEDGE_ROOT = ROOT.join("knowledge")
+
+def usage
+  abort "Usage: ./scripts/m3.sh gaps resolve-fact <gap-id> --answer TEXT [--knowledge-root PATH] [--persona-id ID] [--package-id ID]"
+end
+
+def stable_error(code, message)
+  warn "#{code}: #{message}"
+  exit 1
+end
+
+def slug(value)
+  value.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-+|-+\z/, "")
+end
+
+def parse_args(argv)
+  usage if argv.empty?
+  gap_id = argv.shift
+  flags = { "knowledge_root" => DEFAULT_KNOWLEDGE_ROOT.to_s, "persona_id" => "default" }
+
+  until argv.empty?
+    flag = argv.shift
+    usage unless flag.start_with?("--")
+    flags[flag.delete_prefix("--").tr("-", "_")] = argv.shift || usage
+  end
+
+  stable_error("DIRECT_FACT_ANSWER_REQUIRED", "Direct fact resolution requires a non-empty --answer.") if flags["answer"].to_s.strip.empty?
+  [gap_id, flags]
+end
+
+def front_matter(markdown)
+  lines = markdown.lines
+  stable_error("FRONT_MATTER_MISSING", "Gap record is missing front matter.") unless lines.first&.strip == "---"
+  closing = lines[1..].find_index { |line| line.strip == "---" }
+  stable_error("FRONT_MATTER_MISSING", "Gap record front matter is not closed.") if closing.nil?
+
+  lines[1, closing].each_with_object({}) do |line, data|
+    next if line.strip.empty?
+    key, value = line.split(":", 2)
+    stable_error("FRONT_MATTER_INVALID", "Invalid gap front matter line: #{line.strip}") if value.nil?
+    data[key.strip] = value.strip == "null" ? nil : value.strip
+  end
+end
+
+def run_or_fail(code, message, *command)
+  stdout, stderr, status = Open3.capture3(*command)
+  stable_error(code, "#{message}: #{stderr.strip.empty? ? stdout.strip : stderr.strip}") unless status.success?
+  stdout
+end
+
+def write_package(package_dir, package_id, gap_id, persona_id, question, answer)
+  created_at = Time.now.utc.iso8601
+  package_dir.join("decision-log.md").write(<<~MARKDOWN)
+    # Direct Fact Decision Log
+
+    ## Package ID
+    #{package_id}
+
+    ## Persona ID
+    #{persona_id}
+
+    ## Package Mode
+    direct_fact_resolution
+
+    ## Direct Fact Resolution
+    Captured a simple factual answer from chat for gap `#{gap_id}`.
+
+    ## Conversation Goal
+    Resolve the simple factual knowledge gap `#{gap_id}`.
+
+    ## Questions Asked
+    - #{question}
+
+    ## Options Considered
+    - Resolve the factual gap directly in chat.
+    - Require a full decision-log package.
+
+    ## Pros and Cons
+    - Direct chat resolution: appropriate for a simple factual answer; preserves validation and provenance through an internal package.
+    - Full decision-log package: appropriate for reasoning-heavy gaps; unnecessary for this simple factual answer.
+
+    ## Recommendation
+    Use the direct chat answer as an internal mini decision-log package.
+
+    ## Assumptions
+    - The open gap is classified as simple_factual.
+
+    ## Challenged Assumptions
+    - Every gap requires a full external decision-log package.
+
+    ## Decisions
+    - Gap `#{gap_id}` is resolved through direct fact resolution.
+
+    ## Claims
+    - #{answer}
+
+    ## Confidence Assessment
+    Direct user-provided factual answer; deterministic validation required before ingestion.
+
+    ## Citations
+    - Direct chat answer for gap `#{gap_id}`.
+
+    ## Remaining Non-Blocking Open Questions
+    - None.
+
+    ## Blocking Clarifications
+    None.
+  MARKDOWN
+
+  package_dir.join("knowledge-note.md").write(<<~MARKDOWN)
+    # Direct Fact Knowledge Note
+
+    ## Package ID
+    #{package_id}
+
+    ## Title
+    Direct fact resolution for #{gap_id}
+
+    ## Summary
+    #{answer}
+
+    ## Supported Claims
+    - #{answer}
+
+    ## Decisions To Remember
+    - Gap `#{gap_id}` is resolved through direct fact resolution.
+
+    ## Assumptions To Revisit
+    - None.
+
+    ## Provenance
+    Distilled from `decision-log.md`.
+  MARKDOWN
+
+  package_dir.join("metadata.json").write(JSON.pretty_generate({
+    "schema_version" => "1.0.0",
+    "package_id" => package_id,
+    "persona_id" => persona_id,
+    "mode" => "direct_fact_resolution",
+    "created_by" => "youaskm3.reasoning-assistant",
+    "created_at" => created_at,
+    "source_gap_id" => gap_id,
+    "required_files" => ["decision-log.md", "knowledge-note.md", "metadata.json"]
+  }) + "\n")
+end
+
+gap_id, flags = parse_args(ARGV)
+knowledge_root = Pathname.new(flags.fetch("knowledge_root")).expand_path
+gap_path = knowledge_root.join("gaps", "open", "#{gap_id}.md")
+stable_error("GAP_NOT_FOUND", "Open gap not found: #{gap_id}") unless gap_path.file?
+
+gap = front_matter(gap_path.read)
+unless gap["status"] == "open" && gap["final_complexity"] == "simple_factual" && gap["allowed_resolution_path"] == "direct_chat"
+  stable_error("GAP_REQUIRES_DECISION_LOG_PACKAGE", "Gap #{gap_id} is not eligible for direct chat resolution; use a decision-log package.")
+end
+
+answer = flags.fetch("answer").strip.gsub(/\s+/, " ")
+stable_error("DIRECT_FACT_ANSWER_REQUIRED", "Direct fact resolution requires a non-empty --answer.") if answer.empty?
+package_id = flags["package_id"] || "decision-log-#{Time.now.utc.strftime("%Y%m%d")}-#{slug(gap_id)}-direct-fact"
+
+Dir.mktmpdir("youaskm3-direct-fact-") do |dir|
+  package_dir = Pathname.new(dir).join(package_id)
+  FileUtils.mkdir_p(package_dir)
+  write_package(package_dir, package_id, gap_id, flags.fetch("persona_id"), gap.fetch("source_question"), answer)
+
+  ingest_stdout = run_or_fail(
+    "DIRECT_FACT_INGEST_FAILED",
+    "Internal direct fact package ingestion failed",
+    RbConfig.ruby,
+    ROOT.join("scripts", "ingest-decision-log.rb").to_s,
+    package_dir.to_s,
+    "--knowledge-root",
+    knowledge_root.to_s
+  )
+  ingest_result = JSON.parse(ingest_stdout)
+
+  resolve_stdout = run_or_fail(
+    "DIRECT_FACT_GAP_UPDATE_FAILED",
+    "Direct fact package ingested but gap resolution failed",
+    RbConfig.ruby,
+    ROOT.join("scripts", "knowledge-gap-lifecycle.rb").to_s,
+    "resolve-gap",
+    "--knowledge-root",
+    knowledge_root.to_s,
+    "--gap-id",
+    gap_id,
+    "--linked-package-id",
+    package_id
+  )
+
+  run_or_fail("DIRECT_FACT_SYNC_FAILED", "Direct fact package ingested but graph sync failed", "bash", ROOT.join("scripts", "m3-sync.sh").to_s) if knowledge_root == DEFAULT_KNOWLEDGE_ROOT
+
+  puts JSON.pretty_generate({
+    "status" => "direct_fact_resolved",
+    "gap_id" => gap_id,
+    "package_id" => package_id,
+    "package_path" => ingest_result.fetch("package_path"),
+    "knowledge_note_path" => ingest_result.fetch("knowledge_note_path"),
+    "gap_update" => JSON.parse(resolve_stdout)
+  })
+end

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -117,6 +117,9 @@ bash ./scripts/reasoning-graph-extraction-smoke.sh
 echo "Validating knowledge gap lifecycle..."
 bash ./scripts/knowledge-gap-lifecycle-smoke.sh
 
+echo "Validating direct fact resolution..."
+bash ./scripts/direct-fact-resolution-smoke.sh
+
 echo "Validating answer context selection..."
 bash ./scripts/answer-context-selector-smoke.sh
 


### PR DESCRIPTION
## What this changes
Implements direct chat resolution for simple factual knowledge gaps by generating an internal direct_fact_resolution decision-log package, ingesting it through the existing package validator/provenance path, resolving the linked gap, and refreshing generated graph artifacts through sync.

## Spec reference
openspec/specs/knowledge-gap-lifecycle/spec.md - Resolve simple factual gaps through internal packages
openspec/specs/decision-log-package/spec.md - Validate package structure / preserve source package provenance
openspec/specs/reasoning-graph/spec.md - reasoning graph extraction from decision-log packages

## Spec delta (if spec changed)
None.

## Test coverage
Focused direct fact smoke added for success, package provenance, graph update, reasoning-heavy rejection, and empty answer rejection.

Full smoke passed locally:

```bash
PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh
```

## Lean ops / minimality
Used focused Project/issue queries, reused the existing decision-log validation, ingestion, gap lifecycle, and sync pipeline, and added one small command surface for the active issue.

## Breaking changes
None.

Closes #144
