### PR TITLE
Add decision-log package import automation

### DIFF
--- a/scripts/import-decision-log-package.rb
+++ b/scripts/import-decision-log-package.rb
@@ -1,0 +1,266 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "open3"
+require "pathname"
+require "rbconfig"
+require "tmpdir"
+require "time"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
+DEFAULT_KNOWLEDGE_ROOT = ROOT.join("knowledge")
+REQUIRED_PACKAGE_FILES = ["decision-log.md", "knowledge-note.md", "metadata.json"].freeze
+DEFAULT_MAX_ARCHIVE_BYTES = 5 * 1024 * 1024
+$collect_failures = false
+
+class ImportFailure < StandardError
+  attr_reader :result
+
+  def initialize(result)
+    @result = result
+    super(result.fetch("error").fetch("message"))
+  end
+end
+
+def usage
+  abort <<~USAGE
+    Usage:
+      ./scripts/m3.sh import-decision-log archive <package.zip> [--knowledge-root PATH] [--offline] [--max-archive-bytes N]
+      ./scripts/m3.sh import-decision-log inbox <inbox-dir> [--knowledge-root PATH] [--offline] [--max-archive-bytes N]
+  USAGE
+end
+
+def parse_common_options(argv)
+  knowledge_root = DEFAULT_KNOWLEDGE_ROOT
+  offline = false
+  max_archive_bytes = DEFAULT_MAX_ARCHIVE_BYTES
+
+  until argv.empty?
+    flag = argv.shift
+    case flag
+    when "--knowledge-root"
+      knowledge_root = Pathname.new(argv.shift || usage)
+    when "--offline"
+      offline = true
+    when "--max-archive-bytes"
+      max_archive_bytes = Integer(argv.shift || usage, exception: false) || usage
+    else
+      usage
+    end
+  end
+
+  [knowledge_root.expand_path, offline, max_archive_bytes]
+end
+
+def json_result(status:, source_path:, package_id: nil, ingestion: nil, error: nil, result_path: nil)
+  result = {
+    "status" => status,
+    "source_path" => source_path.to_s,
+    "package_id" => package_id,
+    "ingestion" => ingestion,
+    "error" => error
+  }
+  result["result_path"] = result_path.to_s if result_path
+  result
+end
+
+def stable_failure(code, message, source_path)
+  result = json_result(
+    status: "rejected",
+    source_path: source_path,
+    error: { "code" => code, "message" => message }
+  )
+  raise ImportFailure, result if $collect_failures
+
+  puts JSON.pretty_generate(result)
+  exit 1
+end
+
+def archive?(path)
+  path.to_s.end_with?(".zip")
+end
+
+def list_zip_entries(archive_path)
+  stdout, stderr, status = Open3.capture3("unzip", "-l", archive_path.to_s)
+  stable_failure("ARCHIVE_LIST_FAILED", stderr.strip.empty? ? "Unable to list archive entries." : stderr.strip, archive_path) unless status.success?
+
+  entries = []
+  stdout.each_line do |line|
+    next unless (match = line.match(/\A\s*(\d+)\s+\S+\s+\d{2}:\d{2}\s+(.+?)\s*\z/))
+
+    entries << { "bytes" => Integer(match[1]), "name" => match[2] }
+  end
+  entries
+end
+
+def validate_zip_entries!(archive_path, entries, max_archive_bytes)
+  stable_failure("ARCHIVE_EMPTY", "Archive contains no package files.", archive_path) if entries.empty?
+
+  total_bytes = entries.sum { |entry| entry.fetch("bytes") }
+  if total_bytes > max_archive_bytes
+    stable_failure("ARCHIVE_TOO_LARGE", "Archive expands to #{total_bytes} bytes, above limit #{max_archive_bytes}.", archive_path)
+  end
+
+  entries.each do |entry|
+    name = entry.fetch("name")
+    clean = Pathname.new(name).cleanpath.to_s
+    if name.start_with?("/", "\\") || clean == "." || clean.start_with?("../") || clean == ".." || clean.include?("/../")
+      stable_failure("ARCHIVE_UNSAFE_PATH", "Archive entry escapes extraction root: #{name}", archive_path)
+    end
+  end
+end
+
+def extract_zip(archive_path, destination)
+  stdout, stderr, status = Open3.capture3("unzip", "-q", archive_path.to_s, "-d", destination.to_s)
+  return if status.success?
+
+  stable_failure("ARCHIVE_EXTRACT_FAILED", stderr.strip.empty? ? stdout.strip : stderr.strip, archive_path)
+end
+
+def package_dir_from_extraction(extract_root, source_path)
+  candidates = [extract_root] + extract_root.children.select(&:directory?)
+  package_dirs = candidates.select do |candidate|
+    REQUIRED_PACKAGE_FILES.all? { |file| candidate.join(file).file? }
+  end
+
+  if package_dirs.empty?
+    stable_failure("ARCHIVE_PACKAGE_FILES_MISSING", "Archive does not contain a decision-log package with required files.", source_path)
+  end
+  if package_dirs.length > 1
+    stable_failure("ARCHIVE_AMBIGUOUS_PACKAGE", "Archive contains multiple decision-log package roots.", source_path)
+  end
+
+  package_dirs.first
+end
+
+def validate_package_before_write!(package_dir, source_path)
+  stdout, stderr, status = Open3.capture3(RbConfig.ruby, ROOT.join("scripts", "validate-decision-log-package.rb").to_s, package_dir.to_s)
+  validation = JSON.parse(stdout)
+  return validation if status.success? && validation.fetch("valid")
+
+  first_error = validation.fetch("errors").first || { "code" => "PACKAGE_VALIDATION_FAILED", "message" => stderr }
+  stable_failure(first_error.fetch("code"), first_error.fetch("message"), source_path)
+rescue JSON::ParserError => error
+  stable_failure("VALIDATOR_OUTPUT_INVALID", "Decision-log package validator returned invalid JSON: #{error.message}", source_path)
+end
+
+def ingest_package(package_dir, source_path, knowledge_root, offline)
+  args = [
+    RbConfig.ruby,
+    ROOT.join("scripts", "ingest-decision-log.rb").to_s,
+    package_dir.to_s,
+    "--knowledge-root", knowledge_root.to_s,
+    "--original-import-path", source_path.to_s
+  ]
+  args << "--offline" if offline
+
+  stdout, stderr, status = Open3.capture3(*args)
+  if status.success?
+    ingestion = JSON.parse(stdout)
+    status_name = ingestion.fetch("status") == "staged_offline" ? "staged" : "ingested"
+    return json_result(
+      status: status_name,
+      source_path: source_path,
+      package_id: ingestion.fetch("package_id"),
+      ingestion: ingestion
+    )
+  end
+
+  code = stderr[/\A([A-Z0-9_]+):/, 1] || "IMPORT_BLOCKED"
+  json_result(
+    status: "blocked",
+    source_path: source_path,
+    error: { "code" => code, "message" => stderr.strip.empty? ? stdout.strip : stderr.strip }
+  )
+rescue JSON::ParserError => error
+  json_result(
+    status: "blocked",
+    source_path: source_path,
+    error: { "code" => "INGEST_OUTPUT_INVALID", "message" => "Decision-log ingestion returned invalid JSON: #{error.message}" }
+  )
+end
+
+def import_archive(archive_path, knowledge_root, offline, max_archive_bytes)
+  stable_failure("ARCHIVE_INPUT_REQUIRED", "Archive import requires a .zip package.", archive_path) unless archive?(archive_path)
+  stable_failure("ARCHIVE_NOT_FOUND", "Archive does not exist: #{archive_path}", archive_path) unless archive_path.file?
+
+  entries = list_zip_entries(archive_path)
+  validate_zip_entries!(archive_path, entries, max_archive_bytes)
+
+  Dir.mktmpdir("youaskm3-decision-log-import-") do |temp|
+    extract_root = Pathname.new(temp)
+    extract_zip(archive_path, extract_root)
+    package_dir = package_dir_from_extraction(extract_root, archive_path)
+    validate_package_before_write!(package_dir, archive_path)
+    ingest_package(package_dir, archive_path, knowledge_root, offline)
+  end
+end
+
+def import_directory(package_dir, knowledge_root, offline)
+  validate_package_before_write!(package_dir, package_dir)
+  ingest_package(package_dir, package_dir, knowledge_root, offline)
+end
+
+def result_records_dir(inbox_dir)
+  inbox_dir.join(".youaskm3-import-results")
+end
+
+def write_inbox_result(inbox_dir, source_path, result)
+  FileUtils.mkdir_p(result_records_dir(inbox_dir))
+  slug = source_path.basename.to_s.gsub(/[^a-zA-Z0-9.-]+/, "-")
+  result_path = result_records_dir(inbox_dir).join("#{Time.now.utc.strftime("%Y%m%dT%H%M%SZ")}-#{slug}.json")
+  result["result_path"] = result_path.to_s
+  result_path.write(JSON.pretty_generate(result) + "\n")
+  result
+end
+
+def import_inbox(inbox_dir, knowledge_root, offline, max_archive_bytes)
+  stable_failure("INBOX_NOT_DIRECTORY", "Inbox path must be a directory: #{inbox_dir}", inbox_dir) unless inbox_dir.directory?
+
+  entries = inbox_dir.children.reject { |entry| entry.basename.to_s == ".youaskm3-import-results" }.sort_by(&:to_s)
+  results = entries.map do |entry|
+    result = nil
+    begin
+      $collect_failures = true
+      result =
+        if entry.directory?
+          import_directory(entry, knowledge_root, offline)
+        elsif archive?(entry)
+          import_archive(entry, knowledge_root, offline, max_archive_bytes)
+        else
+          json_result(
+            status: "rejected",
+            source_path: entry,
+            error: { "code" => "INBOX_UNSUPPORTED_ENTRY", "message" => "Inbox entries must be package directories or .zip archives." }
+          )
+        end
+    rescue ImportFailure => error
+      result = error.result
+    ensure
+      $collect_failures = false
+    end
+    write_inbox_result(inbox_dir, entry, result)
+  end
+
+  {
+    "status" => "processed",
+    "inbox_path" => inbox_dir.to_s,
+    "counts" => results.each_with_object(Hash.new(0)) { |result, counts| counts[result.fetch("status")] += 1 },
+    "results" => results
+  }
+end
+
+command = ARGV.shift || usage
+source = Pathname.new(ARGV.shift || usage).expand_path
+knowledge_root, offline, max_archive_bytes = parse_common_options(ARGV)
+
+case command
+when "archive"
+  puts JSON.pretty_generate(import_archive(source, knowledge_root, offline, max_archive_bytes))
+when "inbox"
+  puts JSON.pretty_generate(import_inbox(source, knowledge_root, offline, max_archive_bytes))
+else
+  usage
+end

