### PR TITLE
MVP-054: Add expanded MVP acceptance gate

### DIFF
--- a/docs/mvp-check.md
+++ b/docs/mvp-check.md
@@ -1,0 +1,27 @@
+# Expanded First-MVP Acceptance Gate
+
+`m3 mvp-check` is the final expanded first-MVP gate for the second-brain product loop.
+It is acceptance evidence, not a development shortcut.
+
+Run it with an explicit knowledge root:
+
+```bash
+bash scripts/m3.sh mvp-check --knowledge-root /path/to/knowledge-root
+```
+
+Run it with live Traverse readiness when a local Traverse checkout is available:
+
+```bash
+bash scripts/m3.sh mvp-check \
+  --traverse-repo /path/to/Traverse \
+  --knowledge-root /path/to/knowledge-root
+```
+
+The gate validates first-run setup, real Traverse app bundle evidence, reasoning skill adapter drift, decision-log package validation and ingestion, reasoning graph extraction, knowledge gaps and conflicts, sync preflight, local runtime serve orchestration, PWA chat rendering, HTTP/MCP parity, Traverse MCP workflow parity, and direct fact resolution.
+
+The gate must fail if acceptance depends on Browser demo output, temporary harnesses, fake workflow steps, skeleton manifests, placeholder digests, all-zero evidence, or downstream shortcuts.
+
+Remaining caveats are printed at the end of every successful run:
+
+- Semantic validation availability depends on the configured Traverse/provider environment.
+- WASM-native model execution remains a Traverse/provider capability even though youaskm3 declares and validates the model dependency route.

--- a/scripts/m3-command-surface-smoke.sh
+++ b/scripts/m3-command-surface-smoke.sh
@@ -11,6 +11,7 @@ cp "$ROOT_DIR/scripts/m3.sh" "$TEMP_DIR/scripts/m3.sh"
 cp "$ROOT_DIR/scripts/m3-search.rb" "$TEMP_DIR/scripts/m3-search.rb"
 cp "$ROOT_DIR/scripts/m3-serve.sh" "$TEMP_DIR/scripts/m3-serve.sh"
 cp "$ROOT_DIR/scripts/m3-local-runtime.rb" "$TEMP_DIR/scripts/m3-local-runtime.rb"
+cp "$ROOT_DIR/scripts/m3-mvp-check.sh" "$TEMP_DIR/scripts/m3-mvp-check.sh"
 
 cat <<'EOF' > "$TEMP_DIR/app/site/index.html"
 <!doctype html>
@@ -64,5 +65,13 @@ serve_help_output="$(
 
 grep -q "Usage: ./scripts/m3.sh serve \\[port\\]" <<<"$serve_help_output"
 grep -q "serve --runtime" <<<"$serve_help_output"
+
+mvp_check_help_output="$(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh mvp-check --help 2>&1
+)"
+
+grep -q "Usage: ./scripts/m3.sh mvp-check --knowledge-root PATH" <<<"$mvp_check_help_output"
+grep -q "without Browser demo, skeleton, or" <<<"$mvp_check_help_output"
 
 echo "m3 command surface smoke passed."

