### PR TITLE
Define hosted service architecture

### DIFF
--- a/docs/hosted-service-architecture.md
+++ b/docs/hosted-service-architecture.md
@@ -1,0 +1,76 @@
+# Optional Hosted Service Architecture
+
+## Purpose
+
+Hosted youaskm3 is an optional layer for accounts, teams, permissions, hosted sync, and future hosted runtime operations. The local CLI, local knowledge root, local PWA shell, and Traverse-backed runtime remain valid when hosted service configuration is absent, expired, or unavailable.
+
+## Local-First Boundary
+
+- Hosted configuration is optional.
+- Local commands must not require hosted identity to read or write a local knowledge root.
+- Hosted outages must not block local package validation, local sync preflight, local answer context selection, or local assistant package generation.
+- Hosted features may add remote collaboration and backup, but they must not become the source of truth for local acceptance gates.
+
+## Identity Model
+
+Hosted identity and local persona identity are separate records:
+
+- Hosted account id: authenticates a user to optional hosted infrastructure.
+- Hosted team id: groups hosted accounts for collaboration.
+- Hosted permission grants: authorize hosted account access to team-owned or shared hosted scopes.
+- Local persona id: selects local knowledge, gaps, conflicts, graph context, and assistant metadata.
+
+A hosted account may operate as more than one local persona. A local persona may be used without any hosted account. Hosted permissions can grant access to hosted scopes, but they do not rewrite local persona metadata.
+
+## Teams And Permissions
+
+Hosted teams may contain:
+
+- accounts
+- roles
+- permission grants
+- hosted shared scopes
+- audit records
+
+Permissions are evaluated before hosted data is read or written. Local shared scopes still require explicit local metadata, even when a hosted team grants access. Hosted role names are not local persona ids.
+
+## Hosted Sync
+
+Hosted sync follows the same safety principles as local file-system sync:
+
+- Append-only artifacts may auto-merge when metadata proves the merge is safe.
+- Semantic conflicts become conflict records.
+- Existing knowledge is not silently overwritten.
+- Sync provenance records source device, hosted account id, team id when present, local persona id when selected, and conflict/preflight result.
+
+Hosted sync may stage remote changes before local acceptance. Final local knowledge writes still pass local validation and sync preflight.
+
+## Security And Privacy Risks
+
+Hosted operation introduces risks that local-only operation avoids:
+
+- hosted account compromise
+- team permission misconfiguration
+- accidental upload of private local persona knowledge
+- retention mismatch between local deletion and hosted backups
+- remote operator access to hosted data
+- cross-persona data exposure through incorrectly scoped shared knowledge
+
+Mitigations required before release:
+
+- explicit opt-in before any data leaves the local machine
+- least-privilege hosted permission grants
+- audit records for hosted sync and team access
+- clear local-vs-hosted provenance on synced records
+- conflict records for semantic disagreement
+- no silent promotion of private persona knowledge into hosted shared scopes
+
+## Validation Rules
+
+Hosted service work is valid only when:
+
+- local-first operation remains possible with no hosted config
+- hosted account ids remain distinct from local persona ids
+- hosted teams and permissions are modeled separately from persona metadata
+- hosted sync uses validation, provenance, preflight, and conflict records
+- security and privacy risks are documented for release decisions

--- a/openspec/specs/hosted-service/spec.md
+++ b/openspec/specs/hosted-service/spec.md
@@ -6,6 +6,8 @@ Status: Future scope, unknowns pending
 
 The hosted-service capability defines optional hosted youaskm3 services, including account management, teams, permissions, hosted sync, and hosted runtime operations, without weakening the local-first product.
 
+Hosted service support is an opt-in layer. It must not turn local persona metadata into hosted identity, and it must not replace local validation, local sync preflight, or Traverse-governed runtime acceptance.
+
 ## Requirements
 
 ### Requirement: Preserve local-first operation
@@ -17,6 +19,7 @@ The system SHALL keep local-first operation valid when hosted services are unava
 - GIVEN the user has a local knowledge root
 - WHEN hosted service configuration is absent or unavailable
 - THEN local CLI, local runtime, and local Traverse-backed workflows continue to work
+- AND hosted account, team, and permission checks are skipped because no hosted scope is being accessed
 
 ### Requirement: Separate hosted identity from local persona
 
