### PR TITLE
Add federated answer flow

### DIFF
--- a/fixtures/federated-answer/federation-search-index.json
+++ b/fixtures/federated-answer/federation-search-index.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0.0",
+  "instances": [
+    {
+      "instanceId": "remote-systems",
+      "instanceName": "Remote Systems Notes",
+      "shellUrl": "https://remote.example/"
+    }
+  ],
+  "documents": [
+    {
+      "instanceId": "remote-systems",
+      "instanceName": "Remote Systems Notes",
+      "instanceUrl": "https://remote.example/",
+      "documentId": "remote-wasm-notes",
+      "title": "Remote WASM Notes",
+      "sourcePath": "knowledge/papers/remote-wasm-notes/index.md",
+      "category": "papers",
+      "excerpt": "WASM component evidence can support federated answer exploration.",
+      "confidence": "medium"
+    }
+  ]
+}

--- a/fixtures/federated-answer/policy-disabled.json
+++ b/fixtures/federated-answer/policy-disabled.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": "1.0.0",
+  "allow_federated_answers": false
+}

--- a/fixtures/federated-answer/policy-enabled.json
+++ b/fixtures/federated-answer/policy-enabled.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": "1.0.0",
+  "allow_federated_answers": true
+}

--- a/openspec/specs/federated-answer/spec.md
+++ b/openspec/specs/federated-answer/spec.md
@@ -19,6 +19,13 @@ The system SHALL use federated indexes only when the user or configured policy e
 - THEN only local knowledge is used
 - AND no cross-instance query is performed
 
+#### Scenario: Ask with federation enabled
+
+- GIVEN federation search is explicitly allowed
+- WHEN the user asks a question that matches remote index evidence
+- THEN the remote query is recorded
+- AND returned evidence is labeled as remote
+
 ### Requirement: Preserve remote provenance
 
 The system SHALL label remote evidence distinctly from local personal knowledge.
@@ -39,3 +46,4 @@ The system SHALL allow useful federated evidence to become local knowledge only 
 - GIVEN the user wants to keep remote evidence
 - WHEN the import flow runs
 - THEN the evidence becomes a local source artifact or reasoning package with provenance back to the remote instance
+- AND imported remote evidence is not silently promoted to personal knowledge

--- a/scripts/federated-answer-smoke.sh
+++ b/scripts/federated-answer-smoke.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+cd "$ROOT_DIR"
+
+disabled_output="$(
+  ruby ./scripts/federated-answer.rb answer \
+    --query "WASM component evidence" \
+    --federation-index fixtures/federated-answer/federation-search-index.json \
+    --policy fixtures/federated-answer/policy-disabled.json \
+    --knowledge-root "$TEMP_DIR/knowledge"
+)"
+ruby -rjson -e 'data=JSON.parse(STDIN.read); abort "expected local only disabled mode" unless data.fetch("status") == "local_only" && data.fetch("remote_query_performed") == false && data.fetch("evidence").empty?' <<<"$disabled_output"
+
+enabled_file="$TEMP_DIR/enabled-answer.json"
+ruby ./scripts/federated-answer.rb answer \
+  --query "WASM component evidence" \
+  --federation-index fixtures/federated-answer/federation-search-index.json \
+  --policy fixtures/federated-answer/policy-enabled.json \
+  --knowledge-root "$TEMP_DIR/knowledge" >"$enabled_file"
+ruby -rjson -e 'data=JSON.parse(File.read(ARGV[0])); evidence=data.fetch("evidence").first; abort "expected remote evidence" unless data.fetch("status") == "remote_evidence" && evidence.fetch("evidence_kind") == "remote" && evidence.fetch("remote_instance").fetch("id") == "remote-systems" && evidence.fetch("source_artifact").fetch("id") == "remote-wasm-notes" && evidence.fetch("retrieval").fetch("path") == "federation-search-index" && evidence.key?("confidence")' "$enabled_file"
+
+import_output="$(
+  ruby ./scripts/federated-answer.rb import \
+    --evidence "$enabled_file" \
+    --knowledge-root "$TEMP_DIR/knowledge"
+)"
+ruby -rjson -e 'data=JSON.parse(STDIN.read); abort "expected import without personal knowledge promotion" unless data.fetch("status") == "imported" && data.fetch("personal_knowledge") == false' <<<"$import_output"
+[[ -f "$TEMP_DIR/knowledge/sources/federated/remote-systems/remote-wasm-notes.json" ]]
+grep -q '"personal_knowledge": false' "$TEMP_DIR/knowledge/sources/federated/remote-systems/remote-wasm-notes.json"
+grep -q '"remote_instance"' "$TEMP_DIR/knowledge/sources/federated/remote-systems/remote-wasm-notes.json"
+
+echo "Federated answer smoke passed."

