### PR TITLE
MVP-053: Add MCP answer and gap runtime tools

### DIFF
--- a/app/components/mcp-tools-contract.test.ts
+++ b/app/components/mcp-tools-contract.test.ts
@@ -101,11 +101,14 @@ describe("mcp-tools contracts", () => {
     });
     expect(answerContract?.output_schema.required).toEqual([
       "answer",
+      "provenance_type",
       "citations",
       "graph_evidence",
       "trace_id",
       "validation"
     ]);
+    expect(answerContract?.output_schema.properties).toHaveProperty("gaps");
+    expect(answerContract?.output_schema.properties).toHaveProperty("conflicts");
     expect(searchContract).toBeDefined();
     expect(searchContract?.output_schema.properties).toHaveProperty("results");
     expect(gapsListContract).toMatchObject({

--- a/contracts/capabilities/knowledge.query.answer.json
+++ b/contracts/capabilities/knowledge.query.answer.json
@@ -30,13 +30,16 @@
       "type": "object",
       "properties": {
         "answer": { "type": "string" },
+        "provenance_type": { "type": "string" },
         "citations": { "$ref": "#/$defs/citations" },
         "graph_evidence": { "$ref": "#/$defs/graphEvidence" },
+        "gaps": { "$ref": "#/$defs/gaps" },
+        "conflicts": { "$ref": "#/$defs/conflicts" },
         "trace_id": { "type": "string" },
         "validation": { "$ref": "#/$defs/validation" },
         "failure": { "$ref": "#/$defs/failure" }
       },
-      "required": ["answer", "citations", "graph_evidence", "trace_id", "validation"],
+      "required": ["answer", "provenance_type", "citations", "graph_evidence", "trace_id", "validation"],
       "additionalProperties": false
     }
   },
@@ -66,6 +69,33 @@
           "supporting_chunk_ids": { "type": "array", "items": { "type": "string" } }
         },
         "required": ["node_ids", "edge_ids", "supporting_chunk_ids"],
+        "additionalProperties": false
+      }
+    },
+    "gaps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "gap_id": { "type": "string" },
+          "source_question": { "type": "string" },
+          "allowed_resolution_path": { "type": "string" },
+          "final_complexity": { "type": "string" }
+        },
+        "required": ["gap_id", "source_question", "allowed_resolution_path", "final_complexity"],
+        "additionalProperties": false
+      }
+    },
+    "conflicts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "conflict_id": { "type": "string" },
+          "summary": { "type": "string" },
+          "affects_answer": { "type": "boolean" }
+        },
+        "required": ["conflict_id", "summary", "affects_answer"],
         "additionalProperties": false
       }
     },

--- a/contracts/mcp-tools.json
+++ b/contracts/mcp-tools.json
@@ -39,6 +39,9 @@
           "answer": {
             "type": "string"
           },
+          "provenance_type": {
+            "type": "string"
+          },
           "citations": {
             "type": "array",
             "items": {
@@ -46,6 +49,18 @@
             }
           },
           "graph_evidence": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "gaps": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "conflicts": {
             "type": "array",
             "items": {
               "type": "object"
@@ -61,7 +76,7 @@
             "type": "object"
           }
         },
