### PR TITLE
Add WASM-native model evidence gate

### DIFF
--- a/docs/wasm-native-model-evidence.md
+++ b/docs/wasm-native-model-evidence.md
@@ -1,0 +1,55 @@
+# WASM-Native Model Engine Evidence
+
+## Purpose
+
+youaskm3 can already require Traverse-governed inference selection, placement, trace evidence, and failure handling. That is not the same as proving that the model engine itself runs as WASM.
+
+Until Traverse exposes stable model-engine execution evidence, release notes and readiness reports must keep the first-MVP caveat: inference is Traverse-governed, but the model engine is not proven WASM-native.
+
+## Required Evidence
+
+A positive WASM-native model-engine claim requires Traverse evidence with all of these fields:
+
+- `traverse_version`
+- `inference_dependency_id`
+- `selected_candidate_id`
+- `model_dependency_id`
+- `model_engine_wasm_native: true`
+- `module_identity`
+- `module_sha256`, as a SHA-256 digest
+- `model_asset_id`
+- `model_asset_sha256`, as a SHA-256 digest
+- `runtime_placement: wasm`
+- `execution_trace_id`
+- `failure_mode: null`
+
+If any required positive evidence is absent, the readiness validator must fail a positive WASM-native model-engine claim.
+
+## Supported Distinction
+
+Governed inference evidence may prove:
+
+- Traverse selected an inference dependency.
+- Traverse recorded placement and trace evidence.
+- Traverse reported selected or rejected candidates.
+- youaskm3 did not hardcode downstream provider selection.
+
+WASM-native model-engine evidence must additionally prove:
+
+- the engine module identity
+- the engine module digest
+- the model asset identity
+- the model asset digest
+- WASM runtime placement
+- the model dependency id connected to that execution
+- the public trace id for the execution
+- no failure mode for the claimed successful execution
+
+## Readiness Policy
+
+The readiness validator supports two release postures:
+
+- Caveated posture: `--claim-wasm-native false`; governed inference may pass while the WASM-native model caveat remains.
+- Positive posture: `--claim-wasm-native true`; the validator fails unless required Traverse evidence proves model-engine WASM-native execution.
+
+This keeps unsupported WASM-native model claims out of docs, release notes, and acceptance reports.

--- a/fixtures/wasm-native-model-evidence/governed-only.json
+++ b/fixtures/wasm-native-model-evidence/governed-only.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "1.0.0",
+  "traverse_version": "v0.5.0",
+  "inference_dependency_id": "knowledge.infer",
+  "selected_candidate_id": "local-ollama-llama-3-2",
+  "model_dependency_id": "llama3.2:3b",
+  "traverse_governed_inference": true,
+  "model_engine_wasm_native": false,
+  "runtime_placement": "local-provider",
+  "execution_trace_id": "trace-governed-only",
+  "failure_mode": null
+}

--- a/fixtures/wasm-native-model-evidence/wasm-native.json
+++ b/fixtures/wasm-native-model-evidence/wasm-native.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "1.0.0",
+  "traverse_version": "v0.6.0",
+  "inference_dependency_id": "knowledge.infer",
+  "selected_candidate_id": "wasm-native-llama",
+  "model_dependency_id": "llama-wasm-fixture",
+  "traverse_governed_inference": true,
+  "model_engine_wasm_native": true,
+  "module_identity": "traverse.agent.model.llama-wasm",
+  "module_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "model_asset_id": "llama-wasm-fixture-weights",
+  "model_asset_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "runtime_placement": "wasm",
+  "execution_trace_id": "trace-wasm-native-model",
+  "failure_mode": null
+}

--- a/openspec/specs/wasm-native-model-evidence/spec.md
+++ b/openspec/specs/wasm-native-model-evidence/spec.md
@@ -1,16 +1,18 @@
 # wasm-native-model-evidence Specification
 
