### PR TITLE
MVP-049: Extend m3 init knowledge root setup

### DIFF
--- a/scripts/ingest-decision-log.rb
+++ b/scripts/ingest-decision-log.rb
@@ -79,6 +79,15 @@ def validate_knowledge_root!(knowledge_root)
   stable_error("EXTERNAL_KNOWLEDGE_ROOT_UNINITIALIZED", "External knowledge roots must be initialized before writes: #{knowledge_root}") unless marker.file?
 end
 
+def offline_knowledge_root?(knowledge_root)
+  marker = knowledge_root.join(".youaskm3-knowledge-root.json")
+  return false unless marker.file?
+
+  JSON.parse(marker.read).fetch("offline", false) == true
+rescue JSON::ParserError
+  false
+end
+
 def sync_preflight!(knowledge_root)
   return unless knowledge_root == DEFAULT_KNOWLEDGE_ROOT
 
@@ -150,6 +159,7 @@ stable_error("ARCHIVE_INPUT_UNSUPPORTED", "Decision-log package input must be a 
 stable_error("PACKAGE_NOT_DIRECTORY", "Decision-log package input must be a directory.") unless package_path.directory?
 
 validate_knowledge_root!(knowledge_root)
+stable_error("OFFLINE_KNOWLEDGE_ROOT_REQUIRES_STAGING", "This knowledge root was initialized offline; re-run with --offline to stage package metadata.") if offline_knowledge_root?(knowledge_root) && !offline
 sync_preflight!(knowledge_root)
 
 validation, validator_stderr, ok = run_validator(package_path)

--- a/scripts/local-runtime-mcp-parity-smoke.sh
+++ b/scripts/local-runtime-mcp-parity-smoke.sh
@@ -2,12 +2,27 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-trap 'rm -f /tmp/m3-runtime-*.json' EXIT
+CONFIG_DIR=""
+trap 'rm -f /tmp/m3-runtime-*.json; if [[ -n "$CONFIG_DIR" ]]; then rm -rf "$CONFIG_DIR"; fi' EXIT
 
 cd "$ROOT_DIR"
 
+CONFIG_DIR="$(mktemp -d)"
+cat >"$CONFIG_DIR/config.json" <<'JSON'
+{
+  "schema_version": "1.0.0",
+  "knowledge_root": "/tmp/youaskm3-configured-knowledge",
+  "traverse": {
+    "endpoint": "http://127.0.0.1:8787"
+  }
+}
+JSON
+
 ruby ./scripts/m3-local-runtime.rb --routes-json >/tmp/m3-runtime-health.json
 ruby -rjson -e 'data=JSON.parse(File.read(ARGV[0])); abort "runtime not ready" unless data.fetch("status") == "ready"; routes=data.fetch("routes").map { |route| [route.fetch("method"), route.fetch("path")] }; [%w[POST /api/answer], %w[GET /api/gaps], %w[POST /api/gaps/resolve-fact], %w[POST /mcp/tools/knowledge.query.answer], %w[POST /mcp/tools/knowledge.gaps.list], %w[POST /mcp/tools/knowledge.gaps.resolve_fact]].each { |route| abort "missing route #{route.inspect}" unless routes.include?(route) }' /tmp/m3-runtime-health.json
+
+ruby ./scripts/m3-local-runtime.rb --config "$CONFIG_DIR/config.json" --routes-json >/tmp/m3-runtime-configured-health.json
+ruby -rjson -e 'data=JSON.parse(File.read(ARGV[0])); abort "config endpoint not loaded" unless data.fetch("traverse_endpoint_configured") == true; abort "config knowledge root not loaded" unless data.fetch("knowledge_root") == "/tmp/youaskm3-configured-knowledge"' /tmp/m3-runtime-configured-health.json
 
 ruby ./scripts/m3-local-runtime.rb --simulate POST /api/answer --body '{"query":"What is portable knowledge?","request_id":"parity-answer"}' >/tmp/m3-runtime-http-answer.json || true
 ruby ./scripts/m3-local-runtime.rb --simulate POST /mcp/tools/knowledge.query.answer --body '{"query":"What is portable knowledge?","request_id":"parity-answer"}' >/tmp/m3-runtime-mcp-answer.json || true

--- a/scripts/m3-decision-log-ingest-smoke.sh
+++ b/scripts/m3-decision-log-ingest-smoke.sh
@@ -62,6 +62,15 @@ ruby -rjson -e 'data=JSON.parse(STDIN.read); abort "expected staged offline" unl
 
 if (
   cd "$TEMP_DIR"
+  bash ./scripts/m3.sh ingest-decision-log fixtures/decision-log-packages/valid/knowledge_addition --knowledge-root "$TEMP_DIR/offline-knowledge" >/tmp/decision-log-offline-final.txt 2>&1
+); then
+  echo "Expected offline knowledge root to reject final ingestion." >&2
+  exit 1
+fi
+grep -q 'OFFLINE_KNOWLEDGE_ROOT_REQUIRES_STAGING' /tmp/decision-log-offline-final.txt
+
+if (
+  cd "$TEMP_DIR"
   bash ./scripts/m3.sh ingest-decision-log fixtures/decision-log-packages/invalid/unsupported-note-claim >/tmp/decision-log-invalid-ingest.txt 2>&1
 ); then
   echo "Expected invalid decision-log package to fail ingestion." >&2

--- a/scripts/m3-init-smoke.sh
+++ b/scripts/m3-init-smoke.sh
@@ -17,7 +17,9 @@ bash ./scripts/m3-init.sh "$TEMP_DIR" \
 
 [[ -f "$TEMP_DIR/app/site/author-instance.json" ]]
 [[ -f "$TEMP_DIR/app/site/provider-config.json" ]]
+[[ -f "$TEMP_DIR/.youaskm3/config.json" ]]
 [[ -f "$TEMP_DIR/knowledge/index.md" ]]
+[[ -f "$TEMP_DIR/knowledge/.youaskm3-knowledge-root.json" ]]
 [[ -d "$TEMP_DIR/knowledge/inputs/articles" ]]
 [[ -d "$TEMP_DIR/knowledge/inputs/transcripts" ]]
 
@@ -25,5 +27,29 @@ grep -q '"instanceId": "smoke-instance"' "$TEMP_DIR/app/site/author-instance.jso
 grep -q '"title": "Smoke Instance"' "$TEMP_DIR/app/site/author-instance.json"
 grep -q '"shellUrl": "https://example.com/smoke/"' "$TEMP_DIR/app/site/author-instance.json"
 grep -q '"activeProviderId": "browser-demo"' "$TEMP_DIR/app/site/provider-config.json"
+grep -q '"knowledge_root":' "$TEMP_DIR/.youaskm3/config.json"
+
+EXTERNAL_ROOT="$TEMP_DIR/external-knowledge"
+bash ./scripts/m3-init.sh "$TEMP_DIR/external-workspace" \
+  --name "External Root Smoke" \
+  --shell-url "https://example.com/external/" \
+  --knowledge-root "$EXTERNAL_ROOT" \
+  --offline \
+  --yes
+
+[[ -f "$EXTERNAL_ROOT/.youaskm3-knowledge-root.json" ]]
+[[ -f "$TEMP_DIR/external-workspace/.youaskm3/config.json" ]]
+grep -q '"offline": true' "$EXTERNAL_ROOT/.youaskm3-knowledge-root.json"
+grep -q '"status": "unavailable"' "$TEMP_DIR/external-workspace/.youaskm3/config.json"
+
+if bash ./scripts/m3-init.sh "$TEMP_DIR/invalid-traverse" \
+  --name "Invalid Traverse" \
+  --shell-url "https://example.com/invalid/" \
+  --traverse-repo "$TEMP_DIR/missing-traverse" \
+  --yes >/tmp/m3-init-invalid-traverse.out 2>/tmp/m3-init-invalid-traverse.err; then
+  echo "Expected missing Traverse repo to fail." >&2
+  exit 1
+fi
+grep -q 'TRAVERSE_REPO_UNAVAILABLE' /tmp/m3-init-invalid-traverse.err
 
 echo "m3 init smoke passed."

--- a/scripts/m3-init.sh
+++ b/scripts/m3-init.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 usage() {
   cat >&2 <<'EOF'
 Usage: ./scripts/m3-init.sh [target-dir] [--name NAME] [--shell-url URL] [--instance-id ID] [--active-provider PROFILE] [--yes]
+                         [--knowledge-root PATH] [--traverse-repo PATH] [--offline]
 
-Bootstraps the minimum local instance metadata and directory layout needed for M4.
+Bootstraps local instance metadata, project config, and knowledge-root setup.
 EOF
 }
 
@@ -49,6 +50,29 @@ validate_active_provider() {
   esac
 }
 
+validate_traverse_repo() {
+  local repo="$1"
+  if [[ ! -d "$repo" ]]; then
+    echo "TRAVERSE_REPO_UNAVAILABLE: Traverse checkout not found: $repo" >&2
+    exit 1
+  fi
+
+  if ! git -C "$repo" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "TRAVERSE_REPO_INVALID: Traverse path is not a git checkout: $repo" >&2
+    exit 1
+  fi
+
+  if ! git -C "$repo" rev-parse -q --verify "refs/tags/v0.5.0" >/dev/null; then
+    echo "TRAVERSE_BASELINE_MISSING: Traverse checkout is missing required tag v0.5.0." >&2
+    exit 1
+  fi
+
+  if ! git -C "$repo" merge-base --is-ancestor "v0.5.0" HEAD >/dev/null 2>&1; then
+    echo "TRAVERSE_BASELINE_TOO_OLD: Traverse checkout must be at v0.5.0 or newer." >&2
+    exit 1
+  fi
+}
+
 prompt_if_missing() {
   local label="$1"
   local current_value="$2"
@@ -79,6 +103,9 @@ SHELL_URL=""
 INSTANCE_ID=""
 ACTIVE_PROVIDER="traverse-local"
 ASSUME_YES=false
+KNOWLEDGE_ROOT=""
+TRAVERSE_REPO=""
+OFFLINE=false
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
@@ -97,6 +124,18 @@ while [[ "$#" -gt 0 ]]; do
     --active-provider)
       ACTIVE_PROVIDER="${2:-}"
       shift 2
+      ;;
+    --knowledge-root)
+      KNOWLEDGE_ROOT="${2:-}"
+      shift 2
+      ;;
+    --traverse-repo)
+      TRAVERSE_REPO="${2:-}"
+      shift 2
+      ;;
+    --offline)
+      OFFLINE=true
+      shift
       ;;
     --yes)
       ASSUME_YES=true