--- a/scripts/ingest-decision-log.rb
+++ b/scripts/ingest-decision-log.rb
@@ -15,7 +15,7 @@ REQUIRED_PACKAGE_FILES = ["decision-log.md", "knowledge-note.md", "metadata.json
 ARCHIVE_EXTENSIONS = [".zip", ".tar", ".tgz", ".tar.gz", ".gz"].freeze
 
 def usage
-  abort "Usage: ./scripts/m3.sh ingest-decision-log <package-dir> [--knowledge-root PATH] [--offline]"
+  abort "Usage: ./scripts/m3.sh ingest-decision-log <package-dir> [--knowledge-root PATH] [--offline] [--original-import-path PATH]"
 end
 
 def parse_args(argv)
@@ -23,6 +23,7 @@ def parse_args(argv)
   package_path = Pathname.new(argv.shift)
   knowledge_root = DEFAULT_KNOWLEDGE_ROOT
   offline = false
+  original_import_path = package_path
 
   until argv.empty?
     flag = argv.shift
@@ -31,12 +32,14 @@ def parse_args(argv)
       knowledge_root = Pathname.new(argv.shift || usage)
     when "--offline"
       offline = true
+    when "--original-import-path"
+      original_import_path = Pathname.new(argv.shift || usage)
     else
       usage
     end
   end
 
-  [package_path.expand_path, knowledge_root.expand_path, offline]
+  [package_path.expand_path, knowledge_root.expand_path, offline, original_import_path.expand_path]
 end
 
 def stable_error(code, message)
@@ -156,7 +159,7 @@ def write_normalized_note(knowledge_root, package_id, package_destination)
   MARKDOWN
 end
 
-package_path, knowledge_root, offline = parse_args(ARGV)
+package_path, knowledge_root, offline, original_import_path = parse_args(ARGV)
 stable_error("ARCHIVE_INPUT_UNSUPPORTED", "Decision-log package input must be a directory, not an archive.") if archive_path?(package_path)
 stable_error("PACKAGE_NOT_DIRECTORY", "Decision-log package input must be a directory.") unless package_path.directory?
 
@@ -177,7 +180,7 @@ destination = destination_root.join(package_id)
 stable_error("PACKAGE_ALREADY_EXISTS", "Decision-log package already exists: #{destination}") if destination.exist?
 
 copy_required_package_files(package_path, destination)
-write_provenance(destination, package_path, validation, offline)
+write_provenance(destination, original_import_path, validation, offline)
 write_normalized_note(knowledge_root, package_id, destination) unless offline
 
 result = {

--- a/scripts/m3.sh
+++ b/scripts/m3.sh
@@ -7,7 +7,7 @@ COMMAND="${1:-}"
 cd "$ROOT_DIR"
 
 usage() {
-  echo "Usage: ./scripts/m3.sh {init|add|ingest-decision-log|build|sync|search|serve|mvp-check|test|lint|smoke|status}" >&2
+  echo "Usage: ./scripts/m3.sh {init|add|ingest-decision-log|import-decision-log|build|sync|search|serve|mvp-check|test|lint|smoke|status}" >&2
 }
 
 slugify_url() {
@@ -85,6 +85,10 @@ case "$COMMAND" in
   ingest-decision-log)
     shift
     ruby ./scripts/ingest-decision-log.rb "$@"
+    ;;
+  import-decision-log)
+    shift
+    ruby ./scripts/import-decision-log-package.rb "$@"
     ;;
   build)
     bash ./scripts/build.sh

