### PR TITLE
Record resolved future planning decisions

### DIFF
--- a/docs/expanded-second-brain-mvp-decision-log.md
+++ b/docs/expanded-second-brain-mvp-decision-log.md
@@ -123,3 +123,61 @@ The following items remain outside the first MVP but are no longer undocumented:
 - Evidence required before claiming model-engine execution itself is WASM-native.
 
 These items are captured by future-scope OpenSpec files and FUTURE-001 through FUTURE-007 in `docs/mvp-ticket-backlog.md`.
+
+## Future-Scope Unknowns Resolved
+
+The following planning decisions were approved after the future-scope tickets were created:
+
+### Multi-Persona
+
+- A persona is a knowledge identity. It can represent a real person, role/context, project, or domain-specific thinking identity.
+- Persona is distinct from hosted account.
+- Multi-persona uses a hybrid graph model: isolated persona scopes by default plus explicit shared scopes.
+- Chat uses a configured default persona and explicit persona switching. The runtime must not silently infer/switch persona from message content.
+- Shared scopes are read-only by default and writable only through explicit policy.
+- Reasoning packages can target either a persona scope or an explicit shared scope.
+- Conflict visibility follows scope visibility: mutually visible conflicts can use shared conflict records; hidden scopes use persona-local conflict records.
+- Full multi-persona behavior remains future scope, but current schemas reserve `persona_id`, `scope_id`, and target scope fields.
+
+### Assistant Distribution
+
+- Assistant distribution starts as generated platform artifact bundles, not marketplace-ready packages and not only copy/paste instructions.
+- ChatGPT and Claude remain equal golden targets.
+- Bundles include a small example suite for `knowledge_addition`, `gap_resolution`, and `conflict_resolution`.
+- Bundles produce files for CLI ingestion first. Optional platform action/tool integration is later and must not bypass validation or Traverse-governed ingestion.
+
+### WASM-Native Model Evidence
+
+- WASM-native model engine execution means a WASM-governed runtime engine plus digest-traceable model assets.
+- Evidence must include engine/module identity and digest, model/weights id and digest, placement target, trace id, model dependency id, selected candidate/provider id, and failure mode.
+- WASM-native model evidence is required only for releases that claim fully WASM-native inference.
+- Normal releases may claim Traverse-governed inference while preserving the model-engine caveat.
+
+### Hosted Service
+
+- Hosted service is an optional hosted convenience layer over the local-first core.
+- Nothing leaves the user's machine by default.
+- Hosted features require explicit setup and consent.
+- Personal hosted sync defaults to end-to-end encrypted blobs.
+- Raw readable content or team/shared modes require explicit opt-in and policy.
+- Hosted runtime execution is allowed only per explicit capability policy and must remain Traverse-governed with trace evidence.
+
+### Import Automation
+
+- Archive ingestion comes before inbox/watch-folder automation.
+- First archive format is `.zip`; tar formats are later only if needed.
+- Inbox processing starts as an explicit command, not background watching.
+- Optional watcher behavior is later and must use the same validation path.
+
+### Semantic Quality
+
+- Generic answer benchmark is required and committed.
+- Persona-specific benchmark is optional/local/private.
+- Benchmark release gates cover full trust behavior: correctness, grounding, provenance, unsupported claim rate, conflict disclosure, gap creation behavior, and citation completeness.
+- Claim-level partial ingestion uses deterministic claim extraction plus optional Traverse-governed semantic refinement.
+
+### Federated Answers
+
+- Federated answers can appear in the same chat only when explicitly enabled per question or session.
+- Remote evidence is lower-trust, evidence-only by default.
+- Importing remote evidence has two paths: source artifact for saved reference, or decision-log package for adopted personal reasoning.

--- a/docs/mvp-ticket-backlog.md
+++ b/docs/mvp-ticket-backlog.md
@@ -1862,14 +1862,22 @@ Turn generated ChatGPT, Claude, and future assistant adapters into packaged, ver
 - Packaged artifacts are generated from canonical skill/adapters, not hand-edited copies.
 - Drift checks fail when canonical skill, adapter, or schema versions change without regenerated packages.
 - Package docs list each platform's known limitations and blocked capabilities.
