### PR TITLE
MVP-050: Add sync preflight conflict checks

### DIFF
--- a/scripts/direct-fact-resolution-smoke.sh
+++ b/scripts/direct-fact-resolution-smoke.sh
@@ -20,6 +20,7 @@ cp "$ROOT_DIR/scripts/generate-site-artifacts.rb" "$TEMP_DIR/scripts/generate-si
 cp "$ROOT_DIR/scripts/reasoning-graph-extractor.rb" "$TEMP_DIR/scripts/reasoning-graph-extractor.rb"
 cp "$ROOT_DIR/scripts/validate-decision-log-package.rb" "$TEMP_DIR/scripts/validate-decision-log-package.rb"
 cp "$ROOT_DIR/scripts/ingest-decision-log.rb" "$TEMP_DIR/scripts/ingest-decision-log.rb"
+cp "$ROOT_DIR/scripts/sync-preflight.rb" "$TEMP_DIR/scripts/sync-preflight.rb"
 cp "$ROOT_DIR/scripts/knowledge-gap-lifecycle.rb" "$TEMP_DIR/scripts/knowledge-gap-lifecycle.rb"
 cp "$ROOT_DIR/scripts/resolve-direct-fact-gap.rb" "$TEMP_DIR/scripts/resolve-direct-fact-gap.rb"
 

--- a/scripts/ingest-decision-log.rb
+++ b/scripts/ingest-decision-log.rb
@@ -92,18 +92,20 @@ def sync_preflight!(knowledge_root)
   return unless knowledge_root == DEFAULT_KNOWLEDGE_ROOT
 
   author_instance = ROOT.join("app", "site", "author-instance.json")
-  sync_state = ROOT.join("app", "site", "sync-state.json")
   stable_error("INSTANCE_NOT_INITIALIZED", "Run ./scripts/m3.sh init before ingesting decision-log packages.") unless author_instance.file?
-  return unless sync_state.file?
+  stdout, stderr, status = Open3.capture3(
+    RbConfig.ruby,
+    ROOT.join("scripts", "sync-preflight.rb").to_s,
+    "--knowledge-root", knowledge_root.to_s,
+    "--write-conflicts",
+    "--json"
+  )
+  data = JSON.parse(stdout)
+  return if status.success? && ["clean", "auto_merged"].include?(data.fetch("status"))
 
-  Dir.mktmpdir do |tmpdir|
-    system(RbConfig.ruby, ROOT.join("scripts", "generate-site-artifacts.rb").to_s, tmpdir, out: File::NULL, err: File::NULL) ||
-      stable_error("SYNC_PREFLIGHT_FAILED", "Unable to compute sync preflight state.")
-    generated = Pathname.new(tmpdir).join("sync-state.json")
-    unless generated.read == sync_state.read
-      stable_error("SYNC_PREFLIGHT_DIRTY", "Current knowledge artifacts are stale. Run ./scripts/m3.sh sync before ingesting.")
-    end
-  end
+  stable_error(data.fetch("code", "SYNC_PREFLIGHT_BLOCKED"), data.fetch("message", stderr))
+rescue JSON::ParserError => error
+  stable_error("SYNC_PREFLIGHT_FAILED", "Unable to parse sync preflight result: #{error.message}")
 end
 
 def run_validator(package_path)

--- a/scripts/m3-decision-log-ingest-smoke.sh
+++ b/scripts/m3-decision-log-ingest-smoke.sh
@@ -22,6 +22,7 @@ cp "$ROOT_DIR/scripts/generate-site-artifacts.rb" "$TEMP_DIR/scripts/generate-si
 cp "$ROOT_DIR/scripts/reasoning-graph-extractor.rb" "$TEMP_DIR/scripts/reasoning-graph-extractor.rb"
 cp "$ROOT_DIR/scripts/validate-decision-log-package.rb" "$TEMP_DIR/scripts/validate-decision-log-package.rb"
 cp "$ROOT_DIR/scripts/ingest-decision-log.rb" "$TEMP_DIR/scripts/ingest-decision-log.rb"
