### PR TITLE
MVP-051: Add m3 serve runtime orchestration

### DIFF
--- a/scripts/m3-serve-runtime-smoke.sh
+++ b/scripts/m3-serve-runtime-smoke.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+mkdir -p "$TEMP_DIR/.youaskm3" "$TEMP_DIR/scripts" "$TEMP_DIR/app/site" "$TEMP_DIR/traverse"
+
+cp "$ROOT_DIR/scripts/m3.sh" "$TEMP_DIR/scripts/m3.sh"
+cp "$ROOT_DIR/scripts/m3-serve.sh" "$TEMP_DIR/scripts/m3-serve.sh"
+cp "$ROOT_DIR/scripts/m3-local-runtime.rb" "$TEMP_DIR/scripts/m3-local-runtime.rb"
+cp "$ROOT_DIR/scripts/register-traverse-app.sh" "$TEMP_DIR/scripts/register-traverse-app.sh"
+cp -R "$ROOT_DIR/traverse/youaskm3-app" "$TEMP_DIR/traverse/youaskm3-app"
+cp -R "$ROOT_DIR/contracts" "$TEMP_DIR/contracts"
+
+cat >"$TEMP_DIR/.youaskm3/config.json" <<'JSON'
+{
+  "schema_version": "1.0.0",
+  "knowledge_root": "/tmp/youaskm3-runtime-smoke-knowledge",
+  "traverse": {
+    "endpoint": "test://ready"
+  }
+}
+JSON
+
+ready_output="$(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh serve --runtime 48746 --check-only
+)"
+
+grep -q 'youaskm3 runtime ready' <<<"$ready_output"
+grep -q 'runtime_url: http://127.0.0.1:48746/' <<<"$ready_output"
+grep -q 'mcp_endpoint: http://127.0.0.1:48746/mcp' <<<"$ready_output"
+grep -q 'workspace_id: local-default' <<<"$ready_output"
+grep -q 'trace_evidence_mode: public' <<<"$ready_output"
+
+override_output="$(
+  cd "$TEMP_DIR"
+  TRAVERSE_ENDPOINT= bash ./scripts/m3.sh serve --runtime 48747 --config "$TEMP_DIR/.youaskm3/config.json" --traverse-endpoint test://ready --workspace-id smoke-workspace --check-only
+)"
+
+grep -q 'workspace_id: smoke-workspace' <<<"$override_output"
+
+if (
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh serve --runtime --config "$TEMP_DIR/missing-config.json" --check-only >/tmp/m3-serve-missing-runtime.out 2>/tmp/m3-serve-missing-runtime.err
+); then
+  echo "Expected missing Traverse runtime config to fail." >&2
+  exit 1
+fi
+grep -q 'MISSING_TRAVERSE_RUNTIME' /tmp/m3-serve-missing-runtime.err
+
+if (
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh serve --runtime --config "$TEMP_DIR/.youaskm3/config.json" --traverse-endpoint http://127.0.0.1:9 --check-only >/tmp/m3-serve-unavailable.out 2>/tmp/m3-serve-unavailable.err
+); then
+  echo "Expected unreachable Traverse runtime to fail." >&2
+  exit 1
+fi
+grep -q 'TRAVERSE_RUNTIME_UNAVAILABLE' /tmp/m3-serve-unavailable.err
+
+echo "m3 serve runtime smoke passed."

--- a/scripts/m3-serve.sh
+++ b/scripts/m3-serve.sh
@@ -5,9 +5,49 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PORT="${1:-4173}"
 SITE_DIR="$ROOT_DIR/app/site"
 
+runtime_usage() {
+  cat >&2 <<'EOF'
+Usage: ./scripts/m3.sh serve --runtime [port] [--config PATH] [--traverse-endpoint URL] [--workspace-id ID] [--check-only]
+EOF
+}
+
+resolve_config_value() {
+  ruby -rjson -e '
+path, explicit_endpoint, workspace_id = ARGV
+config = File.file?(path) ? JSON.parse(File.read(path)) : {}
+endpoint = explicit_endpoint.empty? ? config.dig("traverse", "endpoint").to_s : explicit_endpoint
+workspace = workspace_id.empty? ? "local-default" : workspace_id
+puts JSON.generate({ "endpoint" => endpoint, "workspace_id" => workspace })
+' "$1" "$2" "$3"
+}
+
+validate_runtime_ready() {
+  local endpoint="$1"
+  if [[ -z "$endpoint" ]]; then
+    echo "MISSING_TRAVERSE_RUNTIME: Set TRAVERSE_ENDPOINT, pass --traverse-endpoint, or run m3 init --traverse-repo <path>." >&2
+    exit 1
+  fi
+
+  bash "$ROOT_DIR/scripts/register-traverse-app.sh" --validate-only --allow-skeleton --json >/dev/null
+
+  if [[ "$endpoint" == "test://ready" ]]; then
+    return
+  fi
+
+  ruby -rnet/http -ruri -e '
+endpoint = ARGV.fetch(0)
+uri = URI.join(endpoint.end_with?("/") ? endpoint : "#{endpoint}/", "health")
+response = Net::HTTP.get_response(uri)
+exit(response.is_a?(Net::HTTPSuccess) ? 0 : 1)
+' "$endpoint" >/dev/null 2>&1 || {
+    echo "TRAVERSE_RUNTIME_UNAVAILABLE: Traverse runtime is not reachable at ${endpoint}." >&2
+    exit 1
+  }
+}
+
 if [[ "$PORT" == "--help" || "$PORT" == "-h" ]]; then
   echo "Usage: ./scripts/m3.sh serve [port]"