-Status: Future scope, unknowns pending
+Status: Future scope, planning decisions recorded
 
 ## Purpose
 
 The wasm-native-model-evidence capability defines how youaskm3 will prove, when Traverse supports it, that model-engine execution itself is WASM-native instead of only Traverse-governed through dependency resolution and placement.
 
+Normal releases may claim Traverse-governed inference. Only releases that claim fully WASM-native inference must pass this evidence gate.
+
 ## Requirements
 
 ### Requirement: Distinguish governed inference from WASM-native model engine execution
 
-The system SHALL keep the first-MVP caveat explicit until Traverse exposes stable evidence that the model engine itself runs as WASM.
+The system SHALL keep the first-MVP caveat explicit until Traverse exposes stable evidence that the model runtime engine executes as a WASM module and model assets are digest-traceable.
 
 #### Scenario: Report current inference mode
 
@@ -21,21 +23,35 @@ The system SHALL keep the first-MVP caveat explicit until Traverse exposes stabl
 
 ### Requirement: Define required Traverse evidence
 
-The system SHALL document the Traverse evidence needed before claiming WASM-native model-engine execution.
+The system SHALL document the Traverse evidence needed before claiming fully WASM-native inference.
 
 #### Scenario: Verify model engine evidence
 
 - GIVEN Traverse exposes model-engine execution evidence
 - WHEN youaskm3 readiness validation runs
-- THEN validation checks module identity, digest, runtime placement, execution trace, model dependency id, and failure mode
+- THEN validation checks WASM engine/module identity, engine/module digest, model/weights asset id, model/weights digest, placement target, execution trace id, model dependency id, selected provider or candidate id, and failure mode
 
 ### Requirement: Fail closed on unsupported claims
 
-The system SHALL fail readiness if docs or release notes claim WASM-native model-engine execution without matching Traverse evidence.
+The system SHALL fail readiness if docs or release notes claim fully WASM-native inference without matching Traverse evidence.
 
 #### Scenario: Unsupported claim detected
 
-- GIVEN a release note claims WASM-native model-engine execution
+- GIVEN a release note claims fully WASM-native inference
 - AND readiness evidence does not prove it
 - WHEN validation runs
 - THEN the gate fails with a stable unsupported-claim error
+
+#### Scenario: Positive evidence passes
+
+- GIVEN Traverse evidence includes WASM engine/module identity, engine/module digest, model/weights asset id, model/weights digest, placement target, execution trace id, model dependency id, selected provider or candidate id, and null failure mode
+- AND readiness explicitly claims fully WASM-native inference
+- WHEN validation runs
+- THEN the gate passes the positive WASM-native model-engine claim
+
+#### Scenario: Traverse-governed inference release
+
+- GIVEN a release claims Traverse-governed inference but not fully WASM-native inference
+- WHEN readiness validation runs
+- THEN WASM-native model-engine evidence is not required
+- AND docs preserve the distinction between governed inference and fully WASM-native inference

--- a/scripts/m3.sh
+++ b/scripts/m3.sh
@@ -7,7 +7,7 @@ COMMAND="${1:-}"
 cd "$ROOT_DIR"
 
 usage() {
-  echo "Usage: ./scripts/m3.sh {init|add|ingest-decision-log|import-decision-log|semantic-quality|federated-answer|build|sync|search|serve|mvp-check|test|lint|smoke|status}" >&2
+  echo "Usage: ./scripts/m3.sh {init|add|ingest-decision-log|import-decision-log|semantic-quality|federated-answer|wasm-native-model-evidence|build|sync|search|serve|mvp-check|test|lint|smoke|status}" >&2
 }
 
 slugify_url() {
@@ -97,6 +97,10 @@ case "$COMMAND" in
   federated-answer)
     shift
     ruby ./scripts/federated-answer.rb "$@"
