### PR TITLE
MVP-048: Add local runtime MCP parity adapter

### DIFF
--- a/app/components/mcp-tools-contract.test.ts
+++ b/app/components/mcp-tools-contract.test.ts
@@ -44,6 +44,8 @@ describe("mcp-tools contracts", () => {
 
     expect(contracts.tools.map((tool) => tool.name)).toEqual([
       "knowledge.query.answer",
+      "knowledge.gaps.list",
+      "knowledge.gaps.resolve_fact",
       "search",
       "remember",
       "recall",
@@ -78,6 +80,12 @@ describe("mcp-tools contracts", () => {
       (tool) => tool.name === "knowledge.query.answer"
     );
     const searchContract = contracts.tools.find((tool) => tool.name === "search");
+    const gapsListContract = contracts.tools.find(
+      (tool) => tool.name === "knowledge.gaps.list"
+    );
+    const resolveFactContract = contracts.tools.find(
+      (tool) => tool.name === "knowledge.gaps.resolve_fact"
+    );
     const rememberContract = contracts.tools.find(
       (tool) => tool.name === "remember"
     );
@@ -100,6 +108,20 @@ describe("mcp-tools contracts", () => {
     ]);
     expect(searchContract).toBeDefined();
     expect(searchContract?.output_schema.properties).toHaveProperty("results");
+    expect(gapsListContract).toMatchObject({
+      capability_id: "knowledge.gaps.list",
+      contract_path: "contracts/capabilities/knowledge.gaps.list.json",
+      surface: "traverse_mcp",
+      workflow_id: "youaskm3.knowledge.gaps-list"
+    });
+    expect(gapsListContract?.output_schema.required).toEqual(["gaps", "trace_id"]);
+    expect(resolveFactContract).toMatchObject({
+      capability_id: "knowledge.gaps.resolve_fact",
+      contract_path: "contracts/capabilities/knowledge.gaps.resolve_fact.json",
+      surface: "traverse_mcp",
+      workflow_id: "youaskm3.knowledge.gaps-resolve-fact"
+    });
+    expect(resolveFactContract?.input_schema.required).toEqual(["gap_id", "answer"]);
     expect(rememberContract?.input_schema.required).toEqual([
       "source",
       "source_type"

--- a/contracts/capabilities/knowledge.gaps.list.json
+++ b/contracts/capabilities/knowledge.gaps.list.json
@@ -1,0 +1,64 @@
+{
+  "kind": "youaskm3.capability_contract",
+  "schema_version": "1.0.0",
+  "id": "knowledge.gaps.list",
+  "version": "0.1.0",
+  "lifecycle": "mvp",
+  "summary": "List unresolved knowledge gaps with provenance and resolution paths.",
+  "description": "Returns open knowledge gaps through the Traverse runtime boundary so HTTP and MCP clients see the same missing-knowledge surface.",
+  "execution": {
+    "runtime": "traverse",
+    "business_logic": "wasm",
+    "permitted_targets": ["local", "server", "mcp"],
+    "requires_trace": true
+  },
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "persona_id": { "type": "string" },
+        "limit": { "type": "integer", "minimum": 1, "maximum": 100 }
+      },
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "gaps": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "gap_id": { "type": "string" },
+              "status": { "type": "string" },
+              "source_question": { "type": "string" },
+              "allowed_resolution_path": { "type": "string" },
+              "final_complexity": { "type": "string" },
+              "trace_id": { "type": "string" }
+            },
+            "required": ["gap_id", "status", "source_question", "allowed_resolution_path", "final_complexity"],
+            "additionalProperties": false
+          }
+        },
+        "trace_id": { "type": "string" },
+        "failure": { "$ref": "#/$defs/failure" }
+      },
+      "required": ["gaps", "trace_id"],
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "failure": {
+      "type": "object",
+      "properties": {
+        "code": { "type": "string" },
+        "message": { "type": "string" },
+        "recoverable": { "type": "boolean" }
+      },
+      "required": ["code", "message", "recoverable"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/contracts/capabilities/knowledge.gaps.resolve_fact.json
+++ b/contracts/capabilities/knowledge.gaps.resolve_fact.json
@@ -1,0 +1,56 @@
+{
+  "kind": "youaskm3.capability_contract",
+  "schema_version": "1.0.0",
+  "id": "knowledge.gaps.resolve_fact",
+  "version": "0.1.0",
+  "lifecycle": "mvp",
+  "summary": "Resolve a simple factual knowledge gap through an internal decision-log package.",
+  "description": "Accepts a direct factual answer for an eligible gap while preserving Traverse-governed validation, package provenance, graph update, and gap lifecycle behavior.",
+  "execution": {
+    "runtime": "traverse",
+    "business_logic": "wasm",
+    "permitted_targets": ["local", "server", "mcp"],
+    "requires_trace": true
+  },
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "gap_id": { "type": "string", "minLength": 1 },
+        "answer": { "type": "string", "minLength": 1 },
+        "persona_id": { "type": "string" }
+      },
+      "required": ["gap_id", "answer"],
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "status": { "type": "string" },
+        "gap_id": { "type": "string" },
+        "package_id": { "type": "string" },
+        "package_path": { "type": "string" },
+        "knowledge_note_path": { "type": "string" },
+        "trace_id": { "type": "string" },
+        "validation": { "type": "object" },
+        "failure": { "$ref": "#/$defs/failure" }
+      },
+      "required": ["status", "gap_id", "package_id", "trace_id"],
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "failure": {
+      "type": "object",
+      "properties": {
+        "code": { "type": "string" },
+        "message": { "type": "string" },
+        "recoverable": { "type": "boolean" }
+      },
+      "required": ["code", "message", "recoverable"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/contracts/mcp-tools.json
+++ b/contracts/mcp-tools.json
@@ -87,6 +87,130 @@
       }
     },
     {
+      "name": "knowledge.gaps.list",
+      "description": "List unresolved knowledge gaps through the same Traverse-backed operation used by HTTP JSON.",
+      "capability_id": "knowledge.gaps.list",
+      "workflow_id": "youaskm3.knowledge.gaps-list",
+      "contract_path": "contracts/capabilities/knowledge.gaps.list.json",
+      "surface": "traverse_mcp",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "persona_id": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "gaps": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "trace_id": {
+            "type": "string"
+          },
+          "failure": {
+            "type": "object"
+          }
+        },
+        "required": ["gaps", "trace_id"],
+        "additionalProperties": false
+      },
+      "error_schema": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "trace_id": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "message"],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "knowledge.gaps.resolve_fact",
+      "description": "Resolve a simple factual gap through the same Traverse-backed operation used by HTTP JSON.",
+      "capability_id": "knowledge.gaps.resolve_fact",
+      "workflow_id": "youaskm3.knowledge.gaps-resolve-fact",
+      "contract_path": "contracts/capabilities/knowledge.gaps.resolve_fact.json",
+      "surface": "traverse_mcp",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "gap_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "answer": {
+            "type": "string",
+            "minLength": 1
+          },
+          "persona_id": {
+            "type": "string"
+          }
+        },
+        "required": ["gap_id", "answer"],
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          },
+          "gap_id": {
+            "type": "string"
+          },
+          "package_id": {
+            "type": "string"
+          },
+          "trace_id": {
+            "type": "string"
+          },
+          "validation": {
+            "type": "object"
+          },
+          "failure": {
+            "type": "object"
+          }
+        },
+        "required": ["status", "gap_id", "package_id", "trace_id"],
+        "additionalProperties": false
+      },
+      "error_schema": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "trace_id": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "message"],
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "search",
       "description": "Semantic and keyword hybrid search across indexed knowledge.",
       "input_schema": {

--- a/scripts/local-runtime-mcp-parity-smoke.sh
+++ b/scripts/local-runtime-mcp-parity-smoke.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+trap 'rm -f /tmp/m3-runtime-*.json' EXIT
+
+cd "$ROOT_DIR"
+
+ruby ./scripts/m3-local-runtime.rb --routes-json >/tmp/m3-runtime-health.json
+ruby -rjson -e 'data=JSON.parse(File.read(ARGV[0])); abort "runtime not ready" unless data.fetch("status") == "ready"; routes=data.fetch("routes").map { |route| [route.fetch("method"), route.fetch("path")] }; [%w[POST /api/answer], %w[GET /api/gaps], %w[POST /api/gaps/resolve-fact], %w[POST /mcp/tools/knowledge.query.answer], %w[POST /mcp/tools/knowledge.gaps.list], %w[POST /mcp/tools/knowledge.gaps.resolve_fact]].each { |route| abort "missing route #{route.inspect}" unless routes.include?(route) }' /tmp/m3-runtime-health.json
+
+ruby ./scripts/m3-local-runtime.rb --simulate POST /api/answer --body '{"query":"What is portable knowledge?","request_id":"parity-answer"}' >/tmp/m3-runtime-http-answer.json || true
+ruby ./scripts/m3-local-runtime.rb --simulate POST /mcp/tools/knowledge.query.answer --body '{"query":"What is portable knowledge?","request_id":"parity-answer"}' >/tmp/m3-runtime-mcp-answer.json || true
+
+ruby -rjson -e 'http=JSON.parse(File.read(ARGV[0])); mcp=JSON.parse(File.read(ARGV[1])); abort "expected missing runtime" unless http.fetch("code") == "MISSING_TRAVERSE_RUNTIME" && mcp.fetch("code") == "MISSING_TRAVERSE_RUNTIME"; abort "answer capability mismatch" unless http.fetch("capability_id") == mcp.fetch("capability_id") && http.fetch("workflow_id") == mcp.fetch("workflow_id"); abort "answer input mismatch" unless http.fetch("traverse_request").fetch("input") == mcp.fetch("traverse_request").fetch("input"); abort "expected surface split" unless http.fetch("surface") == "http" && mcp.fetch("surface") == "mcp"' /tmp/m3-runtime-http-answer.json /tmp/m3-runtime-mcp-answer.json
+
+ruby ./scripts/m3-local-runtime.rb --simulate GET /api/gaps >/tmp/m3-runtime-http-gaps.json || true
+ruby ./scripts/m3-local-runtime.rb --simulate POST /mcp/tools/knowledge.gaps.list --body '{}' >/tmp/m3-runtime-mcp-gaps.json || true
+
+ruby -rjson -e 'http=JSON.parse(File.read(ARGV[0])); mcp=JSON.parse(File.read(ARGV[1])); abort "gaps capability mismatch" unless http.fetch("capability_id") == "knowledge.gaps.list" && http.fetch("capability_id") == mcp.fetch("capability_id"); abort "gaps workflow mismatch" unless http.fetch("workflow_id") == mcp.fetch("workflow_id")' /tmp/m3-runtime-http-gaps.json /tmp/m3-runtime-mcp-gaps.json
+
+ruby ./scripts/m3-local-runtime.rb --simulate POST /api/gaps/resolve-fact --body '{"gap_id":"gap-author-name","answer":"The author is Enrico Piovesan.","request_id":"parity-resolve"}' >/tmp/m3-runtime-http-resolve.json || true
+ruby ./scripts/m3-local-runtime.rb --simulate POST /mcp/tools/knowledge.gaps.resolve_fact --body '{"gap_id":"gap-author-name","answer":"The author is Enrico Piovesan.","request_id":"parity-resolve"}' >/tmp/m3-runtime-mcp-resolve.json || true
+
+ruby -rjson -e 'http=JSON.parse(File.read(ARGV[0])); mcp=JSON.parse(File.read(ARGV[1])); abort "resolve capability mismatch" unless http.fetch("capability_id") == "knowledge.gaps.resolve_fact" && http.fetch("capability_id") == mcp.fetch("capability_id"); abort "resolve input mismatch" unless http.fetch("traverse_request").fetch("input") == mcp.fetch("traverse_request").fetch("input")' /tmp/m3-runtime-http-resolve.json /tmp/m3-runtime-mcp-resolve.json
+
+if ruby ./scripts/m3-local-runtime.rb --simulate POST /api/answer --body '{invalid json' >/tmp/m3-runtime-invalid.json; then
+  echo "Expected invalid JSON request to fail." >&2
+  exit 1
+fi
+
+echo "Local runtime MCP parity smoke passed."

--- a/scripts/m3-command-surface-smoke.sh
+++ b/scripts/m3-command-surface-smoke.sh
@@ -10,6 +10,7 @@ mkdir -p "$TEMP_DIR/app/site" "$TEMP_DIR/scripts"
 cp "$ROOT_DIR/scripts/m3.sh" "$TEMP_DIR/scripts/m3.sh"
 cp "$ROOT_DIR/scripts/m3-search.rb" "$TEMP_DIR/scripts/m3-search.rb"
 cp "$ROOT_DIR/scripts/m3-serve.sh" "$TEMP_DIR/scripts/m3-serve.sh"
+cp "$ROOT_DIR/scripts/m3-local-runtime.rb" "$TEMP_DIR/scripts/m3-local-runtime.rb"
 
 cat <<'EOF' > "$TEMP_DIR/app/site/index.html"
 <!doctype html>
@@ -62,5 +63,6 @@ serve_help_output="$(
 )"
 
 grep -q "Usage: ./scripts/m3.sh serve \\[port\\]" <<<"$serve_help_output"