+- ChatGPT and Claude are both treated as equal golden targets.
+- Bundles include examples for `knowledge_addition`, `gap_resolution`, and `conflict_resolution`.
+- Bundles produce package files for CLI ingestion without requiring platform action/tool integration.
 - No package hardcodes private user paths or private knowledge.
 - Validation passes.
 
-### Unknowns To Discuss
+### Resolved Planning Decisions
 
-- Which platform should be packaged first for real distribution?
-- What exact packaging format does each platform require at that time?
-- Should marketplace publication be part of this ticket or a later release ticket?
+- Distribution starts as generated platform artifact bundles, not marketplace-ready publishing.
+- ChatGPT and Claude are equal golden targets.
+- Marketplace publication and platform action/tool integration are later scope.
+
+### Remaining Unknowns To Discuss
+
+- What exact packaging format does each platform require at implementation time?
+- Should marketplace publication become a separate release ticket once package artifacts are stable?
 
 ## Ticket FUTURE-002: Add Archive and Inbox Decision-Log Import Automation ([#169](https://github.com/enricopiovesan/youaskm3/issues/169))
 
@@ -1893,16 +1901,24 @@ Add convenience import flows for decision-log packages after the canonical CLI d
 ### Definition of Done
 
 - Archive ingestion rejects unsafe paths, oversized packages, missing files, and invalid metadata before writes.
+- `.zip` is the first supported archive format.
+- Unsupported archive formats fail with stable errors.
 - Inbox processing can be enabled explicitly and does not silently ingest final knowledge without validation.
+- First inbox processing is command-driven, not a background watcher.
 - Automated imports can be reproduced through the canonical CLI command.
 - Validation and error messages match package directory ingestion semantics.
 - Tests cover safe archive, traversal attack, invalid archive, inbox success, inbox rejection, and offline staging.
 - Validation passes.
 
-### Unknowns To Discuss
+### Resolved Planning Decisions
 
-- Which archive formats are worth supporting first?
-- Should inbox processing be polling, explicit command, or filesystem watcher?
+- Archive ingestion comes first.
+- `.zip` is first; tar formats are later only if needed.
+- Inbox processing starts as an explicit command; watcher behavior is later.
+
+### Remaining Unknowns To Discuss
+
+- What should the explicit inbox command be named?
 - How much user confirmation is required before final ingestion from automation?
 
 ## Ticket FUTURE-003: Add Claim-Level Partial Ingestion and Answer Benchmarks ([#170](https://github.com/enricopiovesan/youaskm3/issues/170))
@@ -1928,18 +1944,27 @@ Move beyond first-MVP all-or-nothing semantic validation by supporting claim-lev
 ### Definition of Done
 
 - Claim-level validation schema exists.
+- Deterministic claim extraction is required.
+- Optional Traverse-governed semantic refinement is supported when available.
 - Partial ingestion records accepted and rejected claims with provenance.
 - Rejected claims create or update gaps instead of disappearing.
-- Benchmarks run deterministically and do not mutate personal knowledge.
+- Generic benchmarks run deterministically and do not mutate personal knowledge.
+- Persona-specific benchmarks are optional, local, and private.
 - Benchmark reports are useful for release quality decisions.
+- Release gates cover correctness, grounding, provenance, unsupported claim rate, conflict disclosure, gap creation behavior, and citation completeness.
 - Tests cover partial package ingestion, rejected claim gap creation, and benchmark reporting.
 - Validation passes.
 
-### Unknowns To Discuss
+### Resolved Planning Decisions
 
-- What answer-quality thresholds should block release?
-- Which semantic validator or Traverse agent is acceptable for claim-level review?
-- Should benchmark corpora be generic, project-specific, or persona-specific?
+- Generic benchmark is required; persona-specific benchmark is optional/local.
+- Release-blocking benchmark dimensions cover full trust behavior.
+- Claim extraction is deterministic with optional Traverse-governed semantic refinement.
+
+### Remaining Unknowns To Discuss
+
+- What numeric answer-quality thresholds should block release?
+- Which Traverse semantic validator/agent is acceptable for refinement?
 
 ## Ticket FUTURE-004: Support Multi-Persona Knowledge Isolation and Sharing ([#171](https://github.com/enricopiovesan/youaskm3/issues/171))
 