-  echo "       ./scripts/m3.sh serve --runtime [port] [--traverse-endpoint URL]"
+  echo "       ./scripts/m3.sh serve --runtime [port] [--config PATH] [--traverse-endpoint URL] [--workspace-id ID] [--check-only]"
   exit 0
 fi
 
@@ -17,7 +57,64 @@ if [[ "$PORT" == "--runtime" ]]; then
   if [[ "${1:-}" =~ ^[0-9]+$ ]]; then
     shift
   fi
-  exec ruby "$ROOT_DIR/scripts/m3-local-runtime.rb" --port "$runtime_port" "$@"
+
+  config_path="$ROOT_DIR/.youaskm3/config.json"
+  traverse_endpoint="${TRAVERSE_ENDPOINT:-}"
+  workspace_id="${TRAVERSE_WORKSPACE_ID:-}"
+  check_only=false
+  passthrough=()
+
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --config)
+        config_path="${2:-}"
+        [[ -n "$config_path" ]] || runtime_usage
+        passthrough+=("--config" "$config_path")
+        shift 2
+        ;;
+      --traverse-endpoint)
+        traverse_endpoint="${2:-}"
+        [[ -n "$traverse_endpoint" ]] || runtime_usage
+        passthrough+=("--traverse-endpoint" "$traverse_endpoint")
+        shift 2
+        ;;
+      --workspace-id)
+        workspace_id="${2:-}"
+        [[ -n "$workspace_id" ]] || runtime_usage
+        passthrough+=("--workspace-id" "$workspace_id")
+        shift 2
+        ;;
+      --check-only)
+        check_only=true
+        shift
+        ;;
+      --help|-h)
+        runtime_usage
+        exit 0
+        ;;
+      *)
+        runtime_usage
+        exit 1
+        ;;
+    esac
+  done
+
+  resolved="$(resolve_config_value "$config_path" "$traverse_endpoint" "$workspace_id")"
+  effective_endpoint="$(ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("endpoint")' <<<"$resolved")"
+  effective_workspace="$(ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("workspace_id")' <<<"$resolved")"
+  validate_runtime_ready "$effective_endpoint"
+
+  echo "youaskm3 runtime ready."
+  echo "- runtime_url: http://127.0.0.1:${runtime_port}/"
+  echo "- mcp_endpoint: http://127.0.0.1:${runtime_port}/mcp"
+  echo "- workspace_id: ${effective_workspace}"
+  echo "- trace_evidence_mode: public"
+
+  if [[ "$check_only" == true ]]; then
+    exit 0
+  fi
+
+  exec ruby "$ROOT_DIR/scripts/m3-local-runtime.rb" --port "$runtime_port" "${passthrough[@]}"
 fi
 
 if ! [[ "$PORT" =~ ^[0-9]+$ ]]; then

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -75,6 +75,9 @@ bash ./scripts/sync-preflight-smoke.sh
 echo "Validating m3 search and serve commands..."
 bash ./scripts/m3-command-surface-smoke.sh
 
+echo "Validating m3 serve runtime orchestration..."
+bash ./scripts/m3-serve-runtime-smoke.sh
+
 echo "Validating MVP contracts..."
 bash ./scripts/mvp-contracts-smoke.sh
 


### PR DESCRIPTION
## What this changes
Adds runtime orchestration to `m3 serve --runtime`: it reads project config plus CLI/env overrides, validates the checked-in Traverse app bundle shape, checks Traverse runtime readiness, and only then starts the local HTTP JSON plus MCP adapter. It reports runtime URL, MCP endpoint, workspace id, and trace/evidence mode, with stable missing/unavailable Traverse errors and no Browser demo fallback.

## Spec reference
openspec/specs/local-runtime-sync/spec.md - Serve local chat and MCP runtime
openspec/specs/traverse-integration/spec.md - Traverse-governed runtime boundary

## Spec delta (if spec changed)
None.

## Test coverage
Added `m3-serve-runtime-smoke.sh` covering config read, CLI override, missing Traverse runtime config, unreachable Traverse runtime, bundle validation, and deterministic success harness.

Full smoke passed locally:

```bash
PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh
```

## Lean ops / minimality
Kept orchestration in `m3-serve.sh` and reused the existing local runtime adapter plus app-bundle validator instead of adding another runtime layer.

## Breaking changes
None.

Closes #148