+grep -q "serve --runtime" <<<"$serve_help_output"
 
 echo "m3 command surface smoke passed."

--- a/scripts/m3-local-runtime.rb
+++ b/scripts/m3-local-runtime.rb
@@ -1,0 +1,227 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "securerandom"
+require "uri"
+require "webrick"
+
+OPERATIONS = {
+  "answer" => {
+    "capability_id" => "knowledge.query.answer",
+    "workflow_id" => "youaskm3.knowledge.query-answer",
+    "contract_path" => "contracts/capabilities/knowledge.query.answer.json"
+  },
+  "gaps.list" => {
+    "capability_id" => "knowledge.gaps.list",
+    "workflow_id" => "youaskm3.knowledge.gaps-list",
+    "contract_path" => "contracts/capabilities/knowledge.gaps.list.json"
+  },
+  "gaps.resolve_fact" => {
+    "capability_id" => "knowledge.gaps.resolve_fact",
+    "workflow_id" => "youaskm3.knowledge.gaps-resolve-fact",
+    "contract_path" => "contracts/capabilities/knowledge.gaps.resolve_fact.json"
+  }
+}.freeze
+
+ROUTES = {
+  ["POST", "/api/answer"] => ["http", "answer"],
+  ["GET", "/api/gaps"] => ["http", "gaps.list"],
+  ["POST", "/api/gaps/resolve-fact"] => ["http", "gaps.resolve_fact"],
+  ["POST", "/mcp/tools/knowledge.query.answer"] => ["mcp", "answer"],
+  ["POST", "/mcp/tools/knowledge.gaps.list"] => ["mcp", "gaps.list"],
+  ["POST", "/mcp/tools/knowledge.gaps.resolve_fact"] => ["mcp", "gaps.resolve_fact"]
+}.freeze
+
+def usage
+  abort "Usage: ruby scripts/m3-local-runtime.rb [--port PORT] [--traverse-endpoint URL] [--workspace-id ID] [--routes-json] [--simulate METHOD PATH --body JSON]"
+end
+
+def parse_args(argv)
+  config = {
+    "port" => "8787",
+    "traverse_endpoint" => ENV["TRAVERSE_ENDPOINT"].to_s,
+    "workspace_id" => ENV.fetch("TRAVERSE_WORKSPACE_ID", "local-default"),
+    "routes_json" => false,
+    "simulate" => nil,
+    "body" => "{}"
+  }
+
+  until argv.empty?
+    flag = argv.shift
+    case flag
+    when "--port"
+      config["port"] = argv.shift || usage
+    when "--traverse-endpoint"
+      config["traverse_endpoint"] = argv.shift || usage
+    when "--workspace-id"
+      config["workspace_id"] = argv.shift || usage
+    when "--routes-json"
+      config["routes_json"] = true
+    when "--simulate"
+      method = argv.shift || usage
+      path = argv.shift || usage
+      config["simulate"] = [method, path]
+    when "--body"
+      config["body"] = argv.shift || usage
+    when "--help", "-h"
+      usage
+    else
+      usage
+    end
+  end
+
+  abort "m3 local runtime expects a numeric port." unless config.fetch("port").match?(/\A\d+\z/)
+  config
+end
+
+def read_json_request(request)
+  return {} if request.body.to_s.strip.empty?
+
+  JSON.parse(request.body)
+rescue JSON::ParserError => error
+  raise WEBrick::HTTPStatus::BadRequest, "Invalid JSON request body: #{error.message}"
+end
+
+def parse_json_body(body)
+  return {} if body.to_s.strip.empty?
+
+  JSON.parse(body)
+end
+
+def build_traverse_request(surface, operation, input, workspace_id)
+  operation_contract = OPERATIONS.fetch(operation)
+  request_id = input["request_id"] || "youaskm3-local-#{operation.tr(".", "-")}-#{SecureRandom.hex(6)}"
+
+  {
+    "kind" => "runtime_request",
+    "schema_version" => "1.0.0",
+    "request_id" => request_id,
+    "workspace_id" => workspace_id,
+    "surface" => surface,
+    "intent" => operation_contract,
+    "input" => input.reject { |key, _| key == "request_id" },
+    "lookup" => {
+      "scope" => "prefer_private",
+      "allow_ambiguity" => false
+    },
+    "context" => {
+      "requested_target" => surface == "mcp" ? "mcp" : "local",
+      "caller" => surface == "mcp" ? "youaskm3-mcp" : "youaskm3-http-json"
+    },
+    "governing_spec" => "openspec/specs/local-runtime-sync/spec.md"
+  }
+end
+
+def missing_traverse_response(surface, operation, request)
+  operation_contract = OPERATIONS.fetch(operation)
+
+  {
+    "status" => "blocked",
+    "code" => "MISSING_TRAVERSE_RUNTIME",
+    "message" => "Set TRAVERSE_ENDPOINT or pass --traverse-endpoint to proxy #{operation} through Traverse.",
+    "recoverable" => true,
+    "trace_id" => "local-runtime:#{request.fetch("request_id")}",
+    "surface" => surface,
+    "operation" => operation,
+    "capability_id" => operation_contract.fetch("capability_id"),
+    "workflow_id" => operation_contract.fetch("workflow_id"),
+    "contract_path" => operation_contract.fetch("contract_path"),
+    "traverse_request" => request,
+    "provenance" => {
+      "runtime" => "traverse",
+      "business_logic" => "wasm",
+      "endpoint_configured" => false
+    }
+  }
+end
+
+def proxy_to_traverse(endpoint, workspace_id, request)
+  uri = URI.join(endpoint.end_with?("/") ? endpoint : "#{endpoint}/", "v1/workspaces/#{workspace_id}/execute")
+  response = Net::HTTP.post(uri, JSON.generate(request), "Content-Type" => "application/json", "Accept" => "application/json")
+  [response.code.to_i, JSON.parse(response.body)]
+rescue JSON::ParserError
+  [502, { "code" => "TRAVERSE_RESPONSE_INVALID", "message" => "Traverse returned non-JSON response.", "recoverable" => true }]
+rescue StandardError => error
+  [503, { "code" => "TRAVERSE_UNAVAILABLE", "message" => error.message, "recoverable" => true }]
+end
+
+def write_json(response, status, payload)
+  response.status = status
+  response["Content-Type"] = "application/json"
+  response.body = JSON.pretty_generate(payload) + "\n"
+end
+
+def routes_payload
+  {
+    "status" => "ready",
+    "runtime" => "youaskm3-local-runtime",
+    "routes" => ROUTES.map { |(method, path), (surface, operation)| { "method" => method, "path" => path, "surface" => surface, "operation" => operation } }
+  }
+end
+
+def handle_runtime_request(method, path, input, config)
+  route = ROUTES[[method, path]]
+  return [404, { "code" => "ROUTE_NOT_FOUND", "message" => "No local runtime route for #{method} #{path}." }] unless route
+
+  surface, operation = route
+  traverse_request = build_traverse_request(surface, operation, input, config.fetch("workspace_id"))
+  if config.fetch("traverse_endpoint").empty?
+    [503, missing_traverse_response(surface, operation, traverse_request)]
+  else
+    proxy_to_traverse(config.fetch("traverse_endpoint"), config.fetch("workspace_id"), traverse_request)
+  end
+end
+
+config = parse_args(ARGV)
+
+if config.fetch("routes_json")
+  puts JSON.pretty_generate(routes_payload.merge("traverse_endpoint_configured" => !config.fetch("traverse_endpoint").empty?))
+  exit 0
+end
+
+if config.fetch("simulate")
+  begin
+    method, path = config.fetch("simulate")
+    input = method == "GET" ? {} : parse_json_body(config.fetch("body"))
+    status, payload = handle_runtime_request(method, path, input, config)
+    puts JSON.pretty_generate(payload.merge("_http_status" => status))
+    exit(status < 500 ? 0 : 1)
+  rescue JSON::ParserError => error
+    puts JSON.pretty_generate({ "code" => "INVALID_JSON", "message" => error.message, "_http_status" => 400 })
+    exit 1
+  end
+end
+
+server = WEBrick::HTTPServer.new(
+  BindAddress: "127.0.0.1",
+  Port: config.fetch("port").to_i,
+  AccessLog: [],
+  Logger: WEBrick::Log.new($stderr, WEBrick::Log::WARN)
+)
+
+server.mount_proc "/health" do |_request, response|
+  write_json(response, 200, routes_payload.merge("traverse_endpoint_configured" => !config.fetch("traverse_endpoint").empty?))
+end
+
+ROUTES.each do |(method, path), (surface, operation)|
+  server.mount_proc path do |request, response|
+    unless request.request_method == method
+      write_json(response, 405, { "code" => "METHOD_NOT_ALLOWED", "message" => "#{path} expects #{method}." })
+      next
+    end
+
+    input = method == "GET" ? {} : read_json_request(request)
+    status, payload = handle_runtime_request(method, path, input, config)
+    write_json(response, status, payload)
+  rescue WEBrick::HTTPStatus::BadRequest => error
+    write_json(response, 400, { "code" => "INVALID_JSON", "message" => error.message })
+  end
+end
+
+trap("INT") { server.shutdown }
+trap("TERM") { server.shutdown }
+
+puts "youaskm3 local runtime listening on http://127.0.0.1:#{config.fetch("port")}/"
+server.start