@@ -1964,18 +1989,28 @@ Support multiple personas in one installation while preserving isolation, proven
 ### Definition of Done
 
 - Multiple personas can exist in one installation.
+- A persona is a knowledge identity, distinct from hosted account.
 - Answer context uses only the active persona's allowed scope.
-- Shared scopes require explicit metadata.
-- Conflicts between persona-specific and shared knowledge are visible.
+- Hybrid graph model isolates persona scopes by default and supports explicit shared scopes.
+- Shared scopes require explicit metadata and are read-only by default.
+- Shared-scope writes require explicit policy.
+- Conflicts follow scope visibility.
+- Default persona plus explicit chat/CLI switch are supported; no silent persona inference occurs.
 - Assistant adapters can include persona metadata without embedding private knowledge content.
 - Tests cover isolated personas, shared scope, conflict visibility, and provenance.
 - Validation passes.
 
-### Unknowns To Discuss
+### Resolved Planning Decisions
 
-- Is a persona a person, a role, a project, or all three?
-- Should personas share one graph with scopes or separate graphs?
-- How should persona switching work in chat and CLI?
+- Persona is a knowledge identity: person, role, project, or domain identity.
+- Graph model is hybrid: isolated persona scopes plus explicit shared scopes.
+- Active persona uses default persona plus explicit switch.
+- Full behavior is future scope, but schemas reserve persona/scope fields now.
+
+### Remaining Unknowns To Discuss
+
+- What exact CLI/chat syntax should switch personas?
+- How should shared-scope write policies be expressed?
 
 ## Ticket FUTURE-005: Define Optional Hosted Service, Accounts, Teams, and Hosted Sync ([#172](https://github.com/enricopiovesan/youaskm3/issues/172))
 
@@ -2000,16 +2035,27 @@ Define optional hosted youaskm3 capabilities without weakening local-first opera
 
 - Hosted service architecture spec exists for accounts, teams, permissions, and hosted sync.
 - Local-first operation remains valid without hosted config.
+- Nothing leaves the user's machine by default.
+- Hosted features require explicit opt-in and state what data leaves the machine.
 - Hosted identity and local persona metadata are separate.
+- Personal hosted sync defaults to end-to-end encrypted blobs.
+- Raw readable or team/shared hosted modes require explicit policy and consent.
+- Hosted runtime execution is allowed only per explicit capability placement policy.
 - Hosted sync uses the same semantic conflict principles as local sync.
 - Security and privacy risks are documented before implementation.
 - Validation passes for docs/spec checks.
 
-### Unknowns To Discuss
+### Resolved Planning Decisions
 
-- Is hosted service part of the commercial product or optional community infrastructure?
+- Hosted service is an optional hosted convenience layer over the local-first core.
+- Nothing leaves the machine by default.
+- Hosted sync is mode-specific: encrypted personal sync by default, raw/shared/team modes by explicit opt-in.
+- Hosted runtime is per-capability, explicit, and Traverse-governed.
+
+### Remaining Unknowns To Discuss
+
 - What identity provider and permission model are acceptable?
-- What data, if any, may leave the user's machine by default?
+- Which hosted capabilities are worth implementing first?
 
 ## Ticket FUTURE-006: Add Federated Cross-Instance Answer Flows ([#173](https://github.com/enricopiovesan/youaskm3/issues/173))
 
@@ -2033,17 +2079,25 @@ Extend existing federation registry and index work into explicit cross-instance 
 ### Definition of Done
 
 - Federated answer policy is explicit and disabled unless allowed.
+- Federated answers can appear in the same chat only when explicitly enabled per question or session.
 - Answers distinguish local evidence from remote instance evidence.
+- Remote evidence is lower-trust, evidence-only by default.
 - Remote evidence is never silently treated as personal knowledge.
-- Import from remote evidence preserves source provenance.
+- Import from remote evidence can save a source artifact or create a decision-log package for adopted personal reasoning.
+- Import preserves source provenance.
 - Tests cover disabled federation, remote-evidence answer, and explicit import path.
 - Validation passes.
 
-### Unknowns To Discuss
+### Resolved Planning Decisions
 
-- Should federated answers be available in the same chat or a separate explore mode?
-- What trust model applies to remote instance evidence?
+- Federated answers are same-chat only when explicitly enabled.
+- Remote evidence is lower-trust evidence-only by default.
+- Remote import supports source artifact and decision-log package paths.
+
+### Remaining Unknowns To Discuss
+
 - How should remote content licensing and removal be handled?
