### PR TITLE
Add post-MVP missing-scope specs and tickets

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -239,6 +239,18 @@ These tickets keep youaskm3 product-led while using concrete app evidence to dri
 
 The expanded second-brain tranche is tracked as MVP-041 and later in [docs/mvp-ticket-backlog.md](docs/mvp-ticket-backlog.md). It does not replace MVP-031 through MVP-040; it layers the approved decision-log, reasoning graph, knowledge gap, sync, local runtime, and final expanded acceptance requirements on top of the existing Traverse-backed runtime baseline.
 
+### Post-first-MVP missing scope
+
+The following surfaces are intentionally outside the first MVP but now have explicit future-scope specs and backlog tickets:
+
+- [assistant-distribution](openspec/specs/assistant-distribution/spec.md): packaged ChatGPT, Claude, and future assistant distribution artifacts.
+- [package-import-automation](openspec/specs/package-import-automation/spec.md): zip/archive ingestion and optional inbox/watch-folder processing.
+- [semantic-quality-evaluation](openspec/specs/semantic-quality-evaluation/spec.md): claim-level partial ingestion and production answer benchmarks.
+- [multi-persona](openspec/specs/multi-persona/spec.md): multiple personas, isolation, and shared scopes.
+- [hosted-service](openspec/specs/hosted-service/spec.md): optional hosted accounts, teams, permissions, sync, and runtime services.
+- [federated-answer](openspec/specs/federated-answer/spec.md): cross-instance search and answer flows beyond registry/index discovery.
+- [wasm-native-model-evidence](openspec/specs/wasm-native-model-evidence/spec.md): proof requirements before claiming the model engine itself is WASM-native.
+
 ### Real runtime implementation rule
 
 First-MVP runtime acceptance requires the real product/business implementation, not placeholders:

--- a/docs/expanded-second-brain-mvp-decision-log.md
+++ b/docs/expanded-second-brain-mvp-decision-log.md
@@ -108,3 +108,18 @@ The expanded first MVP is a local-first second-brain product with:
 - Local HTTP JSON and MCP runtime surfaces backed by the same Traverse workflow.
 - File-system sync-folder support with conflict detection.
 - One final `m3 mvp-check` acceptance gate.
+
+## Post-First-MVP Missing Scope Now Ticketed
+
+The following items remain outside the first MVP but are no longer undocumented:
+
+- Packaged/distributed ChatGPT, Claude, and future assistant artifacts.
+- Archive/zip package ingestion and optional inbox/watch-folder processing.
+- Claim-level partial ingestion after semantic validation.
+- Production-quality answer benchmarks.
+- Multi-persona knowledge isolation and explicit sharing.
+- Optional hosted service, accounts, teams, permissions, and hosted sync.
+- Cross-instance federated answer flows beyond registry/index discovery.
+- Evidence required before claiming model-engine execution itself is WASM-native.
+
+These items are captured by future-scope OpenSpec files and FUTURE-001 through FUTURE-007 in `docs/mvp-ticket-backlog.md`.