+    ;;
+  wasm-native-model-evidence)
+    shift
+    ruby ./scripts/wasm-native-model-evidence.rb "$@"
     ;;
   build)
     bash ./scripts/build.sh

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -17,6 +17,7 @@ SPEC_FILES=(
   "openspec/specs/multi-persona/spec.md"
   "openspec/specs/hosted-service/spec.md"
   "openspec/specs/federated-answer/spec.md"
+  "openspec/specs/wasm-native-model-evidence/spec.md"
   "openspec/specs/decision-log-package/spec.md"
   "openspec/specs/reasoning-graph/spec.md"
   "openspec/specs/knowledge-gap-lifecycle/spec.md"
@@ -160,6 +161,9 @@ bash ./scripts/federation-index-smoke.sh
 
 echo "Validating federated answer flows..."
 bash ./scripts/federated-answer-smoke.sh
+
+echo "Validating WASM-native model evidence..."
+bash ./scripts/wasm-native-model-evidence-smoke.sh
 
 echo "Running Rust tests..."
 bash ./scripts/test.sh

--- a/scripts/wasm-native-model-evidence-smoke.sh
+++ b/scripts/wasm-native-model-evidence-smoke.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+ruby ./scripts/wasm-native-model-evidence.rb validate \
+  --evidence fixtures/wasm-native-model-evidence/governed-only.json \
+  --claim-wasm-native false \
+  | ruby -rjson -e 'data=JSON.parse(STDIN.read); abort "expected caveated governed inference" unless data.fetch("status") == "traverse_governed_with_wasm_native_caveat" && data.fetch("model_engine_wasm_native") == false'
+
+if ruby ./scripts/wasm-native-model-evidence.rb validate \
+  --evidence fixtures/wasm-native-model-evidence/governed-only.json \
+  --claim-wasm-native true >/tmp/wasm-native-unsupported.json; then
+  echo "Expected unsupported WASM-native model claim to fail." >&2
+  exit 1
+fi
+ruby -rjson -e 'data=JSON.parse(File.read("/tmp/wasm-native-unsupported.json")); abort "expected unsupported claim code" unless data.fetch("code") == "UNSUPPORTED_WASM_NATIVE_MODEL_CLAIM"'
+
+ruby ./scripts/wasm-native-model-evidence.rb validate \
+  --evidence fixtures/wasm-native-model-evidence/wasm-native.json \
+  --claim-wasm-native true \
+  | ruby -rjson -e 'data=JSON.parse(STDIN.read); abort "expected positive WASM-native proof" unless data.fetch("status") == "wasm_native_model_engine_proven" && data.fetch("model_engine_wasm_native") == true'
+
+grep -q 'model engine itself runs as WASM' docs/wasm-native-model-evidence.md
+grep -q 'Docs preserve the WASM-native model caveat until Traverse proves that path.' docs/mvp-local-inference-policy.md
+
+echo "WASM-native model evidence smoke passed."

--- a/scripts/wasm-native-model-evidence.rb
+++ b/scripts/wasm-native-model-evidence.rb
@@ -1,0 +1,103 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "pathname"
+
+REQUIRED_POSITIVE_FIELDS = [
+  "traverse_version",
+  "inference_dependency_id",
+  "selected_candidate_id",
+  "model_dependency_id",
+  "module_identity",
+  "module_sha256",
+  "model_asset_id",
+  "model_asset_sha256",
+  "runtime_placement",
+  "execution_trace_id",
+  "failure_mode"
+].freeze
+
+def usage
+  abort "Usage: ruby scripts/wasm-native-model-evidence.rb validate --evidence PATH --claim-wasm-native true|false"
+end
+
+def parse_flags(argv)
+  flags = {}
+  until argv.empty?
+    key = argv.shift
+    usage unless key.start_with?("--")
+    flags[key.delete_prefix("--").tr("-", "_")] = argv.shift || usage
+  end
+  flags
+end
+
+def stable_failure(code, message)
+  puts JSON.pretty_generate(
+    {
+      "status" => "failed",
+      "code" => code,
+      "message" => message
+    }
+  )
+  exit 1
+end
+
+def read_json(path)
+  JSON.parse(Pathname.new(path).read)
+rescue JSON::ParserError => error
+  stable_failure("INVALID_EVIDENCE_JSON", "Evidence JSON is invalid: #{error.message}")
+end
+
+def valid_digest?(value)
+  value.to_s.match?(/\A[a-f0-9]{64}\z/)
+end
+
+def validate_positive_claim!(evidence)
+  unless evidence["traverse_governed_inference"] == true
+    stable_failure("UNSUPPORTED_WASM_NATIVE_MODEL_CLAIM", "Traverse-governed inference evidence is required before claiming WASM-native model execution.")
+  end
+  unless evidence["model_engine_wasm_native"] == true
+    stable_failure("UNSUPPORTED_WASM_NATIVE_MODEL_CLAIM", "Model engine evidence does not prove WASM-native execution.")
+  end
+
+  missing = REQUIRED_POSITIVE_FIELDS.reject { |field| evidence.key?(field) }
+  stable_failure("WASM_NATIVE_MODEL_EVIDENCE_MISSING", "Missing required evidence fields: #{missing.join(", ")}") unless missing.empty?
+
+  unless evidence["runtime_placement"] == "wasm"
+    stable_failure("UNSUPPORTED_WASM_NATIVE_MODEL_CLAIM", "Runtime placement must be wasm for WASM-native model-engine claims.")
+  end
+  stable_failure("WASM_NATIVE_MODEL_DIGEST_INVALID", "module_sha256 must be a lowercase SHA-256 digest.") unless valid_digest?(evidence["module_sha256"])
+  stable_failure("WASM_NATIVE_MODEL_DIGEST_INVALID", "model_asset_sha256 must be a lowercase SHA-256 digest.") unless valid_digest?(evidence["model_asset_sha256"])
+  unless evidence["failure_mode"].nil?
+    stable_failure("UNSUPPORTED_WASM_NATIVE_MODEL_CLAIM", "Successful WASM-native model-engine claims require failure_mode to be null.")
+  end
+end
+
+command = ARGV.shift || usage
+usage unless command == "validate"
+flags = parse_flags(ARGV)
+usage unless flags["evidence"] && ["true", "false"].include?(flags["claim_wasm_native"])
+
+evidence = read_json(flags.fetch("evidence"))
+unless evidence["schema_version"] == "1.0.0"
+  stable_failure("UNSUPPORTED_EVIDENCE_SCHEMA", "Evidence schema_version must be 1.0.0.")
+end
+
+claim_wasm_native = flags.fetch("claim_wasm_native") == "true"
+if claim_wasm_native
+  validate_positive_claim!(evidence)
+  status = "wasm_native_model_engine_proven"
+else
+  status = evidence["traverse_governed_inference"] ? "traverse_governed_with_wasm_native_caveat" : "inference_not_governed"
+end
+
+puts JSON.pretty_generate(
+  {
+    "status" => status,
+    "claim_wasm_native" => claim_wasm_native,
+    "traverse_governed_inference" => evidence["traverse_governed_inference"] == true,
+    "model_engine_wasm_native" => evidence["model_engine_wasm_native"] == true,
+    "required_positive_fields" => REQUIRED_POSITIVE_FIELDS
+  }
+)


### PR DESCRIPTION
## Summary

- Adds a WASM-native model-engine evidence contract and readiness validator.
- Keeps Traverse-governed inference distinct from positive WASM-native model-engine claims.
- Adds governed-only and positive WASM-native fixtures covering unsupported and supported validation paths.
- Wires focused smoke coverage and the governing spec into full smoke.

## Spec References

- `openspec/specs/wasm-native-model-evidence/spec.md`
- `docs/mvp-local-inference-policy.md`
- `openspec/specs/traverse-integration/spec.md`

## Validation

- `ruby -c scripts/wasm-native-model-evidence.rb`
- `bash ./scripts/wasm-native-model-evidence-smoke.sh`
- `PATH="/opt/homebrew/opt/rustup/bin:$HOME/.cargo/bin:$PATH" PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`

Closes #174