@@ -28,6 +31,18 @@ The system SHALL define hosted accounts, teams, and permissions separately from 
 - WHEN the user accesses team knowledge
 - THEN access is governed by hosted permissions
 - AND local persona id remains distinct from hosted account id
+- AND hosted team role names do not become local persona ids
+
+### Requirement: Model hosted teams and permissions explicitly
+
+The system SHALL model hosted teams, roles, and permission grants as hosted records that authorize hosted scopes without rewriting local knowledge metadata.
+
+#### Scenario: Access hosted shared scope
+
+- GIVEN a hosted team grants a hosted account access to a shared scope
+- WHEN the user syncs that scope locally
+- THEN hosted permission metadata is recorded separately from local persona metadata
+- AND local shared-scope metadata remains explicit
 
 ### Requirement: Sync without silent conflict loss
 
@@ -39,3 +54,15 @@ The system SHALL preserve the local sync conflict model when hosted sync exists.
 - WHEN hosted sync reconciles changes
 - THEN safe append-only changes may merge
 - AND semantic conflicts become conflict records instead of silent overwrite
+- AND sync provenance records hosted account, team, device, local persona when selected, and preflight result
+
+### Requirement: Document hosted security and privacy risk
+
+The system SHALL document hosted-specific security and privacy risks before hosted service release decisions.
+
+#### Scenario: Review hosted readiness
+
+- GIVEN a release proposes hosted sync or hosted team access
+- WHEN hosted readiness is reviewed
+- THEN account compromise, permission mistakes, accidental private knowledge upload, retention, operator access, and cross-persona exposure risks are documented
+- AND mitigations require explicit opt-in before local data leaves the machine

--- a/scripts/hosted-service-smoke.sh
+++ b/scripts/hosted-service-smoke.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+DOC="docs/hosted-service-architecture.md"
+SPEC="openspec/specs/hosted-service/spec.md"
+
+[[ -f "$DOC" ]]
+grep -q '^## Local-First Boundary$' "$DOC"
+grep -q '^## Identity Model$' "$DOC"
+grep -q '^## Teams And Permissions$' "$DOC"
+grep -q '^## Hosted Sync$' "$DOC"
+grep -q '^## Security And Privacy Risks$' "$DOC"
+grep -q 'Hosted account id' "$DOC"
+grep -q 'Local persona id' "$DOC"
+grep -q 'Semantic conflicts become conflict records' "$DOC"
+grep -q 'local-first operation remains possible with no hosted config' "$DOC"
+
+grep -q 'hosted accounts, teams, and permissions separately from local persona metadata' "$SPEC"
+grep -q 'semantic conflicts become conflict records instead of silent overwrite' "$SPEC"
+
+echo "Hosted service smoke passed."

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -15,6 +15,7 @@ SPEC_FILES=(
   "openspec/specs/package-import-automation/spec.md"
   "openspec/specs/semantic-quality-evaluation/spec.md"
   "openspec/specs/multi-persona/spec.md"
+  "openspec/specs/hosted-service/spec.md"
   "openspec/specs/decision-log-package/spec.md"
   "openspec/specs/reasoning-graph/spec.md"
   "openspec/specs/knowledge-gap-lifecycle/spec.md"
@@ -137,6 +138,9 @@ bash ./scripts/semantic-quality-evaluation-smoke.sh
 
 echo "Validating multi-persona isolation..."
 bash ./scripts/multi-persona-smoke.sh
+
+echo "Validating hosted service architecture..."
+bash ./scripts/hosted-service-smoke.sh
 
 echo "Validating reasoning graph extraction..."
 bash ./scripts/reasoning-graph-extraction-smoke.sh


### PR DESCRIPTION
## Summary

- Adds hosted service architecture docs for accounts, teams, permissions, hosted sync, local-first boundaries, and privacy/security risk.
- Expands the hosted-service spec with explicit identity separation, hosted team permission modeling, sync provenance, and risk documentation requirements.
- Adds hosted-service smoke validation and wires the hosted-service spec into the full smoke gate.

## Spec References

- `openspec/specs/hosted-service/spec.md`
- `openspec/specs/local-runtime-sync/spec.md`
- `openspec/specs/multi-persona/spec.md`

## Validation

- `bash ./scripts/hosted-service-smoke.sh`
- `PATH="/opt/homebrew/opt/rustup/bin:$HOME/.cargo/bin:$PATH" PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`

Closes #172