+- What UI control enables federation per question/session?
 
 ## Ticket FUTURE-007: Prove WASM-Native Model-Engine Execution When Traverse Supports It ([#174](https://github.com/enricopiovesan/youaskm3/issues/174))
 
@@ -2067,17 +2121,22 @@ Define and validate the evidence required before youaskm3 claims the model engin
 ### Definition of Done
 
 - Docs clearly distinguish governed inference from WASM-native model-engine execution.
-- Required Traverse evidence contract is documented.
-- Readiness validation fails if release notes or docs claim WASM-native model execution without evidence.
+- Required Traverse evidence contract includes engine/module identity and digest, model/weights id and digest, placement target, trace id, dependency id, selected provider/candidate id, and failure mode.
+- Readiness validation fails if release notes or docs claim fully WASM-native inference without evidence.
 - Positive validation passes when Traverse exposes stable model-engine WASM evidence.
 - Tests cover unsupported claim failure and supported evidence success.
 - Validation passes.
 
-### Unknowns To Discuss
+### Resolved Planning Decisions
 
-- What exact Traverse trace fields will prove WASM-native model-engine execution?
-- Is a WASI model runtime enough, or must weights/runtime/engine all be WASM-packaged?
-- Should this block a future release or remain an advanced conformance badge?
+- WASM-native model execution means WASM-governed runtime engine plus digest-traceable model assets.
+- Fully WASM-native inference evidence is required only for releases that claim fully WASM-native inference.
+- Normal releases may claim Traverse-governed inference while preserving the model-engine caveat.
+
+### Remaining Unknowns To Discuss
+
+- What exact Traverse trace field names will expose the required evidence?
+- Should fully WASM-native inference become a release blocker later or remain a conformance badge?
 
 ## First Tickets to Start
 

--- a/openspec/specs/assistant-distribution/spec.md
+++ b/openspec/specs/assistant-distribution/spec.md
@@ -1,10 +1,12 @@
 # assistant-distribution Specification
 
-Status: Future scope, unknowns pending
+Status: Future scope, planning decisions recorded
 
 ## Purpose
 
 The assistant-distribution capability defines how generated reasoning-skill adapters become packaged, installable, and versioned artifacts for ChatGPT, Claude, and future assistant platforms without changing the LLM-agnostic canonical skill source.
+
+The first distribution target is a generated platform artifact bundle, not a marketplace-ready package and not only copy/paste instructions. ChatGPT and Claude are equal golden targets.
 
 ## Requirements
 
@@ -18,6 +20,14 @@ The system SHALL treat platform packaging as distribution metadata around genera
 - WHEN a ChatGPT package artifact is produced
 - THEN it preserves the generated adapter instructions, decision-log package rules, and generic CLI handoff
 - AND any platform-specific manifest fields are generated from explicit packaging metadata
+
+#### Scenario: Package both golden targets
+
+- GIVEN the canonical skill source changes
+- WHEN package generation runs
+- THEN ChatGPT and Claude artifact bundles are generated from the same canonical source
+- AND both must pass drift checks
+- AND platform-specific limitations are documented separately instead of changing core behavior
 
 ### Requirement: Version distributed assistant packages
 
@@ -40,3 +50,26 @@ The system SHALL document platform-specific packaging limits such as file export
 - WHEN packaging validation runs
 - THEN the artifact is marked blocked for that platform
 - AND the canonical skill remains valid for other platforms
+
+### Requirement: Include example package suite
+
+The system SHALL include runnable examples in assistant distribution bundles.
+
+#### Scenario: Validate assistant examples
+
+- GIVEN a generated assistant bundle exists
+- WHEN its example suite is checked
+- THEN it includes examples for `knowledge_addition`, `gap_resolution`, and `conflict_resolution`
+- AND each example includes generated `decision-log.md`, `knowledge-note.md`, `metadata.json`, and expected CLI validation result
+
+### Requirement: Produce files before platform actions
+
+The system SHALL make package file output the first distribution baseline and keep platform action/tool integrations optional future work.
+
+#### Scenario: Use distributed assistant without platform action
+
+- GIVEN a user uses the generated ChatGPT or Claude bundle
+- WHEN a reasoning session finalizes
+- THEN the assistant produces files for CLI ingestion
+- AND no platform action/tool integration is required
+- AND future action/tool integrations must not bypass package validation or Traverse-governed ingestion