--- a/scripts/package-import-automation-smoke.sh
+++ b/scripts/package-import-automation-smoke.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+mkdir -p \
+  "$TEMP_DIR/app/site" \
+  "$TEMP_DIR/knowledge/blog" \
+  "$TEMP_DIR/knowledge/books" \
+  "$TEMP_DIR/knowledge/papers" \
+  "$TEMP_DIR/scripts" \
+  "$TEMP_DIR/fixtures/decision-log-packages/valid" \
+  "$TEMP_DIR/fixtures/decision-log-packages/invalid" \
+  "$TEMP_DIR/inbox"
+
+cp "$ROOT_DIR/app/site/author-instance.json" "$TEMP_DIR/app/site/author-instance.json"
+cp "$ROOT_DIR/app/site/provider-config.json" "$TEMP_DIR/app/site/provider-config.json"
+cp "$ROOT_DIR/scripts/m3.sh" "$TEMP_DIR/scripts/m3.sh"
+cp "$ROOT_DIR/scripts/m3-sync.sh" "$TEMP_DIR/scripts/m3-sync.sh"
+cp "$ROOT_DIR/scripts/generate-site-artifacts.rb" "$TEMP_DIR/scripts/generate-site-artifacts.rb"
+cp "$ROOT_DIR/scripts/reasoning-graph-extractor.rb" "$TEMP_DIR/scripts/reasoning-graph-extractor.rb"
+cp "$ROOT_DIR/scripts/validate-decision-log-package.rb" "$TEMP_DIR/scripts/validate-decision-log-package.rb"
+cp "$ROOT_DIR/scripts/ingest-decision-log.rb" "$TEMP_DIR/scripts/ingest-decision-log.rb"
+cp "$ROOT_DIR/scripts/import-decision-log-package.rb" "$TEMP_DIR/scripts/import-decision-log-package.rb"
+cp "$ROOT_DIR/scripts/sync-preflight.rb" "$TEMP_DIR/scripts/sync-preflight.rb"
+cp "$ROOT_DIR/scripts/knowledge-gap-lifecycle.rb" "$TEMP_DIR/scripts/knowledge-gap-lifecycle.rb"
+cp -R "$ROOT_DIR/fixtures/decision-log-packages/valid/knowledge_addition" "$TEMP_DIR/fixtures/decision-log-packages/valid/knowledge_addition"
+cp -R "$ROOT_DIR/fixtures/decision-log-packages/invalid/unsupported-note-claim" "$TEMP_DIR/fixtures/decision-log-packages/invalid/unsupported-note-claim"
+
+(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh sync >/dev/null
+)
+
+(
+  cd "$TEMP_DIR/fixtures/decision-log-packages/valid"
+  zip -qr "$TEMP_DIR/valid-package.zip" knowledge_addition
+)
+
+archive_output="$(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh import-decision-log archive "$TEMP_DIR/valid-package.zip"
+)"
+
+ruby -rjson -e 'data=JSON.parse(STDIN.read); abort "expected archive ingestion" unless data.fetch("status") == "ingested" && data.fetch("package_id") == "decision-log-20260629-portable-reasoning"' <<<"$archive_output"
+grep -q "$TEMP_DIR/valid-package.zip" "$TEMP_DIR/knowledge/sources/decision-logs/decision-log-20260629-portable-reasoning/ingestion-provenance.json"
+
+mkdir -p "$TEMP_DIR/offline-knowledge"
+printf '{"schema_version":"1.0.0","offline":true}\n' >"$TEMP_DIR/offline-knowledge/.youaskm3-knowledge-root.json"
+offline_output="$(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh import-decision-log archive "$TEMP_DIR/valid-package.zip" --offline --knowledge-root "$TEMP_DIR/offline-knowledge"
+)"
+ruby -rjson -e 'data=JSON.parse(STDIN.read); abort "expected staged archive" unless data.fetch("status") == "staged"' <<<"$offline_output"
+[[ -f "$TEMP_DIR/offline-knowledge/sources/decision-logs/.staged/decision-log-20260629-portable-reasoning/ingestion-provenance.json" ]]
+
+(
+  cd "$TEMP_DIR/fixtures/decision-log-packages/invalid"
+  zip -qr "$TEMP_DIR/invalid-package.zip" unsupported-note-claim
+)
+if (
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh import-decision-log archive "$TEMP_DIR/invalid-package.zip" >/tmp/package-import-invalid.json
+); then
+  echo "Expected invalid archive import to fail before knowledge writes." >&2
+  exit 1
+fi
+ruby -rjson -e 'data=JSON.parse(File.read("/tmp/package-import-invalid.json")); abort "expected rejected invalid archive" unless data.fetch("status") == "rejected" && data.fetch("error").fetch("code") == "UNSUPPORTED_KNOWLEDGE_NOTE_CLAIM"'
+[[ ! -f "$TEMP_DIR/knowledge/gaps/open/gap-decision-log-20260629-unsupported-note-validation.md" ]]
+
+mkdir -p "$TEMP_DIR/unsafe-archive/root"
+printf 'bad\n' >"$TEMP_DIR/unsafe-archive/evil.txt"
+(
+  cd "$TEMP_DIR/unsafe-archive/root"
+  zip -q "$TEMP_DIR/unsafe.zip" ../evil.txt
+)
+if (
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh import-decision-log archive "$TEMP_DIR/unsafe.zip" >/tmp/package-import-unsafe.json
+); then
+  echo "Expected unsafe archive import to fail." >&2
+  exit 1
+fi
+ruby -rjson -e 'data=JSON.parse(File.read("/tmp/package-import-unsafe.json")); abort "expected unsafe path rejection" unless data.fetch("status") == "rejected" && data.fetch("error").fetch("code") == "ARCHIVE_UNSAFE_PATH"'
+[[ ! -e "$TEMP_DIR/evil.txt" ]]
+
+cp -R "$TEMP_DIR/fixtures/decision-log-packages/valid/knowledge_addition" "$TEMP_DIR/inbox/knowledge_addition"
+cp "$TEMP_DIR/invalid-package.zip" "$TEMP_DIR/inbox/invalid-package.zip"
+printf 'notes\n' >"$TEMP_DIR/inbox/readme.txt"
+mkdir -p "$TEMP_DIR/inbox-offline-knowledge"
+printf '{"schema_version":"1.0.0","offline":true}\n' >"$TEMP_DIR/inbox-offline-knowledge/.youaskm3-knowledge-root.json"
+inbox_output="$(
+  cd "$TEMP_DIR"
+  bash ./scripts/m3.sh import-decision-log inbox "$TEMP_DIR/inbox" --offline --knowledge-root "$TEMP_DIR/inbox-offline-knowledge"
+)"
+ruby -rjson -e 'data=JSON.parse(STDIN.read); counts=data.fetch("counts"); abort "expected staged, rejected counts" unless counts.fetch("staged") == 1 && counts.fetch("rejected") == 2 && data.fetch("results").all? { |result| result.key?("result_path") }' <<<"$inbox_output"
+[[ "$(find "$TEMP_DIR/inbox/.youaskm3-import-results" -type f | wc -l | tr -d ' ')" == "3" ]]
+
+echo "Package import automation smoke passed."

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -12,6 +12,7 @@ SPEC_FILES=(
   "openspec/specs/pwa-shell/spec.md"
   "openspec/specs/reasoning-assistant-skill/spec.md"
   "openspec/specs/assistant-distribution/spec.md"
+  "openspec/specs/package-import-automation/spec.md"
   "openspec/specs/decision-log-package/spec.md"
   "openspec/specs/reasoning-graph/spec.md"
   "openspec/specs/knowledge-gap-lifecycle/spec.md"
@@ -46,6 +47,8 @@ validate_openspec_file() {
 
 require_cmd npm
 require_cmd ruby
+require_cmd unzip
+require_cmd zip
 
 cd "$ROOT_DIR"
 
@@ -123,6 +126,9 @@ bash ./scripts/decision-log-package-smoke.sh
 
 echo "Validating m3 decision-log package ingestion..."
 bash ./scripts/m3-decision-log-ingest-smoke.sh
+
+echo "Validating package import automation..."
+bash ./scripts/package-import-automation-smoke.sh
 
 echo "Validating reasoning graph extraction..."
 bash ./scripts/reasoning-graph-extraction-smoke.sh


### PR DESCRIPTION
## Summary

- Adds `m3 import-decision-log archive` for safe zip package imports.
- Adds `m3 import-decision-log inbox` for explicit inbox processing with per-item result records.
- Preserves canonical directory ingestion while recording original archive/inbox source provenance.
- Adds package import automation smoke coverage and includes the governing spec in the full smoke gate.

## Spec References

- `openspec/specs/package-import-automation/spec.md`
- `openspec/specs/decision-log-package/spec.md`
- `openspec/specs/local-runtime-sync/spec.md`

## Validation

- `bash ./scripts/m3-decision-log-ingest-smoke.sh`
- `bash ./scripts/package-import-automation-smoke.sh`
- `PATH="/opt/homebrew/opt/rustup/bin:$HOME/.cargo/bin:$PATH" PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`

Closes #169