@@ -124,6 +163,7 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 require_cmd ruby
+require_cmd git
 
 if [[ "$ASSUME_YES" == true ]]; then
   if [[ -z "$INSTANCE_NAME" || -z "$SHELL_URL" ]]; then
@@ -139,6 +179,15 @@ SHELL_URL="$(ensure_trailing_slash "$SHELL_URL")"
 validate_shell_url "$SHELL_URL"
 validate_active_provider "$ACTIVE_PROVIDER"
 
+if [[ "$OFFLINE" == true && -n "$TRAVERSE_REPO" ]]; then
+  echo "INVALID_INIT_MODE: use either --offline or --traverse-repo, not both." >&2
+  exit 1
+fi
+
+if [[ -n "$TRAVERSE_REPO" ]]; then
+  validate_traverse_repo "$TRAVERSE_REPO"
+fi
+
 if [[ -z "$INSTANCE_ID" ]]; then
   INSTANCE_ID="$(slugify "$INSTANCE_NAME")"
 fi
@@ -148,17 +197,27 @@ if [[ -z "$INSTANCE_ID" ]]; then
   exit 1
 fi
 
+if [[ -z "$KNOWLEDGE_ROOT" ]]; then
+  KNOWLEDGE_ROOT="$TARGET_DIR/knowledge"
+fi
+
 mkdir -p \
   "$TARGET_DIR/app/site" \