--- a/openspec/specs/federated-answer/spec.md
+++ b/openspec/specs/federated-answer/spec.md
@@ -1,16 +1,18 @@
 # federated-answer Specification
 
-Status: Future scope, unknowns pending
+Status: Future scope, planning decisions recorded
 
 ## Purpose
 
 The federated-answer capability extends the existing federation registry and shared index work into cross-instance search and answer flows while preserving local ownership, provenance, and opt-in participation.
 
+Federated answers can appear in the same chat only when explicitly enabled per question or session. Remote evidence is lower-trust, evidence-only by default.
+
 ## Requirements
 
 ### Requirement: Query federated indexes explicitly
 
-The system SHALL use federated indexes only when the user or configured policy explicitly allows cross-instance search.
+The system SHALL use federated indexes only when the user or configured policy explicitly allows cross-instance search for the current question or session.
 
 #### Scenario: Ask with federation disabled
 
@@ -36,14 +38,22 @@ The system SHALL label remote evidence distinctly from local personal knowledge.
 - WHEN the answer is rendered
 - THEN provenance identifies the remote instance, source artifact, retrieval path, and confidence
 - AND the answer does not imply the remote evidence is part of the user's personal knowledge unless imported
+- AND the evidence is treated as lower-trust evidence-only by default
 
 ### Requirement: Support import from federated evidence
 
-The system SHALL allow useful federated evidence to become local knowledge only through explicit import or decision-log reasoning.
+The system SHALL allow useful federated evidence to be saved as a source artifact or adopted into personal reasoning through a decision-log package.
 
 #### Scenario: Import remote evidence
 
-- GIVEN the user wants to keep remote evidence
+- GIVEN the user wants to keep remote evidence as a reference
 - WHEN the import flow runs
-- THEN the evidence becomes a local source artifact or reasoning package with provenance back to the remote instance
-- AND imported remote evidence is not silently promoted to personal knowledge
+- THEN the evidence becomes a local source artifact with provenance back to the remote instance
+- AND the source artifact is not treated as personal endorsement
+
+#### Scenario: Adopt remote evidence into personal reasoning
+
+- GIVEN the user wants to adopt or endorse remote evidence
+- WHEN a decision-log package is created from that evidence
+- THEN the package records reasoning and provenance back to the remote instance
+- AND answers can distinguish saved remote source from personal decision or knowledge

--- a/openspec/specs/hosted-service/spec.md
+++ b/openspec/specs/hosted-service/spec.md
@@ -1,12 +1,14 @@
 # hosted-service Specification
 
-Status: Future scope, unknowns pending
+Status: Future scope, planning decisions recorded
 
 ## Purpose
 
-The hosted-service capability defines optional hosted youaskm3 services, including account management, teams, permissions, hosted sync, and hosted runtime operations, without weakening the local-first product.
+The hosted-service capability defines an optional hosted convenience layer for youaskm3, including account management, teams, permissions, hosted sync, and hosted runtime operations, without weakening the local-first product.
 
 Hosted service support is an opt-in layer. It must not turn local persona metadata into hosted identity, and it must not replace local validation, local sync preflight, or Traverse-governed runtime acceptance.
+
+Nothing leaves the user's machine by default. Hosted features require explicit setup and consent. Personal hosted sync defaults to end-to-end encrypted blobs; raw/shared/team modes require explicit policy.
 
 ## Requirements
 
@@ -20,6 +22,23 @@ The system SHALL keep local-first operation valid when hosted services are unava
 - WHEN hosted service configuration is absent or unavailable
 - THEN local CLI, local runtime, and local Traverse-backed workflows continue to work
 - AND hosted account, team, and permission checks are skipped because no hosted scope is being accessed
