### PR TITLE
MVP-052: Add chat runtime evidence rendering

### DIFF
--- a/app/components/index.test.ts
+++ b/app/components/index.test.ts
@@ -8,6 +8,7 @@ import {
   componentNamespace,
   providerConfigPath,
   renderChatCard,
+  renderRuntimeChatResponse,
   renderResultCard,
   renderSourceCard,
   resultTagName,
@@ -19,6 +20,103 @@ import {
 describe("componentNamespace", () => {
   it("returns the expected namespace", () => {
     expect(componentNamespace()).toBe("youaskm3");
+  });
+});
+
+describe("renderRuntimeChatResponse", () => {
+  it("renders supported runtime answers with provenance and evidence", () => {
+    const markup = renderRuntimeChatResponse({
+      answer: "Portable knowledge stays source-backed.",
+      provenance_type: "traverse_runtime",
+      citations: [
+        {
+          citation_id: "cite-1",
+          source_path: "knowledge/blog/portable.md",
+          excerpt: "source-backed excerpt"
+        }
+      ],
+      graph_evidence: [{ node_ids: ["node-a"], edge_ids: ["edge-a"] }],
+      trace_id: "trace-answer",
+      validation: { status: "valid", checks: ["grounded"] }
+    });
+
+    expect(markup).toContain("Portable knowledge stays source-backed.");
+    expect(markup).toContain("traverse_runtime");
+    expect(markup).toContain("knowledge/blog/portable.md");
+    expect(markup).toContain("node-a");
+    expect(markup).toContain("Trace trace-answer");
+  });
+
+  it("renders unsupported deferrals and direct fact prompts from runtime gaps", () => {
+    const markup = renderRuntimeChatResponse({
+      answer: "",
+      provenance_type: "traverse_runtime",
+      citations: [],
+      graph_evidence: [],
+      trace_id: "trace-gap",
+      validation: { status: "invalid", checks: ["missing-knowledge"] },
+      failure: {
+        code: "MISSING_KNOWLEDGE",
+        message: "I need one simple fact before I can answer.",
+        recoverable: true
+      },
+      gaps: [
+        {
+          gap_id: "gap-author-name",
+          source_question: "What is the author name?",
+          allowed_resolution_path: "direct_chat",
+          final_complexity: "simple_factual"
+        }
+      ]
+    });
+
+    expect(markup).toContain('data-mode="deferral"');
+    expect(markup).toContain("I need one simple fact before I can answer.");
+    expect(markup).toContain('class="m3-direct-fact"');
+    expect(markup).toContain('data-gap-id="gap-author-name"');
+  });
+
+  it("discloses only conflicts that affect the answer", () => {
+    const markup = renderRuntimeChatResponse({
+      answer: "The runtime boundary is Traverse-owned.",
+      provenance_type: "traverse_runtime",
+      citations: [],
+      graph_evidence: [],
+      trace_id: "trace-conflict",
+      validation: { status: "partial", checks: ["conflict-disclosed"] },
+      conflicts: [
+        {
+          conflict_id: "conflict-runtime-boundary",
+          summary: "Two notes disagree about runtime ownership.",
+          affects_answer: true
+        },
+        {
+          conflict_id: "conflict-unrelated",
+          summary: "Unrelated conflict.",
+          affects_answer: false
+        }
+      ]
+    });
+
+    expect(markup).toContain("conflict-runtime-boundary");
+    expect(markup).toContain("Two notes disagree about runtime ownership.");
+    expect(markup).not.toContain("conflict-unrelated");
+  });
+
+  it("does not treat Browser demo or pipeline internals as acceptance UI", () => {
+    const markup = renderRuntimeChatResponse({
+      answer: "Answer comes from the runtime response.",
+      provenance_type: "traverse_runtime",
+      citations: [],
+      graph_evidence: [],
+      trace_id: "trace-clean",
+      validation: { status: "valid", checks: ["formatted"] }
+    });
+
+    expect(markup).not.toContain("Browser demo");
+    expect(markup).not.toContain("temporary harness");
+    expect(markup).not.toContain("retrieval");
+    expect(markup).not.toContain("context packing");
   });
 });
 

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -24,6 +24,49 @@ export type ChatCard = {
   sources: SourceCard[];
 };
 
+export type RuntimeCitation = {
+  citation_id: string;
+  source_path: string;
+  excerpt: string;
+};
+
+export type RuntimeGraphEvidence = {
+  node_ids: string[];
+  edge_ids: string[];
+};
+
+export type RuntimeGap = {
+  gap_id: string;
+  source_question: string;
+  allowed_resolution_path: string;
+  final_complexity: string;
+};
+
+export type RuntimeConflict = {
+  conflict_id: string;
+  summary: string;
+  affects_answer: boolean;
+};
+
+export type RuntimeChatResponse = {
+  answer: string;
+  provenance_type: string;
+  citations: RuntimeCitation[];
+  graph_evidence: RuntimeGraphEvidence[];
+  trace_id: string;
+  validation: {
+    status: "valid" | "invalid" | "partial";
+    checks: string[];
+  };
+  gaps?: RuntimeGap[];
+  conflicts?: RuntimeConflict[];
+  failure?: {
+    code: string;
+    message: string;
+    recoverable: boolean;
+  };
+};
+
 export function componentNamespace(): string {
   return COMPONENT_NAMESPACE;
 }
@@ -79,6 +122,33 @@ export function renderChatCard(chat: ChatCard): string {
   ].join("");
 }
 
+export function renderRuntimeChatResponse(response: RuntimeChatResponse): string {
+  const directFactGaps = (response.gaps ?? []).filter(
+    (gap) => gap.allowed_resolution_path === "direct_chat"
+  );
+  const relevantConflicts = (response.conflicts ?? []).filter(
+    (conflict) => conflict.affects_answer
+  );
+  const mode = response.failure ? "deferral" : "answer";
+
+  return [
+    `<article class="m3-runtime-chat" data-mode="${mode}">`,
+    `<section class="m3-runtime-answer">`,
+    `<p class="m3-runtime-validation">${escapeHtml(response.validation.status)}</p>`,
+    `<p class="m3-runtime-provenance">${escapeHtml(response.provenance_type)}</p>`,
+    `<p class="m3-runtime-trace">Trace ${escapeHtml(response.trace_id)}</p>`,
+    response.failure
+      ? `<p class="m3-runtime-deferral">${escapeHtml(response.failure.message)}</p>`
+      : `<p>${escapeHtml(response.answer)}</p>`,
+    `</section>`,
+    renderRuntimeCitations(response.citations),
+    renderRuntimeGraphEvidence(response.graph_evidence),
+    renderRuntimeGaps(directFactGaps),
+    renderRuntimeConflicts(relevantConflicts),
+    `</article>`
+  ].join("");
+}
+
 export function browserComponentModulePath(): string {
   return "./components.js";
 }
@@ -110,4 +180,64 @@ function escapeHtml(value: string): string {
     .replaceAll(">", "&gt;")
     .replaceAll('"', "&quot;")
     .replaceAll("'", "&#39;");
+}
+
+function renderRuntimeCitations(citations: RuntimeCitation[]): string {
+  if (citations.length === 0) {
+    return "";
+  }
+
+  const items = citations
+    .map(
+      (citation) =>
+        `<li><strong>${escapeHtml(citation.citation_id)}</strong> ${escapeHtml(citation.source_path)} <span>${escapeHtml(citation.excerpt)}</span></li>`
+    )
+    .join("");
+
+  return `<section class="m3-runtime-evidence" aria-label="Citations"><h3>Citations</h3><ul>${items}</ul></section>`;
+}
+
+function renderRuntimeGraphEvidence(evidence: RuntimeGraphEvidence[]): string {
+  if (evidence.length === 0) {
+    return "";
+  }
+
+  const items = evidence
+    .map(
+      (entry) =>
+        `<li>Nodes ${escapeHtml(entry.node_ids.join(", "))}; edges ${escapeHtml(entry.edge_ids.join(", "))}</li>`
+    )
+    .join("");
+
+  return `<section class="m3-runtime-graph" aria-label="Graph evidence"><h3>Graph evidence</h3><ul>${items}</ul></section>`;
+}
+
+function renderRuntimeGaps(gaps: RuntimeGap[]): string {
+  if (gaps.length === 0) {
+    return "";
+  }
+
+  const forms = gaps
+    .map(
+      (gap) =>
+        `<form class="m3-direct-fact" data-gap-id="${escapeHtml(gap.gap_id)}"><label>${escapeHtml(gap.source_question)}<input name="answer" autocomplete="off" /></label><button type="submit">Resolve fact</button></form>`
+    )
+    .join("");
+
+  return `<section class="m3-runtime-gaps" aria-label="Knowledge gaps">${forms}</section>`;
+}
+
+function renderRuntimeConflicts(conflicts: RuntimeConflict[]): string {
+  if (conflicts.length === 0) {
+    return "";
+  }
+
+  const items = conflicts
+    .map(
+      (conflict) =>
+        `<li><strong>${escapeHtml(conflict.conflict_id)}</strong> ${escapeHtml(conflict.summary)}</li>`
+    )
+    .join("");
+
+  return `<section class="m3-runtime-conflicts" aria-label="Relevant conflicts"><h3>Relevant conflicts</h3><ul>${items}</ul></section>`;
 }


### PR DESCRIPTION
## Summary

- add a runtime chat response renderer for the PWA surface
- show supported answers with provenance, citations, graph evidence, validation, and trace references
- show runtime deferrals with direct simple-fact resolution prompts and answer-affecting conflicts only

## Spec / Contracts

- PWA shell remains the acceptance surface; this does not use Browser demo or pipeline internals as UX
- aligns runtime evidence display with knowledge-gap lifecycle, reasoning graph, and answer validation outputs
- referenced specs: `openspec/specs/pwa-shell/spec.md`, `openspec/specs/knowledge-gap-lifecycle/spec.md`, `openspec/specs/reasoning-graph/spec.md`

## Validation

- `npm test -- app/components/index.test.ts`
- `PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`

Closes #149