-  "$TARGET_DIR/knowledge/blog" \
-  "$TARGET_DIR/knowledge/books" \
-  "$TARGET_DIR/knowledge/papers" \
-  "$TARGET_DIR/knowledge/inputs/articles" \
-  "$TARGET_DIR/knowledge/inputs/notes" \
-  "$TARGET_DIR/knowledge/inputs/transcripts"
+  "$TARGET_DIR/.youaskm3" \
+  "$KNOWLEDGE_ROOT/blog" \
+  "$KNOWLEDGE_ROOT/books" \
+  "$KNOWLEDGE_ROOT/papers" \
+  "$KNOWLEDGE_ROOT/inputs/articles" \
+  "$KNOWLEDGE_ROOT/inputs/notes" \
+  "$KNOWLEDGE_ROOT/inputs/transcripts" \
+  "$KNOWLEDGE_ROOT/gaps/open" \
+  "$KNOWLEDGE_ROOT/gaps/resolved" \
+  "$KNOWLEDGE_ROOT/conflicts/open" \
+  "$KNOWLEDGE_ROOT/sources/decision-logs" \
+  "$KNOWLEDGE_ROOT/notes/decision-logs"
 
-if [[ ! -f "$TARGET_DIR/knowledge/index.md" ]]; then
-  cat >"$TARGET_DIR/knowledge/index.md" <<'EOF'
+if [[ ! -f "$KNOWLEDGE_ROOT/index.md" ]]; then
+  cat >"$KNOWLEDGE_ROOT/index.md" <<'EOF'
 # Knowledge Index
 
 This directory is the source-controlled knowledge store for this youaskm3 instance.