+
+### Requirement: Require explicit opt-in before data leaves the machine
+
+The system SHALL require explicit hosted feature configuration before content, metadata, runtime requests, or sync state leave the local machine.
+
+#### Scenario: Hosted features absent
+
+- GIVEN no hosted service is configured
+- WHEN local commands or runtime workflows run
+- THEN no content, metadata, hosted sync state, or hosted runtime request is sent to a hosted service
+
+#### Scenario: Enable hosted feature
+
+- GIVEN the user enables a hosted feature
+- WHEN setup runs
+- THEN the system states what data leaves the machine
+- AND the feature records explicit consent and configuration
 
 ### Requirement: Separate hosted identity from local persona
 
@@ -55,6 +74,41 @@ The system SHALL preserve the local sync conflict model when hosted sync exists.
 - THEN safe append-only changes may merge
 - AND semantic conflicts become conflict records instead of silent overwrite
 - AND sync provenance records hosted account, team, device, local persona when selected, and preflight result
+
+### Requirement: Support hosted sync modes
+
+The system SHALL support sync modes that distinguish encrypted personal sync from explicit readable shared/team modes.
+
+#### Scenario: Personal hosted sync
+
+- GIVEN a user enables personal hosted sync
+- WHEN content is uploaded
+- THEN the default uploaded form is end-to-end encrypted blobs
+- AND the hosted service cannot read raw knowledge content by default
+
+#### Scenario: Explicit raw or team sync
+
+- GIVEN a user enables a raw readable or team/shared mode
+- WHEN setup runs
+- THEN policy and consent explicitly state that the server or team may access readable content according to that mode
+- AND there is no silent downgrade from encrypted to raw sync
+
+### Requirement: Allow hosted runtime only by capability policy
+
+The system SHALL allow hosted runtime execution only when explicit capability placement policy permits it.
+
+#### Scenario: Hosted capability execution
+
+- GIVEN a capability policy permits hosted execution
+- WHEN Traverse places that capability on a hosted runtime
+- THEN the trace records hosted execution, placement target, capability id, and policy decision
+- AND the hosted runtime executes the same WASM/business-logic contracts as local runtime
+
+#### Scenario: Local-only capability
+
+- GIVEN a capability policy is local-only
+- WHEN hosted runtime is available
+- THEN Traverse does not place that capability on hosted runtime
 
 ### Requirement: Document hosted security and privacy risk
 

--- a/openspec/specs/multi-persona/spec.md
+++ b/openspec/specs/multi-persona/spec.md
@@ -1,10 +1,12 @@
 # multi-persona Specification
 
-Status: Future scope, unknowns pending
+Status: Future scope, planning decisions recorded
 
 ## Purpose
 
 The multi-persona capability defines how more than one persona can maintain isolated or intentionally shared knowledge, gaps, decision logs, graph context, and assistant adapters.
+
+A persona is a knowledge identity. It can represent a real person, a role/context, a project, or a domain-specific thinking identity. It is distinct from a hosted account.
 
 ## Requirements
 
@@ -19,9 +21,21 @@ The system SHALL keep persona knowledge, gaps, conflicts, and reasoning graphs i
 - THEN answer context is selected only from that persona's allowed knowledge scope
 - AND provenance records the active persona id
 
+### Requirement: Use a hybrid scoped graph model
+
+The system SHALL isolate persona graph views by default and allow explicit shared graph scopes.
+
+#### Scenario: Share scoped reasoning
+
+- GIVEN a package targets a shared scope
+- WHEN graph extraction runs
+- THEN extracted nodes and edges record the shared scope id
+- AND only personas allowed to read that scope can use those graph elements for answers
+- AND no cross-persona leakage occurs through default answer context selection
+
 ### Requirement: Support explicit shared scopes
 
-The system SHALL support shared knowledge scopes only through explicit metadata and conflict policy.
+The system SHALL support shared knowledge scopes only through explicit metadata and conflict policy. Shared scopes are read-only by default and writable only when an explicit policy allows writes.
 
 #### Scenario: Share a decision log
 
@@ -29,6 +43,42 @@ The system SHALL support shared knowledge scopes only through explicit metadata 
 - WHEN it is ingested
 - THEN the package records which personas may use it
 - AND conflicts between persona-specific knowledge and shared knowledge are visible