--- a/scripts/m3-mvp-check.sh
+++ b/scripts/m3-mvp-check.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TRAVERSE_REPO="${TRAVERSE_REPO:-}"
+KNOWLEDGE_ROOT=""
+WORKSPACE_DIR=""
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: ./scripts/m3.sh mvp-check --knowledge-root PATH [--traverse-repo PATH]
+
+Runs the expanded first-MVP acceptance gate without Browser demo, skeleton, or
+placeholder acceptance evidence.
+
+Required:
+  --knowledge-root PATH   Knowledge root used for first-run setup validation.
+
+Optional:
+  --traverse-repo PATH    Local Traverse checkout for live readiness validation.
+EOF
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "m3 mvp-check failed: missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+run_gate() {
+  local label="$1"
+  shift
+
+  echo "==> ${label}"
+  "$@"
+  echo "ok: ${label}"
+}
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --knowledge-root)
+      KNOWLEDGE_ROOT="${2:-}"
+      [[ -n "$KNOWLEDGE_ROOT" ]] || { usage; exit 1; }
+      shift 2
+      ;;
+    --traverse-repo)
+      TRAVERSE_REPO="${2:-}"
+      [[ -n "$TRAVERSE_REPO" ]] || { usage; exit 1; }
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown mvp-check argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$KNOWLEDGE_ROOT" ]]; then
+  usage
+  exit 1
+fi
+
+require_cmd bash
+require_cmd ruby
+require_cmd node
+require_cmd npm
+require_cmd cargo
+
+mkdir -p "$KNOWLEDGE_ROOT"
+WORKSPACE_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$WORKSPACE_DIR"
+}
+trap cleanup EXIT
+
+cd "$ROOT_DIR"
+
+echo "m3 expanded first-MVP acceptance gate"
+echo "knowledge_root: $KNOWLEDGE_ROOT"
+if [[ -n "$TRAVERSE_REPO" ]]; then
+  echo "traverse_repo: $TRAVERSE_REPO"
+else
+  echo "traverse_repo: not supplied; live Traverse readiness will be recorded as a caveat"
+fi
+
+init_args=(
+  "$WORKSPACE_DIR"
+  --name "youaskm3 Expanded MVP Check"
+  --shell-url "https://example.com/youaskm3-mvp-check/"
+  --instance-id "youaskm3-mvp-check"
+  --knowledge-root "$KNOWLEDGE_ROOT"
+  --yes
+)
+if [[ -n "$TRAVERSE_REPO" ]]; then
+  init_args+=(--traverse-repo "$TRAVERSE_REPO")
+else
+  init_args+=(--offline)
+fi
+
+run_gate "first-run setup with external knowledge root" \
+  bash ./scripts/m3-init.sh "${init_args[@]}"
+
+run_gate "real Traverse app bundle validation without skeleton mode" \
+  bash ./scripts/register-traverse-app.sh --validate-only --json
+
+run_gate "no placeholder runtime acceptance evidence" \
+  ruby ./scripts/m3-mvp-placeholder-check.rb
+
+run_gate "reasoning assistant skill adapter drift" \
+  bash ./scripts/reasoning-skill-adapters-smoke.sh
+
+run_gate "decision-log package contract" \
+  bash ./scripts/decision-log-package-smoke.sh
+
+run_gate "decision-log package ingestion" \
+  bash ./scripts/m3-decision-log-ingest-smoke.sh
+
+run_gate "reasoning graph extraction" \
+  bash ./scripts/reasoning-graph-extraction-smoke.sh
+
+run_gate "knowledge gaps and conflicts lifecycle" \
+  bash ./scripts/knowledge-gap-lifecycle-smoke.sh
+
+run_gate "sync preflight and conflict checks" \
+  bash ./scripts/sync-preflight-smoke.sh
+
+run_gate "local runtime serve orchestration" \
+  bash ./scripts/m3-serve-runtime-smoke.sh
+
+run_gate "PWA shell and chat rendering contract" \
+  npm test -- app/components/index.test.ts app/components/browser-runtime.test.ts
+
+run_gate "HTTP JSON and MCP parity surfaces" \
+  bash ./scripts/local-runtime-mcp-parity-smoke.sh
+
+run_gate "Traverse MCP workflow contract parity" \
+  bash ./scripts/traverse-mcp-answer-workflow-smoke.sh
+
+run_gate "direct fact resolution through package pipeline" \
+  bash ./scripts/direct-fact-resolution-smoke.sh
+
+if [[ -n "$TRAVERSE_REPO" ]]; then
+  run_gate "live Traverse readiness" \
+    env TRAVERSE_REPO="$TRAVERSE_REPO" bash ./scripts/traverse-readiness.sh
+fi
+
+cat <<'EOF'
+Remaining caveats:
+- semantic validation availability: deterministic validation and contracts pass; live model semantics depend on the configured Traverse/provider environment.
+- WASM-native model engine: model dependency routing is Traverse-governed; native model execution remains a Traverse/provider capability.
+
+m3 expanded first-MVP acceptance gate passed.
+EOF