@@ -178,17 +237,29 @@ This directory is the source-controlled knowledge store for this youaskm3 instan
 EOF
 fi
 
-export INSTANCE_ID INSTANCE_NAME SHELL_URL ACTIVE_PROVIDER TARGET_DIR
+export INSTANCE_ID INSTANCE_NAME SHELL_URL ACTIVE_PROVIDER TARGET_DIR KNOWLEDGE_ROOT TRAVERSE_REPO OFFLINE
 ruby <<'RUBY'
 require "json"
+require "pathname"
+require "time"
 
 target_dir = ENV.fetch("TARGET_DIR")
+knowledge_root = Pathname.new(ENV.fetch("KNOWLEDGE_ROOT")).expand_path
+target_path = Pathname.new(target_dir).expand_path
+offline = ENV.fetch("OFFLINE") == "true"
+traverse_repo = ENV.fetch("TRAVERSE_REPO")
+knowledge_base = begin
+  "#{knowledge_root.relative_path_from(target_path)}/"
+rescue ArgumentError
+  knowledge_root.to_s
+end
+
 instance = {
   "instanceId" => ENV.fetch("INSTANCE_ID"),
   "title" => ENV.fetch("INSTANCE_NAME"),
   "shellUrl" => ENV.fetch("SHELL_URL"),
   "providerProfiles" => ["browser-demo", "traverse-local", "claude-api", "openai-api"],
-  "knowledgeBase" => "knowledge/"
+  "knowledgeBase" => knowledge_base
 }
 
 provider_config = {
@@ -232,6 +303,47 @@ provider_config = {
   ]
 }
 
+marker = {
+  "schema_version" => "1.0.0",
+  "kind" => "youaskm3_knowledge_root",
+  "instance_id" => ENV.fetch("INSTANCE_ID"),
+  "offline" => offline,
+  "created_at" => Time.now.utc.iso8601
+}
+
+config = {
+  "schema_version" => "1.0.0",
+  "instance_id" => ENV.fetch("INSTANCE_ID"),
+  "knowledge_root" => knowledge_root.to_s,
+  "offline" => offline,
+  "runtime_readiness" => if offline
+                           {
+                             "status" => "unavailable",
+                             "reason" => "offline_init",
+                             "next_action" => "Re-run m3 init with --traverse-repo <path> when Traverse is available."
+                           }
+                         elsif traverse_repo.empty?
+                           {
+                             "status" => "unconfigured",
+                             "reason" => "traverse_repo_not_provided",
+                             "next_action" => "Run m3 init --traverse-repo <path> or pass runtime CLI overrides."
+                           }
+                         else
+                           {
+                             "status" => "configured",
+                             "reason" => "traverse_baseline_validated",
+                             "next_action" => "Run ./scripts/m3.sh serve --runtime when ready."
+                           }
+                         end,
+  "traverse" => {
+    "repo" => traverse_repo.empty? ? nil : Pathname.new(traverse_repo).expand_path.to_s,
+    "minimum_tag" => "v0.5.0",
+    "endpoint" => "http://127.0.0.1:8787"
+  }
+}
+
+File.write(knowledge_root.join(".youaskm3-knowledge-root.json"), JSON.pretty_generate(marker) + "\n")
+File.write(File.join(target_dir, ".youaskm3/config.json"), JSON.pretty_generate(config) + "\n")
 File.write(File.join(target_dir, "app/site/author-instance.json"), JSON.pretty_generate(instance) + "\n")
 File.write(File.join(target_dir, "app/site/provider-config.json"), JSON.pretty_generate(provider_config) + "\n")
 RUBY
@@ -239,4 +351,5 @@ RUBY
 echo "Initialized youaskm3 instance metadata in ${TARGET_DIR}"
 echo "- app/site/author-instance.json"
 echo "- app/site/provider-config.json"
-echo "- knowledge/ directory scaffold"
+echo "- .youaskm3/config.json"
+echo "- ${KNOWLEDGE_ROOT}/ directory scaffold"

--- a/scripts/m3-local-runtime.rb
+++ b/scripts/m3-local-runtime.rb
@@ -3,9 +3,12 @@
 
 require "json"
 require "net/http"