--- a/scripts/m3-serve.sh
+++ b/scripts/m3-serve.sh
@@ -7,7 +7,17 @@ SITE_DIR="$ROOT_DIR/app/site"
 
 if [[ "$PORT" == "--help" || "$PORT" == "-h" ]]; then
   echo "Usage: ./scripts/m3.sh serve [port]"
+  echo "       ./scripts/m3.sh serve --runtime [port] [--traverse-endpoint URL]"
   exit 0
+fi
+
+if [[ "$PORT" == "--runtime" ]]; then
+  shift
+  runtime_port="${1:-8787}"
+  if [[ "${1:-}" =~ ^[0-9]+$ ]]; then
+    shift
+  fi
+  exec ruby "$ROOT_DIR/scripts/m3-local-runtime.rb" --port "$runtime_port" "$@"
 fi
 
 if ! [[ "$PORT" =~ ^[0-9]+$ ]]; then

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -90,6 +90,9 @@ bash ./scripts/traverse-answer-workflow-smoke.sh
 echo "Validating Traverse MCP answer workflow parity..."
 bash ./scripts/traverse-mcp-answer-workflow-smoke.sh
 
+echo "Validating local runtime MCP parity..."
+bash ./scripts/local-runtime-mcp-parity-smoke.sh
+
 echo "Validating local inference policy..."
 bash ./scripts/local-inference-policy-smoke.sh
 


### PR DESCRIPTION
## What this changes
Adds a local HTTP JSON runtime adapter for answer, gaps list, and direct fact resolution operations, with MCP-shaped routes for the same operations. Both surfaces build the same Traverse runtime request envelope and either proxy to a configured Traverse endpoint or return a stable missing-runtime setup response without duplicating retrieval, inference, graph, validation, or gap lifecycle logic in the host.

## Spec reference
openspec/specs/local-runtime-sync/spec.md - Serve local chat and MCP runtime
openspec/specs/mcp-interface/spec.md - Use expanded second-brain tools from MCP / preserve trace and evidence references
openspec/specs/traverse-integration/spec.md - Traverse-governed runtime boundary

## Spec delta (if spec changed)
None.

## Test coverage
Added local runtime MCP parity smoke for route existence, HTTP/MCP envelope parity, stable missing Traverse runtime responses, and invalid JSON rejection. Updated MCP contract coverage for gaps list and direct fact resolution tools.

Full smoke passed locally:

```bash
PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh
```

## Lean ops / minimality
Reused the existing Traverse request-envelope shape and contract-first boundaries. The local runtime adapter is a thin proxy/setup surface; it does not implement product/business behavior outside Traverse-governed capabilities.

## Breaking changes
None.

Closes #145