--- a/scripts/federated-answer.rb
+++ b/scripts/federated-answer.rb
@@ -1,0 +1,145 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "pathname"
+require "time"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
+DEFAULT_KNOWLEDGE_ROOT = ROOT.join("knowledge")
+
+def usage
+  abort <<~USAGE
+    Usage:
+      ./scripts/m3.sh federated-answer answer --query QUERY --federation-index PATH --policy PATH [--knowledge-root PATH]
+      ./scripts/m3.sh federated-answer import --evidence PATH [--knowledge-root PATH]
+  USAGE
+end
+
+def parse_flags(argv)
+  flags = { "knowledge_root" => DEFAULT_KNOWLEDGE_ROOT.to_s }
+  until argv.empty?
+    key = argv.shift
+    usage unless key.start_with?("--")
+    flags[key.delete_prefix("--").tr("-", "_")] = argv.shift || usage
+  end
+  flags
+end
+
+def read_json(path)
+  JSON.parse(Pathname.new(path).read)
+rescue JSON::ParserError => error
+  abort "INVALID_JSON: #{path} is not valid JSON: #{error.message}"
+end
+
+def query_terms(query)
+  query.downcase.scan(/[a-z0-9]+/).reject { |term| term.length < 3 }
+end
+
+def score_document(document, terms)
+  haystack = [document["title"], document["excerpt"], document["category"]].compact.join(" ").downcase
+  terms.count { |term| haystack.include?(term) }
+end
+
+def remote_evidence(document, query, score)
+  {
+    "evidence_kind" => "remote",
+    "remote_instance" => {
+      "id" => document.fetch("instanceId"),
+      "name" => document.fetch("instanceName"),
+      "url" => document.fetch("instanceUrl")
+    },
+    "source_artifact" => {
+      "id" => document.fetch("documentId"),
+      "title" => document.fetch("title"),
+      "path" => document.fetch("sourcePath"),
+      "category" => document.fetch("category")
+    },
+    "retrieval" => {
+      "query" => query,
+      "path" => "federation-search-index",
+      "score" => score
+    },
+    "confidence" => document.fetch("confidence", "unknown"),
+    "excerpt" => document.fetch("excerpt")
+  }
+end
+
+def answer(flags)
+  query = flags.fetch("query")
+  policy = read_json(flags.fetch("policy"))
+  unless policy.fetch("allow_federated_answers", false)
+    puts JSON.pretty_generate(
+      {
+        "status" => "local_only",
+        "federated_answers_allowed" => false,
+        "remote_query_performed" => false,
+        "answer" => "Federated answers are disabled; use local knowledge only.",
+        "evidence" => []
+      }
+    )
+    return
+  end
+
+  index = read_json(flags.fetch("federation_index"))
+  terms = query_terms(query)
+  evidence = index.fetch("documents").map do |document|
+    score = score_document(document, terms)
+    score.positive? ? remote_evidence(document, query, score) : nil
+  end.compact.sort_by { |item| -item.fetch("retrieval").fetch("score") }
+
+  puts JSON.pretty_generate(
+    {
+      "status" => evidence.empty? ? "no_remote_evidence" : "remote_evidence",
+      "federated_answers_allowed" => true,
+      "remote_query_performed" => true,
+      "answer" => evidence.empty? ? "No federated evidence matched." : "Federated evidence is available, but it is not personal knowledge unless explicitly imported.",
+      "evidence" => evidence
+    }
+  )
+end
+
+def slug(value)
+  value.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-+|-+\z/, "")
+end
+
+def import(flags)
+  evidence = read_json(flags.fetch("evidence"))
+  first = evidence.fetch("evidence").find { |item| item.fetch("evidence_kind") == "remote" } ||
+    abort("REMOTE_EVIDENCE_MISSING: evidence file does not contain remote evidence")
+  knowledge_root = Pathname.new(flags.fetch("knowledge_root")).expand_path
+  instance_id = first.fetch("remote_instance").fetch("id")
+  artifact_id = first.fetch("source_artifact").fetch("id")
+  path = knowledge_root.join("sources", "federated", slug(instance_id), "#{slug(artifact_id)}.json")
+  FileUtils.mkdir_p(path.dirname)
+  record = {
+    "schema_version" => "1.0.0",
+    "kind" => "federated_source_artifact",
+    "ingestion_status" => "imported_remote_evidence",
+    "personal_knowledge" => false,
+    "imported_at" => Time.now.utc.iso8601,
+    "remote_provenance" => first
+  }
+  path.write(JSON.pretty_generate(record) + "\n")
+  puts JSON.pretty_generate(
+    {
+      "status" => "imported",
+      "path" => path.relative_path_from(ROOT).to_s,
+      "remote_instance_id" => instance_id,
+      "source_artifact_id" => artifact_id,
+      "personal_knowledge" => false
+    }
+  )
+end
+
+command = ARGV.shift || usage
+flags = parse_flags(ARGV)
+case command
+when "answer"
+  answer(flags)
+when "import"
+  import(flags)
+else
+  usage
+end