+require "pathname"
 require "securerandom"
 require "uri"
 require "webrick"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
 
 OPERATIONS = {
   "answer" => {
@@ -43,6 +46,8 @@ def parse_args(argv)
     "port" => "8787",
     "traverse_endpoint" => ENV["TRAVERSE_ENDPOINT"].to_s,
     "workspace_id" => ENV.fetch("TRAVERSE_WORKSPACE_ID", "local-default"),
+    "config_path" => ENV.fetch("M3_PROJECT_CONFIG", ROOT.join(".youaskm3", "config.json").to_s),
+    "explicit_traverse_endpoint" => ENV.key?("TRAVERSE_ENDPOINT"),
     "routes_json" => false,
     "simulate" => nil,
     "body" => "{}"
@@ -55,8 +60,11 @@ def parse_args(argv)
       config["port"] = argv.shift || usage
     when "--traverse-endpoint"
       config["traverse_endpoint"] = argv.shift || usage
+      config["explicit_traverse_endpoint"] = true
     when "--workspace-id"
       config["workspace_id"] = argv.shift || usage
+    when "--config"
+      config["config_path"] = argv.shift || usage
     when "--routes-json"
       config["routes_json"] = true
     when "--simulate"
@@ -73,7 +81,21 @@ def parse_args(argv)
   end
 
   abort "m3 local runtime expects a numeric port." unless config.fetch("port").match?(/\A\d+\z/)
+  apply_project_config(config)
   config
+end
+
+def apply_project_config(config)
+  path = Pathname.new(config.fetch("config_path"))
+  return unless path.file?
+
+  project_config = JSON.parse(path.read)
+  if !config.fetch("explicit_traverse_endpoint") && config.fetch("traverse_endpoint").empty?
+    config["traverse_endpoint"] = project_config.dig("traverse", "endpoint").to_s
+  end
+  config["knowledge_root"] ||= project_config["knowledge_root"]
+rescue JSON::ParserError => error
+  abort "PROJECT_CONFIG_INVALID: #{path} is not valid JSON: #{error.message}"
 end
 
 def read_json_request(request)
@@ -153,10 +175,11 @@ def write_json(response, status, payload)
   response.body = JSON.pretty_generate(payload) + "\n"
 end
 
-def routes_payload
+def routes_payload(config)
   {
     "status" => "ready",
     "runtime" => "youaskm3-local-runtime",
+    "knowledge_root" => config["knowledge_root"],
     "routes" => ROUTES.map { |(method, path), (surface, operation)| { "method" => method, "path" => path, "surface" => surface, "operation" => operation } }
   }
 end
@@ -177,7 +200,7 @@ end
 config = parse_args(ARGV)
 
 if config.fetch("routes_json")
-  puts JSON.pretty_generate(routes_payload.merge("traverse_endpoint_configured" => !config.fetch("traverse_endpoint").empty?))
+  puts JSON.pretty_generate(routes_payload(config).merge("traverse_endpoint_configured" => !config.fetch("traverse_endpoint").empty?))
   exit 0
 end
 
@@ -202,7 +225,7 @@ server = WEBrick::HTTPServer.new(
 )
 
 server.mount_proc "/health" do |_request, response|
-  write_json(response, 200, routes_payload.merge("traverse_endpoint_configured" => !config.fetch("traverse_endpoint").empty?))
+  write_json(response, 200, routes_payload(config).merge("traverse_endpoint_configured" => !config.fetch("traverse_endpoint").empty?))
 end
 
 ROUTES.each do |(method, path), (surface, operation)|


### PR DESCRIPTION
## What this changes
Extends `m3 init` into the first-run setup command for default and external knowledge roots, project config, Traverse repo validation, and offline mode. Knowledge roots now get a `.youaskm3-knowledge-root.json` marker, workspaces get `.youaskm3/config.json`, offline-initialized roots block final ingestion unless the caller explicitly stages offline, and the local runtime adapter can read project config defaults while preserving CLI/env override precedence.

## Spec reference
openspec/specs/local-runtime-sync/spec.md - Initialize workspace and knowledge roots / Protect external knowledge roots
openspec/specs/decision-log-package/spec.md - Support offline staging only

## Spec delta (if spec changed)
None.

## Test coverage
Updated init smoke for default workspace config, external knowledge roots, offline runtime readiness, and missing Traverse repo setup errors. Updated decision-log ingestion smoke for offline-root final-ingest rejection. Updated local runtime parity smoke for project config loading.

Full smoke passed locally:

```bash
PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh
```

## Lean ops / minimality
Kept this as setup/config behavior and reused the existing ingest marker check instead of adding a new storage abstraction. Traverse validation is the minimum baseline check needed for this setup slice.

## Breaking changes
None.

Closes #146