+cp "$ROOT_DIR/scripts/sync-preflight.rb" "$TEMP_DIR/scripts/sync-preflight.rb"
 cp "$ROOT_DIR/scripts/knowledge-gap-lifecycle.rb" "$TEMP_DIR/scripts/knowledge-gap-lifecycle.rb"
 cp -R "$ROOT_DIR/fixtures/decision-log-packages/valid/knowledge_addition" "$TEMP_DIR/fixtures/decision-log-packages/valid/knowledge_addition"
 cp -R "$ROOT_DIR/fixtures/decision-log-packages/invalid/unsupported-note-claim" "$TEMP_DIR/fixtures/decision-log-packages/invalid/unsupported-note-claim"

--- a/scripts/m3.sh
+++ b/scripts/m3.sh
@@ -90,7 +90,13 @@ case "$COMMAND" in
     bash ./scripts/build.sh
     ;;
   sync)
-    bash ./scripts/m3-sync.sh
+    shift
+    if [[ "${1:-}" == "check" ]]; then
+      shift
+      ruby ./scripts/sync-preflight.rb "$@"
+    else
+      bash ./scripts/m3-sync.sh "$@"
+    fi
     ;;
   search)
     shift

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -69,6 +69,9 @@ bash ./scripts/m3-build-smoke.sh
 echo "Validating incremental sync..."
 bash ./scripts/m3-sync-smoke.sh
 
+echo "Validating sync preflight..."
+bash ./scripts/sync-preflight-smoke.sh
+
 echo "Validating m3 search and serve commands..."
 bash ./scripts/m3-command-surface-smoke.sh
 