-        "required": ["answer", "citations", "graph_evidence", "trace_id", "validation"],
+        "required": ["answer", "provenance_type", "citations", "graph_evidence", "trace_id", "validation"],
         "additionalProperties": false
       },
       "error_schema": {

--- a/crates/youaskm3-mcp/src/lib.rs
+++ b/crates/youaskm3-mcp/src/lib.rs
@@ -18,6 +18,18 @@ pub struct ToolDescriptor {
 /// Initial MCP tools defined by `contracts/mcp-tools.json`.
 pub const INITIAL_TOOLS: &[ToolDescriptor] = &[
     ToolDescriptor {
+        name: "knowledge.query.answer",
+        description: "Answer a question through the registered Traverse answer workflow.",
+    },
+    ToolDescriptor {
+        name: "knowledge.gaps.list",
+        description: "List unresolved knowledge gaps through the Traverse runtime.",
+    },
+    ToolDescriptor {
+        name: "knowledge.gaps.resolve_fact",
+        description: "Resolve an eligible simple factual gap through Traverse.",
+    },
+    ToolDescriptor {
         name: "search",
         description: "Semantic and keyword hybrid search across indexed knowledge.",
     },
@@ -46,6 +58,39 @@ pub const INITIAL_TOOLS: &[ToolDescriptor] = &[
 /// Structured MCP tool input accepted by the local adapter.
 #[derive(Debug, Clone, Copy)]
 pub enum ToolInput<'a> {
+    /// Input for the `knowledge.query.answer` tool.
+    QueryAnswer {
+        /// User-facing question supplied by the MCP client.
+        query: &'a str,
+        /// Optional conversation id for continuity across turns.
+        conversation_id: Option<&'a str>,
+        /// Optional artifact ids or paths that bound the answer scope.
+        artifact_scope: &'a [&'a str],
+        /// Optional source limit requested by the client.
+        max_sources: Option<u8>,
+        /// Optional request id for trace correlation.
+        request_id: Option<&'a str>,
+    },
+    /// Input for the `knowledge.gaps.list` tool.
+    GapsList {
+        /// Optional persona id used to scope gaps.
+        persona_id: Option<&'a str>,
+        /// Optional result limit requested by the client.
+        limit: Option<u16>,
+        /// Optional request id for trace correlation.
+        request_id: Option<&'a str>,
+    },
+    /// Input for the `knowledge.gaps.resolve_fact` tool.
+    ResolveFact {
+        /// Gap id marked eligible for direct factual resolution.
+        gap_id: &'a str,
+        /// Direct factual answer supplied by the MCP client.
+        answer: &'a str,
+        /// Optional persona id used to scope the resolution.
+        persona_id: Option<&'a str>,
+        /// Optional request id for trace correlation.
+        request_id: Option<&'a str>,
+    },
     /// Input for the `search` tool.
     Search {
         /// Query text supplied by the client.
@@ -81,6 +126,11 @@ pub enum ToolInput<'a> {
 /// Structured MCP tool output returned by the local adapter.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ToolOutput {
+    /// Output returned by expanded Traverse-backed MCP tools before runtime execution.
+    RuntimeRequest {
+        /// Structured request that a host sends through Traverse.
+        request: RuntimeRequest,
+    },
     /// Output returned by the `search` tool.
     Search {
         /// Ranked source-aware search results.
@@ -131,6 +181,36 @@ pub struct Connection {
     pub relationship: String,
     /// Source path supporting the connection.
     pub supporting_source_path: String,
+}
+
+/// One typed field included in a Traverse-bound MCP runtime request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeInputField {
+    /// Field name from the MCP tool input schema.
+    pub name: String,
+    /// String representation of the field value.
+    pub value: String,
+}
+
+/// Structured request emitted by the MCP adapter for Traverse-backed tools.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeRequest {
+    /// Stable request id for trace correlation.
+    pub request_id: String,
+    /// MCP surface marker.
+    pub surface: String,
+    /// Capability id from the MCP contract.
+    pub capability_id: String,
+    /// Traverse workflow id from the MCP contract.
+    pub workflow_id: String,
+    /// Capability contract path from the MCP contract.
+    pub contract_path: String,
+    /// Target requested by the MCP client.
+    pub requested_target: String,
+    /// Governing spec that defines runtime parity.
+    pub governing_spec: String,
+    /// Validated input fields to pass through Traverse.
+    pub input: Vec<RuntimeInputField>,
 }
 
 /// Errors returned by the local MCP adapter.
@@ -215,6 +295,39 @@ pub fn is_known_tool(name: &str) -> bool {
 /// its input.
 pub fn call_tool(tool_name: &str, input: ToolInput<'_>) -> Result<ToolOutput, ToolCallError> {
     match (tool_name, input) {
+        (
+            "knowledge.query.answer",
+            ToolInput::QueryAnswer {
+                query,
+                conversation_id,
+                artifact_scope,
+                max_sources,
+                request_id,
+            },
+        ) => plan_query_answer(
+            query,
+            conversation_id,
+            artifact_scope,
+            max_sources,
+            request_id,
+        ),
+        (
+            "knowledge.gaps.list",
+            ToolInput::GapsList {
+                persona_id,
+                limit,
+                request_id,
+            },
+        ) => plan_gaps_list(persona_id, limit, request_id),
+        (
+            "knowledge.gaps.resolve_fact",
+            ToolInput::ResolveFact {
+                gap_id,
+                answer,
+                persona_id,
+                request_id,
+            },
+        ) => plan_resolve_fact(gap_id, answer, persona_id, request_id),
         ("search", ToolInput::Search { query, documents }) => {
             let results = search_documents(query, documents)?;
             Ok(ToolOutput::Search { results })
@@ -235,6 +348,142 @@ pub fn call_tool(tool_name: &str, input: ToolInput<'_>) -> Result<ToolOutput, To
         (name, _) => Err(ToolCallError::UnknownTool {
             name: name.to_string(),
         }),
+    }
+}
+
+fn plan_query_answer(
+    query: &str,
+    conversation_id: Option<&str>,
+    artifact_scope: &[&str],
+    max_sources: Option<u8>,
+    request_id: Option<&str>,
+) -> Result<ToolOutput, ToolCallError> {
+    let query = require_non_empty("knowledge.query.answer", "query", query)?;
+    if matches!(max_sources, Some(0 | 21..=u8::MAX)) {
+        return Err(ToolCallError::InvalidInput {
+            tool: "knowledge.query.answer".to_string(),
+            message: "max_sources must be between 1 and 20".to_string(),
+        });
+    }
+
+    let mut input = vec![RuntimeInputField {
+        name: "query".to_string(),
+        value: query.to_string(),
+    }];
+    push_optional_field(&mut input, "conversation_id", conversation_id);
+    if !artifact_scope.is_empty() {
+        input.push(RuntimeInputField {
+            name: "artifact_scope".to_string(),
+            value: artifact_scope.join(","),
+        });
+    }
+    if let Some(max_sources) = max_sources {
+        input.push(RuntimeInputField {
+            name: "max_sources".to_string(),
+            value: max_sources.to_string(),
+        });
+    }
+
+    Ok(ToolOutput::RuntimeRequest {
+        request: runtime_request(
+            request_id,
+            "knowledge.query.answer",
+            "youaskm3.knowledge.query-answer",
+            "contracts/capabilities/knowledge.query.answer.json",
+            input,
+        ),
+    })
+}
+
+fn plan_gaps_list(
+    persona_id: Option<&str>,
+    limit: Option<u16>,
+    request_id: Option<&str>,
+) -> Result<ToolOutput, ToolCallError> {
+    if matches!(limit, Some(0 | 101..=u16::MAX)) {
+        return Err(ToolCallError::InvalidInput {
+            tool: "knowledge.gaps.list".to_string(),
+            message: "limit must be between 1 and 100".to_string(),
+        });
+    }
+
+    let mut input = Vec::new();
+    push_optional_field(&mut input, "persona_id", persona_id);
+    if let Some(limit) = limit {
+        input.push(RuntimeInputField {
+            name: "limit".to_string(),
+            value: limit.to_string(),
+        });
+    }
+
+    Ok(ToolOutput::RuntimeRequest {
+        request: runtime_request(
+            request_id,
+            "knowledge.gaps.list",
+            "youaskm3.knowledge.gaps-list",
+            "contracts/capabilities/knowledge.gaps.list.json",
+            input,
+        ),
+    })
+}
+
+fn plan_resolve_fact(
+    gap_id: &str,
+    answer: &str,
+    persona_id: Option<&str>,
+    request_id: Option<&str>,
+) -> Result<ToolOutput, ToolCallError> {
+    let gap_id = require_non_empty("knowledge.gaps.resolve_fact", "gap_id", gap_id)?;
+    let answer = require_non_empty("knowledge.gaps.resolve_fact", "answer", answer)?;
+
+    let mut input = vec![
+        RuntimeInputField {
+            name: "gap_id".to_string(),
+            value: gap_id.to_string(),
+        },
+        RuntimeInputField {
+            name: "answer".to_string(),
+            value: answer.to_string(),
+        },
+    ];
+    push_optional_field(&mut input, "persona_id", persona_id);
+
+    Ok(ToolOutput::RuntimeRequest {
+        request: runtime_request(
+            request_id,
+            "knowledge.gaps.resolve_fact",
+            "youaskm3.knowledge.gaps-resolve-fact",
+            "contracts/capabilities/knowledge.gaps.resolve_fact.json",
+            input,
+        ),
+    })
+}
+
+fn runtime_request(
+    request_id: Option<&str>,
+    capability_id: &str,
+    workflow_id: &str,
+    contract_path: &str,
+    input: Vec<RuntimeInputField>,
+) -> RuntimeRequest {
+    RuntimeRequest {
+        request_id: request_id.unwrap_or("youaskm3-mcp-request").to_string(),
+        surface: "mcp".to_string(),
+        capability_id: capability_id.to_string(),
+        workflow_id: workflow_id.to_string(),
+        contract_path: contract_path.to_string(),
+        requested_target: "mcp".to_string(),
+        governing_spec: "openspec/specs/local-runtime-sync/spec.md".to_string(),
+        input,
+    }
+}
+
+fn push_optional_field(fields: &mut Vec<RuntimeInputField>, name: &str, value: Option<&str>) {
+    if let Some(value) = value {
+        fields.push(RuntimeInputField {
+            name: name.to_string(),
+            value: value.to_string(),
+        });
     }
 }
 
@@ -388,8 +637,8 @@ fn slugify(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        Connection, RecallMatch, ToolCallError, ToolInput, ToolOutput, call_tool, crate_name,
-        is_known_tool, tool_contract_json, tool_descriptors,
+        Connection, RecallMatch, RuntimeInputField, RuntimeRequest, ToolCallError, ToolInput,
+        ToolOutput, call_tool, crate_name, is_known_tool, tool_contract_json, tool_descriptors,
     };
     use youaskm3_search::{SearchDocument, SearchError};
 
@@ -408,6 +657,9 @@ mod tests {
         assert_eq!(
             names,
             vec![
+                "knowledge.query.answer",
+                "knowledge.gaps.list",
+                "knowledge.gaps.resolve_fact",
                 "search",
                 "remember",
                 "recall",
@@ -416,6 +668,9 @@ mod tests {
                 "status"
             ]
         );
+        assert!(is_known_tool("knowledge.query.answer"));
+        assert!(is_known_tool("knowledge.gaps.list"));
+        assert!(is_known_tool("knowledge.gaps.resolve_fact"));
         assert!(is_known_tool("search"));
         assert!(!is_known_tool("ask"));
     }
@@ -428,6 +683,194 @@ mod tests {
         for tool in tool_descriptors() {
             assert!(contract.contains(&format!("\"name\": \"{}\"", tool.name)));
         }
+    }
+
+    #[test]
+    fn plans_answer_tool_as_traverse_mcp_runtime_request() {
+        let output = call_tool(
+            "knowledge.query.answer",
+            ToolInput::QueryAnswer {
+                query: "What is portable knowledge?",
+                conversation_id: Some("conversation-1"),
+                artifact_scope: &["artifact-a", "artifact-b"],
+                max_sources: Some(3),
+                request_id: Some("answer-request"),
+            },
+        );
+
+        assert_eq!(
+            output,
+            Ok(ToolOutput::RuntimeRequest {
+                request: RuntimeRequest {
+                    request_id: "answer-request".to_string(),
+                    surface: "mcp".to_string(),
+                    capability_id: "knowledge.query.answer".to_string(),
+                    workflow_id: "youaskm3.knowledge.query-answer".to_string(),
+                    contract_path: "contracts/capabilities/knowledge.query.answer.json".to_string(),
+                    requested_target: "mcp".to_string(),
+                    governing_spec: "openspec/specs/local-runtime-sync/spec.md".to_string(),
+                    input: vec![
+                        RuntimeInputField {
+                            name: "query".to_string(),
+                            value: "What is portable knowledge?".to_string(),
+                        },
+                        RuntimeInputField {
+                            name: "conversation_id".to_string(),
+                            value: "conversation-1".to_string(),
+                        },
+                        RuntimeInputField {
+                            name: "artifact_scope".to_string(),
+                            value: "artifact-a,artifact-b".to_string(),
+                        },
+                        RuntimeInputField {
+                            name: "max_sources".to_string(),
+                            value: "3".to_string(),
+                        },
+                    ],
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn plans_gaps_list_tool_with_trace_and_runtime_parity_metadata() {
+        let output = call_tool(
+            "knowledge.gaps.list",
+            ToolInput::GapsList {
+                persona_id: Some("default"),
+                limit: Some(25),
+                request_id: Some("gaps-request"),
+            },
+        );
+
+        assert_eq!(
+            output,
+            Ok(ToolOutput::RuntimeRequest {
+                request: RuntimeRequest {
+                    request_id: "gaps-request".to_string(),
+                    surface: "mcp".to_string(),
+                    capability_id: "knowledge.gaps.list".to_string(),
+                    workflow_id: "youaskm3.knowledge.gaps-list".to_string(),
+                    contract_path: "contracts/capabilities/knowledge.gaps.list.json".to_string(),
+                    requested_target: "mcp".to_string(),
+                    governing_spec: "openspec/specs/local-runtime-sync/spec.md".to_string(),
+                    input: vec![
+                        RuntimeInputField {
+                            name: "persona_id".to_string(),
+                            value: "default".to_string(),
+                        },
+                        RuntimeInputField {
+                            name: "limit".to_string(),
+                            value: "25".to_string(),
+                        },
+                    ],
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn plans_direct_fact_resolution_tool_without_local_business_logic() {
+        let output = call_tool(
+            "knowledge.gaps.resolve_fact",
+            ToolInput::ResolveFact {
+                gap_id: "gap-author-name",
+                answer: "The author is Enrico Piovesan.",
+                persona_id: None,
+                request_id: Some("resolve-request"),
+            },
+        );
+
+        assert_eq!(
+            output,
+            Ok(ToolOutput::RuntimeRequest {
+                request: RuntimeRequest {
+                    request_id: "resolve-request".to_string(),
+                    surface: "mcp".to_string(),
+                    capability_id: "knowledge.gaps.resolve_fact".to_string(),
+                    workflow_id: "youaskm3.knowledge.gaps-resolve-fact".to_string(),
+                    contract_path: "contracts/capabilities/knowledge.gaps.resolve_fact.json"
+                        .to_string(),
+                    requested_target: "mcp".to_string(),
+                    governing_spec: "openspec/specs/local-runtime-sync/spec.md".to_string(),
+                    input: vec![
+                        RuntimeInputField {
+                            name: "gap_id".to_string(),
+                            value: "gap-author-name".to_string(),
+                        },
+                        RuntimeInputField {
+                            name: "answer".to_string(),
+                            value: "The author is Enrico Piovesan.".to_string(),
+                        },
+                    ],
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_expanded_mcp_inputs_with_stable_errors() {
+        assert_eq!(
+            call_tool(
+                "knowledge.query.answer",
+                ToolInput::QueryAnswer {
+                    query: "",
+                    conversation_id: None,
+                    artifact_scope: &[],
+                    max_sources: None,
+                    request_id: None,
+                },
+            ),
+            Err(ToolCallError::InvalidInput {
+                tool: "knowledge.query.answer".to_string(),
+                message: "missing query".to_string(),
+            })
+        );
+        assert_eq!(
+            call_tool(
+                "knowledge.query.answer",
+                ToolInput::QueryAnswer {
+                    query: "What changed?",
+                    conversation_id: None,
+                    artifact_scope: &[],
+                    max_sources: Some(21),
+                    request_id: None,
+                },
+            ),
+            Err(ToolCallError::InvalidInput {
+                tool: "knowledge.query.answer".to_string(),
+                message: "max_sources must be between 1 and 20".to_string(),
+            })
+        );
+        assert_eq!(
+            call_tool(
+                "knowledge.gaps.list",
+                ToolInput::GapsList {
+                    persona_id: None,
+                    limit: Some(101),
+                    request_id: None,
+                },
+            ),
+            Err(ToolCallError::InvalidInput {
+                tool: "knowledge.gaps.list".to_string(),
+                message: "limit must be between 1 and 100".to_string(),
+            })
+        );
+        assert_eq!(
+            call_tool(
+                "knowledge.gaps.resolve_fact",
+                ToolInput::ResolveFact {
+                    gap_id: "gap-heavy-reasoning",
+                    answer: " ",
+                    persona_id: None,
+                    request_id: None,
+                },
+            ),
+            Err(ToolCallError::InvalidInput {
+                tool: "knowledge.gaps.resolve_fact".to_string(),
+                message: "missing answer".to_string(),
+            })
+        );
     }
 
     #[test]

--- a/scripts/traverse-mcp-answer-workflow-smoke.sh
+++ b/scripts/traverse-mcp-answer-workflow-smoke.sh
@@ -68,9 +68,12 @@ abort "query answer contract id mismatch" unless query_contract.fetch("id") == m
 abort "query answer contract must permit MCP" unless query_contract.fetch("execution").fetch("permitted_targets").include?("mcp")
 abort "query answer contract must require trace" unless query_contract.fetch("execution").fetch("requires_trace") == true
 
-required_output = %w[answer citations graph_evidence trace_id validation]
+required_output = %w[answer provenance_type citations graph_evidence trace_id validation]
 missing_output = required_output - mcp_tool.fetch("output_schema").fetch("required")
 abort "MCP answer tool output missing #{missing_output.join(", ")}" unless missing_output.empty?
+%w[gaps conflicts].each do |field|
+  abort "MCP answer tool output missing optional evidence field #{field}" unless mcp_tool.fetch("output_schema").fetch("properties").key?(field)
+end
 
 trace = workflow.fetch("trace")
 abort "MCP parity requires workflow trace" unless trace.fetch("required") == true

--- a/traverse/youaskm3-app/contracts/knowledge.query.answer.contract.json
+++ b/traverse/youaskm3-app/contracts/knowledge.query.answer.contract.json
@@ -48,11 +48,20 @@
         "answer": {
           "type": "string"
         },
+        "provenance_type": {
+          "type": "string"
+        },
         "citations": {
           "$ref": "#/$defs/citations"
         },
         "graph_evidence": {
           "$ref": "#/$defs/graphEvidence"
+        },
+        "gaps": {
+          "$ref": "#/$defs/gaps"
+        },
+        "conflicts": {
+          "$ref": "#/$defs/conflicts"
         },
         "trace_id": {
           "type": "string"
@@ -66,6 +75,7 @@
       },
       "required": [
         "answer",
+        "provenance_type",
         "citations",
         "graph_evidence",
         "trace_id",


### PR DESCRIPTION
## Summary

- expose `knowledge.query.answer`, `knowledge.gaps.list`, and `knowledge.gaps.resolve_fact` as first-class MCP crate tools
- return typed Traverse-bound MCP runtime requests with trace, capability, workflow, contract, and target metadata
- expand MCP answer contracts to include provenance type plus optional gap and conflict evidence fields
- tighten MCP contract and Traverse MCP parity checks

## Spec / Contracts

- `openspec/specs/mcp-interface/spec.md`
- `openspec/specs/local-runtime-sync/spec.md`
- `openspec/specs/knowledge-gap-lifecycle/spec.md`

## Validation

- `cargo test -p youaskm3-mcp`
- `cargo clippy -p youaskm3-mcp -- -D warnings`
- `npm test -- app/components/mcp-tools-contract.test.ts app/components/browser-runtime.test.ts`
- `bash scripts/traverse-mcp-answer-workflow-smoke.sh`
- `PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`

Closes #150