--- a/docs/mvp-ticket-backlog.md
+++ b/docs/mvp-ticket-backlog.md
@@ -1834,6 +1834,251 @@ bash scripts/smoke.sh
 m3 mvp-check --traverse-repo /path/to/Traverse --knowledge-root /path/to/root
 ```
 
+## Post-First-MVP Missing Scope
+
+The following tickets cover missing surfaces that are intentionally outside the expanded first MVP but now have traceable specs and DoD.
+
+## Ticket FUTURE-001: Package and Distribute Assistant Adapters ([#168](https://github.com/enricopiovesan/youaskm3/issues/168))
+
+### Objective
+
+Turn generated ChatGPT, Claude, and future assistant adapters into packaged, versioned distribution artifacts without moving product logic out of the canonical LLM-agnostic skill.
+
+### Governing Specs
+
+- `openspec/specs/assistant-distribution/spec.md`
+- `openspec/specs/reasoning-assistant-skill/spec.md`
+
+### Scope
+
+- Define platform packaging metadata for ChatGPT and Claude.
+- Generate packaged artifacts from existing generated adapters.
+- Add package/version drift checks against canonical skill and package schema versions.
+- Document platform limitations for marketplace publishing, file export, local handoff, and action/tool availability.
+
+### Definition of Done
+
+- Packaging metadata exists for ChatGPT and Claude adapters.
+- Packaged artifacts are generated from canonical skill/adapters, not hand-edited copies.
+- Drift checks fail when canonical skill, adapter, or schema versions change without regenerated packages.
+- Package docs list each platform's known limitations and blocked capabilities.
+- No package hardcodes private user paths or private knowledge.
+- Validation passes.
+
+### Unknowns To Discuss
+
+- Which platform should be packaged first for real distribution?
+- What exact packaging format does each platform require at that time?
+- Should marketplace publication be part of this ticket or a later release ticket?
+
+## Ticket FUTURE-002: Add Archive and Inbox Decision-Log Import Automation ([#169](https://github.com/enricopiovesan/youaskm3/issues/169))
+
+### Objective
+
+Add convenience import flows for decision-log packages after the canonical CLI directory ingestion path is stable.
+
+### Governing Specs
+
+- `openspec/specs/package-import-automation/spec.md`
+- `openspec/specs/decision-log-package/spec.md`
+- `openspec/specs/local-runtime-sync/spec.md`
+
+### Scope
+
+- Add safe zip/archive ingestion with path traversal, size, and structure validation.
+- Add optional inbox/watch-folder processing.
+- Preserve the same validation, provenance, sync preflight, and Traverse final-ingestion rules as `m3 ingest-decision-log`.
+- Add clear ingested, rejected, staged, and blocked result records.
+
+### Definition of Done
+
+- Archive ingestion rejects unsafe paths, oversized packages, missing files, and invalid metadata before writes.
+- Inbox processing can be enabled explicitly and does not silently ingest final knowledge without validation.
+- Automated imports can be reproduced through the canonical CLI command.
+- Validation and error messages match package directory ingestion semantics.
+- Tests cover safe archive, traversal attack, invalid archive, inbox success, inbox rejection, and offline staging.
+- Validation passes.
+
+### Unknowns To Discuss
+
+- Which archive formats are worth supporting first?
+- Should inbox processing be polling, explicit command, or filesystem watcher?
+- How much user confirmation is required before final ingestion from automation?
+
+## Ticket FUTURE-003: Add Claim-Level Partial Ingestion and Answer Benchmarks ([#170](https://github.com/enricopiovesan/youaskm3/issues/170))
+
+### Objective
+
+Move beyond first-MVP all-or-nothing semantic validation by supporting claim-level partial ingestion and production-quality answer benchmarks.
+
+### Governing Specs
+
+- `openspec/specs/semantic-quality-evaluation/spec.md`
+- `openspec/specs/decision-log-package/spec.md`
+- `openspec/specs/reasoning-graph/spec.md`
+- `openspec/specs/knowledge-gap-lifecycle/spec.md`
+
+### Scope
+
+- Define claim-level extraction and validation records.
+- Allow accepted claims to ingest while rejected claims become gaps.
+- Add benchmark fixture corpus for grounding, provenance, conflicts, gaps, and reasoning usefulness.
+- Report unsupported claim rate, conflict disclosure rate, gap behavior, and provenance completeness.
+
+### Definition of Done
+
+- Claim-level validation schema exists.
+- Partial ingestion records accepted and rejected claims with provenance.
+- Rejected claims create or update gaps instead of disappearing.
+- Benchmarks run deterministically and do not mutate personal knowledge.
+- Benchmark reports are useful for release quality decisions.
+- Tests cover partial package ingestion, rejected claim gap creation, and benchmark reporting.
+- Validation passes.
+
+### Unknowns To Discuss
+
+- What answer-quality thresholds should block release?
+- Which semantic validator or Traverse agent is acceptable for claim-level review?
+- Should benchmark corpora be generic, project-specific, or persona-specific?
+
+## Ticket FUTURE-004: Support Multi-Persona Knowledge Isolation and Sharing ([#171](https://github.com/enricopiovesan/youaskm3/issues/171))
+
+### Objective
+
+Support multiple personas in one installation while preserving isolation, provenance, and explicit sharing rules.
+
+### Governing Specs
+
+- `openspec/specs/multi-persona/spec.md`
+- `openspec/specs/decision-log-package/spec.md`
+- `openspec/specs/reasoning-graph/spec.md`
+- `openspec/specs/knowledge-gap-lifecycle/spec.md`
+
+### Scope
+
+- Add persona registry and active persona selection.
+- Isolate knowledge, gaps, conflicts, graph context, and assistant package metadata by default.
+- Support explicit shared scopes with conflict visibility.
+- Generate persona-aware assistant packages without embedding private knowledge.
+
+### Definition of Done
+
+- Multiple personas can exist in one installation.
+- Answer context uses only the active persona's allowed scope.
+- Shared scopes require explicit metadata.
+- Conflicts between persona-specific and shared knowledge are visible.
+- Assistant adapters can include persona metadata without embedding private knowledge content.
+- Tests cover isolated personas, shared scope, conflict visibility, and provenance.
+- Validation passes.
+
+### Unknowns To Discuss
+
+- Is a persona a person, a role, a project, or all three?
+- Should personas share one graph with scopes or separate graphs?
+- How should persona switching work in chat and CLI?
+
+## Ticket FUTURE-005: Define Optional Hosted Service, Accounts, Teams, and Hosted Sync ([#172](https://github.com/enricopiovesan/youaskm3/issues/172))
+
+### Objective
+
+Define optional hosted youaskm3 capabilities without weakening local-first operation.
+
+### Governing Specs
+
+- `openspec/specs/hosted-service/spec.md`
+- `openspec/specs/local-runtime-sync/spec.md`
+- `openspec/specs/multi-persona/spec.md`
+
+### Scope
+
+- Define hosted account, team, permission, and hosted sync boundaries.
+- Keep hosted identity separate from local persona identity.
+- Preserve local operation when hosted service is unavailable.
+- Preserve conflict records and no-silent-overwrite policy in hosted sync.
+
+### Definition of Done
+
+- Hosted service architecture spec exists for accounts, teams, permissions, and hosted sync.
+- Local-first operation remains valid without hosted config.
+- Hosted identity and local persona metadata are separate.
+- Hosted sync uses the same semantic conflict principles as local sync.
+- Security and privacy risks are documented before implementation.
+- Validation passes for docs/spec checks.
+
+### Unknowns To Discuss
+
+- Is hosted service part of the commercial product or optional community infrastructure?
+- What identity provider and permission model are acceptable?
+- What data, if any, may leave the user's machine by default?
+
+## Ticket FUTURE-006: Add Federated Cross-Instance Answer Flows ([#173](https://github.com/enricopiovesan/youaskm3/issues/173))
+
+### Objective
+
+Extend existing federation registry and index work into explicit cross-instance search and answer behavior.
+
+### Governing Specs
+
+- `openspec/specs/federated-answer/spec.md`
+- `openspec/specs/federation/spec.md`
+- `openspec/specs/reasoning-graph/spec.md`
+
+### Scope
+
+- Add opt-in policy for federated search and answers.
+- Label remote evidence separately from local personal knowledge.
+- Preserve remote instance, source artifact, retrieval path, and confidence provenance.
+- Support explicit import from federated evidence into local knowledge or decision-log reasoning.
+
+### Definition of Done
+
+- Federated answer policy is explicit and disabled unless allowed.
+- Answers distinguish local evidence from remote instance evidence.
+- Remote evidence is never silently treated as personal knowledge.
+- Import from remote evidence preserves source provenance.
+- Tests cover disabled federation, remote-evidence answer, and explicit import path.
+- Validation passes.
+
+### Unknowns To Discuss
+
+- Should federated answers be available in the same chat or a separate explore mode?
+- What trust model applies to remote instance evidence?
+- How should remote content licensing and removal be handled?
+
+## Ticket FUTURE-007: Prove WASM-Native Model-Engine Execution When Traverse Supports It ([#174](https://github.com/enricopiovesan/youaskm3/issues/174))
+
+### Objective
+
+Define and validate the evidence required before youaskm3 claims the model engine itself is WASM-native.
+
+### Governing Specs
+
+- `openspec/specs/wasm-native-model-evidence/spec.md`
+- `docs/mvp-local-inference-policy.md`
+- `openspec/specs/traverse-integration/spec.md`
+
+### Scope
+
+- Distinguish Traverse-governed inference from WASM-native model-engine execution.
+- Define required Traverse evidence: module identity, digest, placement, execution trace, model dependency id, and failure mode.
+- Add readiness checks that fail unsupported WASM-native model claims.
+- Keep the first-MVP caveat until evidence exists.
+
+### Definition of Done
+
+- Docs clearly distinguish governed inference from WASM-native model-engine execution.
+- Required Traverse evidence contract is documented.
+- Readiness validation fails if release notes or docs claim WASM-native model execution without evidence.
+- Positive validation passes when Traverse exposes stable model-engine WASM evidence.
+- Tests cover unsupported claim failure and supported evidence success.
+- Validation passes.
+
+### Unknowns To Discuss
+
+- What exact Traverse trace fields will prove WASM-native model-engine execution?
+- Is a WASI model runtime enough, or must weights/runtime/engine all be WASM-packaged?
+- Should this block a future release or remain an advanced conformance badge?
+
 ## First Tickets to Start
 
 Recommended first implementation ticket for the Traverse-backed runtime baseline:

--- a/docs/mvp-user-stories.md
+++ b/docs/mvp-user-stories.md
@@ -43,6 +43,16 @@ MVP runtime acceptance requires the real implementation. Browser demo, temporary
 - Automatic inbox watcher for decision-log packages.
 - Claim-level partial ingestion after failed semantic validation.
 
+These post-MVP surfaces now have explicit future-scope specs:
+
+- `openspec/specs/assistant-distribution/spec.md`
+- `openspec/specs/package-import-automation/spec.md`
+- `openspec/specs/semantic-quality-evaluation/spec.md`
+- `openspec/specs/multi-persona/spec.md`
+- `openspec/specs/hosted-service/spec.md`
+- `openspec/specs/federated-answer/spec.md`
+- `openspec/specs/wasm-native-model-evidence/spec.md`
+
 ## Personas And Stories
 
 ### Local-First Knowledge Owner

--- a/openspec/specs/assistant-distribution/spec.md
+++ b/openspec/specs/assistant-distribution/spec.md
@@ -1,0 +1,42 @@
+# assistant-distribution Specification
+
+Status: Future scope, unknowns pending
+
+## Purpose
+
+The assistant-distribution capability defines how generated reasoning-skill adapters become packaged, installable, and versioned artifacts for ChatGPT, Claude, and future assistant platforms without changing the LLM-agnostic canonical skill source.
+
+## Requirements
+
+### Requirement: Package adapters without changing product logic
+
+The system SHALL treat platform packaging as distribution metadata around generated adapters, not as a new source of product/business behavior.
+
+#### Scenario: Package a ChatGPT adapter
+
+- GIVEN the canonical reasoning skill and generated ChatGPT adapter pass drift checks
+- WHEN a ChatGPT package artifact is produced
+- THEN it preserves the generated adapter instructions, decision-log package rules, and generic CLI handoff
+- AND any platform-specific manifest fields are generated from explicit packaging metadata
+
+### Requirement: Version distributed assistant packages
+
+The system SHALL version packaged assistant artifacts against the canonical skill version and package schema version.
+
+#### Scenario: Detect stale distributed package
+
+- GIVEN a generated adapter or package schema changes
+- WHEN the distribution check runs
+- THEN stale platform packages fail validation
+- AND the failure reports the exact canonical version mismatch
+
+### Requirement: Keep platform limitations explicit
+
+The system SHALL document platform-specific packaging limits such as file export shape, action/tool availability, local file handoff, and marketplace publication constraints.
+
+#### Scenario: Review platform readiness
+
+- GIVEN a platform does not support a required package export or local handoff
+- WHEN packaging validation runs
+- THEN the artifact is marked blocked for that platform
+- AND the canonical skill remains valid for other platforms

--- a/openspec/specs/federated-answer/spec.md
+++ b/openspec/specs/federated-answer/spec.md
@@ -1,0 +1,41 @@
+# federated-answer Specification
+
+Status: Future scope, unknowns pending
+
+## Purpose
+
+The federated-answer capability extends the existing federation registry and shared index work into cross-instance search and answer flows while preserving local ownership, provenance, and opt-in participation.
+
+## Requirements
+
+### Requirement: Query federated indexes explicitly
+
+The system SHALL use federated indexes only when the user or configured policy explicitly allows cross-instance search.
+
+#### Scenario: Ask with federation disabled
+
+- GIVEN federation search is disabled
+- WHEN the user asks a question
+- THEN only local knowledge is used
+- AND no cross-instance query is performed
+
+### Requirement: Preserve remote provenance
+
+The system SHALL label remote evidence distinctly from local personal knowledge.
+
+#### Scenario: Answer from remote instance evidence
+
+- GIVEN a federated answer uses evidence from another instance
+- WHEN the answer is rendered
+- THEN provenance identifies the remote instance, source artifact, retrieval path, and confidence
+- AND the answer does not imply the remote evidence is part of the user's personal knowledge unless imported
+
+### Requirement: Support import from federated evidence
+
+The system SHALL allow useful federated evidence to become local knowledge only through explicit import or decision-log reasoning.
+
+#### Scenario: Import remote evidence
+
+- GIVEN the user wants to keep remote evidence
+- WHEN the import flow runs
+- THEN the evidence becomes a local source artifact or reasoning package with provenance back to the remote instance

--- a/openspec/specs/hosted-service/spec.md
+++ b/openspec/specs/hosted-service/spec.md
@@ -1,0 +1,41 @@
+# hosted-service Specification
+
+Status: Future scope, unknowns pending
+
+## Purpose
+
+The hosted-service capability defines optional hosted youaskm3 services, including account management, teams, permissions, hosted sync, and hosted runtime operations, without weakening the local-first product.
+
+## Requirements
+
+### Requirement: Preserve local-first operation
+
+The system SHALL keep local-first operation valid when hosted services are unavailable or unused.
+
+#### Scenario: Hosted service unavailable
+
+- GIVEN the user has a local knowledge root
+- WHEN hosted service configuration is absent or unavailable
+- THEN local CLI, local runtime, and local Traverse-backed workflows continue to work
+
+### Requirement: Separate hosted identity from local persona
+
+The system SHALL define hosted accounts, teams, and permissions separately from local persona metadata.
+
+#### Scenario: Join a team workspace
+
+- GIVEN a hosted account joins a team
+- WHEN the user accesses team knowledge
+- THEN access is governed by hosted permissions
+- AND local persona id remains distinct from hosted account id
+
+### Requirement: Sync without silent conflict loss
+
+The system SHALL preserve the local sync conflict model when hosted sync exists.
+
+#### Scenario: Hosted sync detects conflict
+
+- GIVEN two devices update the same semantic knowledge
+- WHEN hosted sync reconciles changes
+- THEN safe append-only changes may merge
+- AND semantic conflicts become conflict records instead of silent overwrite

--- a/openspec/specs/multi-persona/spec.md
+++ b/openspec/specs/multi-persona/spec.md
@@ -1,0 +1,42 @@
+# multi-persona Specification
+
+Status: Future scope, unknowns pending
+
+## Purpose
+
+The multi-persona capability defines how more than one persona can maintain isolated or intentionally shared knowledge, gaps, decision logs, graph context, and assistant adapters.
+
+## Requirements
+
+### Requirement: Isolate persona knowledge by default
+
+The system SHALL keep persona knowledge, gaps, conflicts, and reasoning graphs isolated unless sharing is explicitly configured.
+
+#### Scenario: Ask as one persona
+
+- GIVEN two personas exist in the same installation
+- WHEN the active persona asks a question
+- THEN answer context is selected only from that persona's allowed knowledge scope
+- AND provenance records the active persona id
+
+### Requirement: Support explicit shared scopes
+
+The system SHALL support shared knowledge scopes only through explicit metadata and conflict policy.
+
+#### Scenario: Share a decision log
+
+- GIVEN a decision-log package is marked as shared
+- WHEN it is ingested
+- THEN the package records which personas may use it
+- AND conflicts between persona-specific knowledge and shared knowledge are visible
+
+### Requirement: Generate persona-aware assistant packages
+
+The system SHALL allow generated assistant adapters to include persona context without hardcoding private knowledge into the adapter.
+
+#### Scenario: Generate adapter for a persona
+
+- GIVEN a persona profile exists
+- WHEN assistant packaging runs
+- THEN generated instructions may include allowed persona metadata
+- AND do not embed private knowledge content outside the knowledge store

--- a/openspec/specs/package-import-automation/spec.md
+++ b/openspec/specs/package-import-automation/spec.md
@@ -1,0 +1,42 @@
+# package-import-automation Specification
+
+Status: Future scope, unknowns pending
+
+## Purpose
+
+The package-import-automation capability defines optional import convenience features beyond first-MVP CLI directory ingestion, including archive package ingestion and inbox/watch-folder processing.
+
+## Requirements
+
+### Requirement: Import decision-log package archives safely
+
+The system SHALL support archive ingestion only after validating archive structure, size limits, paths, and package contents.
+
+#### Scenario: Reject path traversal archive
+
+- GIVEN a zip archive contains a path outside the intended extraction root
+- WHEN archive ingestion runs
+- THEN ingestion fails before extraction
+- AND no knowledge-root files are written
+
+### Requirement: Support inbox processing without silent ingestion
+
+The system SHALL allow an optional inbox or watch-folder flow only when it preserves explicit validation, provenance, sync preflight, and user-visible results.
+
+#### Scenario: Process inbox package
+
+- GIVEN a package appears in a configured inbox
+- WHEN the inbox processor runs
+- THEN it validates the package through the same path as `m3 ingest-decision-log`
+- AND writes a clear ingested, rejected, or staged result
+- AND does not bypass Traverse-required final ingestion rules
+
+### Requirement: Preserve the CLI ingestion contract
+
+The system SHALL keep `m3 ingest-decision-log /path/to/package/` as the canonical ingestion behavior even when archives or inbox flows exist.
+
+#### Scenario: Debug an automated import
+
+- GIVEN an inbox import fails
+- WHEN the user wants to reproduce the failure
+- THEN the same package can be passed to the CLI ingestion command with equivalent validation results

--- a/openspec/specs/semantic-quality-evaluation/spec.md
+++ b/openspec/specs/semantic-quality-evaluation/spec.md
@@ -1,0 +1,43 @@
+# semantic-quality-evaluation Specification
+
+Status: Future scope, unknowns pending
+
+## Purpose
+
+The semantic-quality-evaluation capability defines claim-level semantic validation, partial ingestion, and production-quality answer benchmarking after the deterministic first-MVP path is stable.
+
+## Requirements
+
+### Requirement: Support claim-level partial ingestion
+
+The system SHALL allow semantically accepted claims to be ingested while rejected claims become knowledge gaps only after claim extraction, provenance, and conflict semantics are stable.
+
+#### Scenario: Partially ingest a package
+
+- GIVEN a decision-log package contains multiple claims
+- AND semantic validation rejects only some claims
+- WHEN partial ingestion runs
+- THEN accepted claims are ingested with provenance
+- AND rejected claims create or update gaps
+- AND the package records partial status instead of all-or-nothing success
+
+### Requirement: Benchmark answer quality against fixtures
+
+The system SHALL define production-quality answer evaluation fixtures that test grounding, provenance, conflict behavior, gap creation, and reasoning usefulness.
+
+#### Scenario: Run answer benchmark
+
+- GIVEN a benchmark corpus and expected evidence rules exist
+- WHEN the benchmark runs
+- THEN it reports grounded answer quality, unsupported claim rate, conflict disclosure rate, gap behavior, and provenance completeness
+
+### Requirement: Keep benchmark output non-authoritative for knowledge
+
+The system SHALL use benchmarks as quality evidence and not as a source of personal knowledge.
+
+#### Scenario: Benchmark produces feedback
+
+- GIVEN a benchmark detects a weak answer
+- WHEN the report is generated
+- THEN the report does not update the knowledge graph directly
+- AND any product issue becomes a traceable ticket or gap

--- a/openspec/specs/wasm-native-model-evidence/spec.md
+++ b/openspec/specs/wasm-native-model-evidence/spec.md
@@ -1,0 +1,41 @@
+# wasm-native-model-evidence Specification
+
+Status: Future scope, unknowns pending
+
+## Purpose
+
+The wasm-native-model-evidence capability defines how youaskm3 will prove, when Traverse supports it, that model-engine execution itself is WASM-native instead of only Traverse-governed through dependency resolution and placement.
+
+## Requirements
+
+### Requirement: Distinguish governed inference from WASM-native model engine execution
+
+The system SHALL keep the first-MVP caveat explicit until Traverse exposes stable evidence that the model engine itself runs as WASM.
+
+#### Scenario: Report current inference mode
+
+- GIVEN Traverse resolves a local or server inference dependency
+- WHEN youaskm3 records runtime evidence
+- THEN it reports whether the inference dependency was Traverse-governed
+- AND separately reports whether the model engine itself was WASM-native when that evidence exists
+
+### Requirement: Define required Traverse evidence
+
+The system SHALL document the Traverse evidence needed before claiming WASM-native model-engine execution.
+
+#### Scenario: Verify model engine evidence
+
+- GIVEN Traverse exposes model-engine execution evidence
+- WHEN youaskm3 readiness validation runs
+- THEN validation checks module identity, digest, runtime placement, execution trace, model dependency id, and failure mode
+
+### Requirement: Fail closed on unsupported claims
+
+The system SHALL fail readiness if docs or release notes claim WASM-native model-engine execution without matching Traverse evidence.
+
+#### Scenario: Unsupported claim detected
+
+- GIVEN a release note claims WASM-native model-engine execution
+- AND readiness evidence does not prove it
+- WHEN validation runs
+- THEN the gate fails with a stable unsupported-claim error


### PR DESCRIPTION
## Summary

- Add future-scope OpenSpec files for the remaining post-first-MVP gaps.
- Add FUTURE-001 through FUTURE-007 to the backlog with full DoD and unknowns to discuss.
- Link created GitHub issues #168-#174 and add them to Project 3 as Ready.

## Spec References

- openspec/specs/assistant-distribution/spec.md
- openspec/specs/package-import-automation/spec.md
- openspec/specs/semantic-quality-evaluation/spec.md
- openspec/specs/multi-persona/spec.md
- openspec/specs/hosted-service/spec.md
- openspec/specs/federated-answer/spec.md
- openspec/specs/wasm-native-model-evidence/spec.md

## Validation

```bash
PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH \
PYTHON=/opt/homebrew/bin/python3.14 \
bash scripts/smoke.sh
```

Result: passed.