--- a/scripts/sync-preflight-smoke.sh
+++ b/scripts/sync-preflight-smoke.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+mkdir -p "$TEMP_DIR/app/site" "$TEMP_DIR/knowledge/inputs/notes" "$TEMP_DIR/knowledge/conflicts/open" "$TEMP_DIR/scripts"
+
+cp "$ROOT_DIR/app/site/author-instance.json" "$TEMP_DIR/app/site/author-instance.json"
+cp "$ROOT_DIR/app/site/provider-config.json" "$TEMP_DIR/app/site/provider-config.json"
+cp "$ROOT_DIR/scripts/m3.sh" "$TEMP_DIR/scripts/m3.sh"
+cp "$ROOT_DIR/scripts/m3-sync.sh" "$TEMP_DIR/scripts/m3-sync.sh"
+cp "$ROOT_DIR/scripts/sync-preflight.rb" "$TEMP_DIR/scripts/sync-preflight.rb"
+cp "$ROOT_DIR/scripts/generate-site-artifacts.rb" "$TEMP_DIR/scripts/generate-site-artifacts.rb"
+cp "$ROOT_DIR/scripts/reasoning-graph-extractor.rb" "$TEMP_DIR/scripts/reasoning-graph-extractor.rb"
+cp "$ROOT_DIR/scripts/knowledge-gap-lifecycle.rb" "$TEMP_DIR/scripts/knowledge-gap-lifecycle.rb"
+
+(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh sync >/dev/null
+)
+
+clean_output="$(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh sync check --json
+)"
+ruby -rjson -e 'data=JSON.parse(STDIN.read); abort "expected clean" unless data.fetch("status") == "clean" && data.fetch("code") == "SYNC_CLEAN"' <<<"$clean_output"
+
+cat >"$TEMP_DIR/knowledge/inputs/notes/daily.append.md" <<'EOF'
+# Daily Append
+
+Safe append-only note.
+EOF
+
+merge_output="$(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh sync check --json
+)"
+ruby -rjson -e 'data=JSON.parse(STDIN.read); abort "expected auto merge" unless data.fetch("status") == "auto_merged" && data.fetch("auto_merged").length == 1' <<<"$merge_output"
+[[ -f "$TEMP_DIR/knowledge/inputs/notes/daily.md" ]]
+[[ ! -e "$TEMP_DIR/knowledge/inputs/notes/daily.append.md" ]]
+
+(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh sync >/dev/null
+)
+
+cat >"$TEMP_DIR/knowledge/inputs/notes/conflicted.md" <<'EOF'
+<<<<<<< local
+one
+=======
+two
+>>>>>>> remote
+EOF
+
+if (
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh sync check --write-conflicts --json >/tmp/sync-conflict.json
+); then
+  echo "Expected conflict marker preflight to fail." >&2
+  exit 1
+fi
+ruby -rjson -e 'data=JSON.parse(File.read("/tmp/sync-conflict.json")); abort "expected open conflict" unless data.fetch("status") == "open_conflict" && data.fetch("code") == "SYNC_CONFLICT_OPEN"; abort "missing written conflict" if data.fetch("written_conflict_paths").empty?' 
+
+rm "$TEMP_DIR/knowledge/inputs/notes/conflicted.md"
+rm "$TEMP_DIR"/knowledge/conflicts/open/*.md
+
+echo '{}' >"$TEMP_DIR/app/site/sync-state.json"
+if (
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh sync check --json >/tmp/sync-blocked.json
+); then
+  echo "Expected dirty metadata preflight to fail." >&2
+  exit 1
+fi
+ruby -rjson -e 'data=JSON.parse(File.read("/tmp/sync-blocked.json")); abort "expected blocked dirty metadata" unless data.fetch("status") == "blocked" && data.fetch("code") == "SYNC_METADATA_DIRTY"'
+
+echo "Sync preflight smoke passed."

--- a/scripts/sync-preflight.rb
+++ b/scripts/sync-preflight.rb
@@ -1,0 +1,150 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "digest"
+require "fileutils"
+require "json"
+require "open3"
+require "pathname"
+require "rbconfig"
+require "tmpdir"
+require "time"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
+DEFAULT_KNOWLEDGE_ROOT = ROOT.join("knowledge")
+SITE_DIR = ROOT.join("app", "site")
+
+def parse_args(argv)
+  flags = { "knowledge_root" => DEFAULT_KNOWLEDGE_ROOT.to_s, "json" => false, "write_conflicts" => false }
+  until argv.empty?
+    flag = argv.shift
+    case flag
+    when "--knowledge-root"
+      flags["knowledge_root"] = argv.shift || abort("Missing value for --knowledge-root")
+    when "--json"
+      flags["json"] = true
+    when "--write-conflicts"
+      flags["write_conflicts"] = true
+    else
+      abort "Usage: ruby scripts/sync-preflight.rb [--knowledge-root PATH] [--json] [--write-conflicts]"
+    end
+  end
+  flags
+end
+
+def slug(value)
+  value.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-+|-+\z/, "")
+end
+
+def relative(path)
+  Pathname.new(path).relative_path_from(ROOT).to_s
+rescue ArgumentError
+  Pathname.new(path).to_s
+end
+
+def conflict_marker_files(knowledge_root)
+  roots = [knowledge_root, SITE_DIR].select(&:exist?)
+  roots.flat_map do |root|
+    Dir.glob(root.join("**", "*")).select do |path|
+      File.file?(path) && File.read(path, 4096).include?("<<<<<<<")
+    rescue ArgumentError
+      false
+    end
+  end.sort
+end
+
+def append_files(knowledge_root)
+  Dir.glob(knowledge_root.join("inputs", "notes", "*.append.md")).sort
+end
+
+def auto_merge_append_files(paths)
+  merged = []
+  paths.each do |path_string|
+    path = Pathname.new(path_string)
+    target = path.sub(/\.append\.md\z/, ".md")
+    FileUtils.mkdir_p(target.dirname)
+    existing = target.file? ? target.read : ""
+    append = path.read
+    target.write([existing.strip, append.strip].reject(&:empty?).join("\n\n") + "\n")
+    path.delete
+    merged << { "source" => relative(path), "target" => relative(target) }
+  end
+  merged
+end
+
+def generated_sync_state
+  Dir.mktmpdir do |tmpdir|
+    ok = system(RbConfig.ruby, ROOT.join("scripts", "generate-site-artifacts.rb").to_s, tmpdir, out: File::NULL, err: File::NULL)
+    return nil unless ok
+    Pathname.new(tmpdir).join("sync-state.json").read
+  end
+end
+
+def metadata_dirty?
+  sync_state = SITE_DIR.join("sync-state.json")
+  return false unless sync_state.file?
+
+  generated = generated_sync_state
+  return true if generated.nil?
+
+  generated != sync_state.read
+end
+
+def write_conflict_reports(knowledge_root, paths)
+  paths.map do |path|
+    conflict_id = "conflict-sync-#{slug(relative(path))[0, 56].gsub(/-\z/, "")}"
+    summary = "File-system sync conflict markers detected in #{relative(path)}."
+    system(
+      RbConfig.ruby,
+      ROOT.join("scripts", "knowledge-gap-lifecycle.rb").to_s,
+      "create-conflict",
+      "--knowledge-root", knowledge_root.to_s,
+      "--conflict-id", conflict_id,
+      "--summary", summary,
+      out: File::NULL
+    )
+    knowledge_root.join("conflicts", "open", "#{conflict_id}.md")
+  end
+end
+
+flags = parse_args(ARGV)
+knowledge_root = Pathname.new(flags.fetch("knowledge_root")).expand_path
+FileUtils.mkdir_p(knowledge_root)
+
+merged = auto_merge_append_files(append_files(knowledge_root))
+marker_conflicts = conflict_marker_files(knowledge_root)
+written_conflicts = flags.fetch("write_conflicts") && !marker_conflicts.empty? ? write_conflict_reports(knowledge_root, marker_conflicts) : []
+open_conflicts = Dir.glob(knowledge_root.join("conflicts", "open", "*.md")).sort
+dirty = metadata_dirty?
+
+status, code, message = if !marker_conflicts.empty? || !open_conflicts.empty?
+                          ["open_conflict", "SYNC_CONFLICT_OPEN", "Open sync conflicts must be resolved before knowledge writes."]
+                        elsif !merged.empty?
+                          ["auto_merged", "SYNC_AUTO_MERGED", "Append-only sync artifacts were auto-merged."]
+                        elsif dirty
+                          ["blocked", "SYNC_METADATA_DIRTY", "Generated sync metadata is stale. Run ./scripts/m3.sh sync before writing knowledge."]
+                        else
+                          ["clean", "SYNC_CLEAN", "Sync preflight clean."]
+                        end
+
+result = {
+  "status" => status,
+  "code" => code,
+  "message" => message,
+  "knowledge_root" => knowledge_root.to_s,
+  "auto_merged" => merged,
+  "conflict_marker_paths" => marker_conflicts.map { |path| relative(path) },
+  "written_conflict_paths" => written_conflicts.map { |path| relative(path) },
+  "open_conflict_paths" => open_conflicts.map { |path| relative(path) },
+  "metadata_dirty" => dirty
+}
+
+if flags.fetch("json")
+  puts JSON.pretty_generate(result)
+else
+  puts "#{status}: #{message}"
+  result.fetch("auto_merged").each { |entry| puts "- merged #{entry.fetch("source")} -> #{entry.fetch("target")}" }
+  result.fetch("open_conflict_paths").each { |path| puts "- open conflict #{path}" }
+end
+
+exit(status == "clean" || status == "auto_merged" ? 0 : 1)


### PR DESCRIPTION
## What this changes
Adds `m3 sync check` through a shared sync preflight command for clean, auto-merged, open-conflict, and blocked metadata states. Decision-log ingestion now runs that preflight before mutating the default knowledge root, writes structured conflict reports for marker conflicts, and blocks stale metadata writes with stable setup errors.

## Spec reference
openspec/specs/local-runtime-sync/spec.md - Run sync conflict preflight / Provide manual sync inspection
openspec/specs/knowledge-gap-lifecycle/spec.md - Track conflicts as structured markdown

## Spec delta (if spec changed)
None.

## Test coverage
Added sync preflight smoke for clean state, append-only auto-merge, conflict marker report creation, and stale metadata blocked state. Updated ingestion/direct-fact smokes to copy and exercise the shared preflight path.

Full smoke passed locally:

```bash
PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh
```

## Lean ops / minimality
Added one shared preflight script and reused existing conflict markdown lifecycle creation rather than embedding conflict handling in each writer.

## Breaking changes
None.

Closes #147