--- a/scripts/m3-mvp-placeholder-check.rb
+++ b/scripts/m3-mvp-placeholder-check.rb
@@ -1,0 +1,74 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "English"
+require "pathname"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
+APP_ROOT = ROOT.join("traverse", "youaskm3-app")
+ZERO_DIGEST = "sha256:#{"0" * 64}"
+
+def read_json(path)
+  JSON.parse(path.read)
+rescue Errno::ENOENT
+  abort "MVP placeholder check failed: missing file #{path}"
+rescue JSON::ParserError => error
+  abort "MVP placeholder check failed: invalid JSON in #{path}: #{error.message}"
+end
+
+def relative(path)
+  Pathname.new(path).relative_path_from(ROOT).to_s
+end
+
+def reject_zero_digest(path, value)
+  return unless value == ZERO_DIGEST
+
+  abort "MVP placeholder check failed: #{relative(path)} contains all-zero digest evidence."
+end
+
+app = read_json(APP_ROOT.join("manifest.json"))
+unless app.fetch("integration_status") == "wasm_components_ready"
+  abort "MVP placeholder check failed: app integration_status must be wasm_components_ready."
+end
+
+app.fetch("components").each do |entry|
+  manifest_path = APP_ROOT.join(entry.fetch("manifest_path")).cleanpath
+  manifest = read_json(manifest_path)
+
+  reject_zero_digest(manifest_path, manifest["wasm_digest"])
+  manifest.fetch("artifacts", []).each do |artifact|
+    reject_zero_digest(manifest_path, artifact["digest"])
+  end
+
+  if manifest.fetch("implementation", "").match?(/placeholder|skeleton|fake/i)
+    abort "MVP placeholder check failed: #{relative(manifest_path)} has placeholder implementation marker."
+  end
+end
+
+app.fetch("workflows").each do |entry|
+  workflow_path = APP_ROOT.join(entry.fetch("path")).cleanpath
+  workflow = read_json(workflow_path)
+  workflow_text = JSON.generate(workflow)
+  if workflow_text.match?(/browser-demo|temporary harness|fake workflow|placeholder digest|skeleton manifest/i)
+    abort "MVP placeholder check failed: #{relative(workflow_path)} contains non-acceptance workflow markers."
+  end
+end
+
+registration = IO.popen(
+  ["bash", "scripts/register-traverse-app.sh", "--validate-only", "--json"],
+  chdir: ROOT.to_s,
+  err: [:child, :out],
+  &:read
+)
+unless $CHILD_STATUS.success?
+  abort "MVP placeholder check failed: Traverse app validation failed.\n#{registration}"
+end
+
+payload = JSON.parse(registration)
+evidence = payload.fetch("evidence")
+unless evidence.fetch("missing_wasm_count").zero? && evidence.fetch("zero_digest_component_count").zero?
+  abort "MVP placeholder check failed: Traverse app validation reported missing WASM or zero digest evidence."
+end
+
+puts "MVP placeholder check passed."

--- a/scripts/m3.sh
+++ b/scripts/m3.sh
@@ -7,7 +7,7 @@ COMMAND="${1:-}"
 cd "$ROOT_DIR"
 
 usage() {
-  echo "Usage: ./scripts/m3.sh {init|add|ingest-decision-log|build|sync|search|serve|test|lint|smoke|status}" >&2
+  echo "Usage: ./scripts/m3.sh {init|add|ingest-decision-log|build|sync|search|serve|mvp-check|test|lint|smoke|status}" >&2
 }
 
 slugify_url() {
@@ -122,6 +122,10 @@ case "$COMMAND" in
   serve)
     shift
     bash ./scripts/m3-serve.sh "$@"
+    ;;
+  mvp-check)
+    shift
+    bash ./scripts/m3-mvp-check.sh "$@"
     ;;
   test)
     bash ./scripts/test.sh


### PR DESCRIPTION
## Summary

- add `m3 mvp-check` as the expanded first-MVP acceptance gate
- validate first-run setup, non-skeleton Traverse app evidence, reasoning skill adapters, decision-log package ingestion, reasoning graph extraction, gaps/conflicts, sync preflight, local runtime serve, PWA chat rendering, HTTP/MCP parity, Traverse MCP workflow parity, direct fact resolution, and optional live Traverse readiness
- add a focused placeholder checker for all-zero digests, skeleton markers, and fake workflow acceptance evidence
- document the real acceptance path and caveats

## Spec / Contracts

- `openspec/specs/reasoning-assistant-skill/spec.md`
- `openspec/specs/decision-log-package/spec.md`
- `openspec/specs/reasoning-graph/spec.md`
- `openspec/specs/knowledge-gap-lifecycle/spec.md`
- `openspec/specs/local-runtime-sync/spec.md`
- `openspec/specs/traverse-integration/spec.md`
- `openspec/specs/mcp-interface/spec.md`

## Validation

- `ruby scripts/m3-mvp-placeholder-check.rb`
- `bash scripts/m3-command-surface-smoke.sh`
- `bash scripts/m3.sh mvp-check --knowledge-root /private/tmp/youaskm3-mvp-check-knowledge`
- `bash scripts/m3.sh mvp-check --traverse-repo ../Traverse --knowledge-root /private/tmp/youaskm3-mvp-check-knowledge`
- `PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`

Live Traverse readiness evidence from the local run:

- application bundle registration: passed
- public CLI app registration: passed
- WASM workflow execution: passed
- model dependency resolution: passed
- HTTP/JSON app path: passed
- MCP parity path: passed

Closes #151