--- a/scripts/m3.sh
+++ b/scripts/m3.sh
@@ -7,7 +7,7 @@ COMMAND="${1:-}"
 cd "$ROOT_DIR"
 
 usage() {
-  echo "Usage: ./scripts/m3.sh {init|add|ingest-decision-log|import-decision-log|semantic-quality|build|sync|search|serve|mvp-check|test|lint|smoke|status}" >&2
+  echo "Usage: ./scripts/m3.sh {init|add|ingest-decision-log|import-decision-log|semantic-quality|federated-answer|build|sync|search|serve|mvp-check|test|lint|smoke|status}" >&2
 }
 
 slugify_url() {
@@ -93,6 +93,10 @@ case "$COMMAND" in
   semantic-quality)
     shift
     ruby ./scripts/semantic-quality-evaluation.rb "$@"
+    ;;
+  federated-answer)
+    shift
+    ruby ./scripts/federated-answer.rb "$@"
     ;;
   build)
     bash ./scripts/build.sh

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -16,6 +16,7 @@ SPEC_FILES=(
   "openspec/specs/semantic-quality-evaluation/spec.md"
   "openspec/specs/multi-persona/spec.md"
   "openspec/specs/hosted-service/spec.md"
+  "openspec/specs/federated-answer/spec.md"
   "openspec/specs/decision-log-package/spec.md"
   "openspec/specs/reasoning-graph/spec.md"
   "openspec/specs/knowledge-gap-lifecycle/spec.md"
@@ -156,6 +157,9 @@ bash ./scripts/answer-context-selector-smoke.sh
 
 echo "Validating federation index generation..."
 bash ./scripts/federation-index-smoke.sh
+
+echo "Validating federated answer flows..."
+bash ./scripts/federated-answer-smoke.sh
 
 echo "Running Rust tests..."
 bash ./scripts/test.sh


### PR DESCRIPTION
## Summary

- Adds `m3 federated-answer answer` with explicit disabled/enabled federation policy handling.
- Labels remote evidence separately from local knowledge with remote instance, source artifact, retrieval path, and confidence provenance.
- Adds `m3 federated-answer import` to preserve remote provenance without silently promoting remote evidence to personal knowledge.
- Adds fixtures, focused smoke coverage, and full smoke wiring for federated answer flows.

## Spec References

- `openspec/specs/federated-answer/spec.md`
- `openspec/specs/federation/spec.md`
- `openspec/specs/reasoning-graph/spec.md`

## Validation

- `ruby -c scripts/federated-answer.rb`
- `bash ./scripts/federated-answer-smoke.sh`
- `PATH="/opt/homebrew/opt/rustup/bin:$HOME/.cargo/bin:$PATH" PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`

Closes #173