+
+#### Scenario: Write to shared scope
+
+- GIVEN a shared scope allows writes by explicit policy
+- WHEN a package writes to that shared scope
+- THEN provenance records writer persona, package id, timestamp, and scope id
+- AND no existing shared knowledge is silently overwritten
+
+### Requirement: Select active persona explicitly
+
+The system SHALL use a configured default persona for normal use and require explicit chat or CLI switching for other personas.
+
+#### Scenario: Switch persona in chat
+
+- GIVEN a user has multiple personas
+- WHEN the user explicitly switches to another persona
+- THEN the runtime records the new active persona id in session state and trace evidence
+- AND the system does not silently infer or switch persona from message content
+
+### Requirement: Resolve conflicts according to scope visibility
+
+The system SHALL create shared conflict records only when conflicting scopes are mutually visible.
+
+#### Scenario: Conflict across hidden scopes
+
+- GIVEN two hidden persona scopes contain conflicting knowledge
+- WHEN conflict detection runs
+- THEN conflict records remain persona-local
+- AND hidden scope content is not leaked
+
+#### Scenario: Conflict across visible scopes
+
+- GIVEN both conflicting scopes are mutually visible
+- WHEN conflict detection runs
+- THEN one shared conflict record may be created
+- AND resolution requires a package targeting a scope allowed to see and resolve the conflict
 
 ### Requirement: Generate persona-aware assistant packages
 
@@ -40,3 +90,14 @@ The system SHALL allow generated assistant adapters to include persona context w
 - WHEN assistant packaging runs
 - THEN generated instructions may include allowed persona metadata
 - AND do not embed private knowledge content outside the knowledge store
+
+### Requirement: Reserve persona metadata before full multi-persona implementation
+
+The system SHALL keep full multi-persona behavior future-scoped while reserving `persona_id`, `scope_id`, and package target scope fields in current schemas.
+
+#### Scenario: First-MVP package uses one active persona
+
+- GIVEN the first MVP has one active persona
+- WHEN package metadata is validated
+- THEN reserved persona and scope fields can be present
+- AND full persona switching or shared-scope behavior is not required until this future capability is implemented

--- a/openspec/specs/package-import-automation/spec.md
+++ b/openspec/specs/package-import-automation/spec.md
@@ -1,16 +1,18 @@
 # package-import-automation Specification
 
-Status: Future scope, unknowns pending
+Status: Future scope, planning decisions recorded
 
 ## Purpose
 
 The package-import-automation capability defines optional import convenience features beyond first-MVP CLI directory ingestion, including archive package ingestion and inbox/watch-folder processing.
 
+Archive ingestion comes before inbox/watch-folder automation. The first supported archive format is `.zip`; tar formats are future work only if needed.
+
 ## Requirements
 
 ### Requirement: Import decision-log package archives safely
 
-The system SHALL support archive ingestion only after validating archive structure, size limits, paths, and package contents.
+The system SHALL support `.zip` archive ingestion only after validating archive structure, size limits, paths, and package contents.
 
 #### Scenario: Reject path traversal archive
 
@@ -19,17 +21,30 @@ The system SHALL support archive ingestion only after validating archive structu
 - THEN ingestion fails before extraction
 - AND no knowledge-root files are written
 
+#### Scenario: Reject unsupported archive format
+
+- GIVEN a user passes an unsupported archive format
+- WHEN archive ingestion runs
+- THEN the command fails with a stable unsupported-format error
+- AND the error states that `.zip` is the first supported archive format
+
 ### Requirement: Support inbox processing without silent ingestion
 
-The system SHALL allow an optional inbox or watch-folder flow only when it preserves explicit validation, provenance, sync preflight, and user-visible results.
+The system SHALL allow optional inbox processing only through an explicit command first. Background watch-folder behavior is later scope and must use the same validation path.
 
 #### Scenario: Process inbox package
 
 - GIVEN a package appears in a configured inbox
-- WHEN the inbox processor runs
+- WHEN the explicit inbox import command runs
 - THEN it validates the package through the same path as `m3 ingest-decision-log`
 - AND writes a clear ingested, rejected, or staged result
 - AND does not bypass Traverse-required final ingestion rules
+
+#### Scenario: Later watcher uses same path
+
+- GIVEN a future watch-folder mode is enabled
+- WHEN the watcher detects a package
+- THEN it must produce the same validation and result records as the explicit inbox command
 
 ### Requirement: Preserve the CLI ingestion contract
 

--- a/openspec/specs/semantic-quality-evaluation/spec.md
+++ b/openspec/specs/semantic-quality-evaluation/spec.md
@@ -1,16 +1,18 @@
 # semantic-quality-evaluation Specification
 
-Status: Future scope, unknowns pending
+Status: Future scope, planning decisions recorded
 
 ## Purpose
 
 The semantic-quality-evaluation capability defines claim-level semantic validation, partial ingestion, and production-quality answer benchmarking after the deterministic first-MVP path is stable.
 
+Generic benchmarks are required and committed. Persona-specific benchmarks are optional, local/private, and must not leak private content. Release-blocking benchmark gates cover full trust behavior.
+
 ## Requirements
 
 ### Requirement: Support claim-level partial ingestion
 
-The system SHALL allow semantically accepted claims to be ingested while rejected claims become knowledge gaps only after claim extraction, provenance, and conflict semantics are stable.
+The system SHALL allow semantically accepted claims to be ingested while rejected claims become knowledge gaps only after deterministic claim extraction, optional Traverse-governed semantic refinement, provenance, and conflict semantics are stable.
 
 #### Scenario: Partially ingest a package
 
@@ -21,15 +23,29 @@ The system SHALL allow semantically accepted claims to be ingested while rejecte
 - AND rejected claims create or update gaps
 - AND the package records partial status instead of all-or-nothing success
 
+#### Scenario: Refine extracted claims
+
+- GIVEN deterministic claim extraction has produced claim records
+- WHEN optional Traverse-governed semantic refinement is available
+- THEN refinement may improve claim classification and validation
+- AND trace evidence records extraction, refinement, and final validation results
+
 ### Requirement: Benchmark answer quality against fixtures
 
-The system SHALL define production-quality answer evaluation fixtures that test grounding, provenance, conflict behavior, gap creation, and reasoning usefulness.
+The system SHALL define production-quality answer evaluation fixtures that test correctness, grounding, provenance, unsupported claims, conflict disclosure, gap creation, citation completeness, and reasoning usefulness.
 
 #### Scenario: Run answer benchmark
 
 - GIVEN a benchmark corpus and expected evidence rules exist
 - WHEN the benchmark runs
-- THEN it reports grounded answer quality, unsupported claim rate, conflict disclosure rate, gap behavior, and provenance completeness
+- THEN it reports correctness, grounded answer quality, unsupported claim rate, conflict disclosure rate, gap behavior, citation completeness, and provenance completeness
+
+#### Scenario: Run persona-specific benchmark locally
+
+- GIVEN a user has private persona-specific benchmark fixtures
+- WHEN the local benchmark runs
+- THEN results are stored locally
+- AND private benchmark content is not required for CI or shared reporting
 
 ### Requirement: Keep benchmark output non-authoritative for knowledge
 

--- a/openspec/specs/wasm-native-model-evidence/spec.md
+++ b/openspec/specs/wasm-native-model-evidence/spec.md
@@ -49,6 +49,10 @@ The system SHALL fail readiness if docs or release notes claim fully WASM-native
 - WHEN validation runs
 - THEN the gate passes the positive WASM-native model-engine claim
 
+### Requirement: Allow Traverse-governed inference releases
+
+The system SHALL allow releases that claim Traverse-governed inference without claiming fully WASM-native inference.
+
 #### Scenario: Traverse-governed inference release
 
 - GIVEN a release claims Traverse-governed inference but not fully WASM-native inference


### PR DESCRIPTION
## Summary
- Record brainstorm-approved planning decisions for post-MVP scope in the decision log and ticket backlog.
- Update approved OpenSpec specs with resolved decisions and remaining unknowns for FUTURE-001 through FUTURE-007.
- Keep the work planning-only: no runtime behavior changes.

## Spec References
- openspec/specs/multi-persona/spec.md
- openspec/specs/assistant-distribution/spec.md
- openspec/specs/package-import-automation/spec.md
- openspec/specs/semantic-quality-evaluation/spec.md
- openspec/specs/federated-answer/spec.md
- openspec/specs/hosted-service/spec.md
- openspec/specs/wasm-native-model-evidence/spec.md

## Validation
- PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh
- Result: passed, including lint, build, Rust tests, coverage gate, typecheck, frontend tests, workflow YAML validation, and OpenSpec validation.