### PR TITLE
Plan hosted public gap collector

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -239,6 +239,12 @@ These tickets keep youaskm3 product-led while using concrete app evidence to dri
 
 The expanded second-brain tranche is tracked as MVP-041 and later in [docs/mvp-ticket-backlog.md](docs/mvp-ticket-backlog.md). It does not replace MVP-031 through MVP-040; it layers the approved decision-log, reasoning graph, knowledge gap, sync, local runtime, and final expanded acceptance requirements on top of the existing Traverse-backed runtime baseline.
 
+### Public hosted gap collector
+
+Published GitHub Pages chat can browse and answer from public artifacts without a server, but low-friction external knowledge-gap capture requires a trusted write boundary. The approved minimal hosted surface is [hosted-gap-collector](openspec/specs/hosted-gap-collector/spec.md): an optional, narrow gap inbox backed by zero/near-zero-cost managed primitives such as Cloudflare Worker, D1, and Turnstile.
+
+The collector stores pending external gap reports only. It does not answer questions, run inference, write to the local knowledge graph, or replace the local Traverse-backed runtime. The owner pulls, reviews, and imports accepted reports through the CLI so the user-owned local instance remains the source of truth.
+
 ### Post-first-MVP missing scope
 
 The following surfaces are intentionally outside the first MVP but now have explicit future-scope specs and backlog tickets:
@@ -413,6 +419,7 @@ Dual-licensed: **MIT** and **Apache-2.0**. Users choose.
 ### Later — Fork, Federation, and Network Effects
 - [ ] One-command setup documented in README with a target under 15 minutes.
 - [ ] `youaskm3.com` serves the author's public instance.
+- [ ] Optional hosted gap collector supports low-friction public gap submissions without browser secrets or full hosted youaskm3 accounts.
 - [ ] Federation registry and cross-instance search remain separate from the first MVP.
 
 ---

--- a/docs/expanded-second-brain-mvp-decision-log.md
+++ b/docs/expanded-second-brain-mvp-decision-log.md
@@ -119,10 +119,11 @@ The following items remain outside the first MVP but are no longer undocumented:
 - Production-quality answer benchmarks.
 - Multi-persona knowledge isolation and explicit sharing.
 - Optional hosted service, accounts, teams, permissions, and hosted sync.
+- Optional hosted public gap collector for low-friction GitHub Pages gap capture.
 - Cross-instance federated answer flows beyond registry/index discovery.
 - Evidence required before claiming model-engine execution itself is WASM-native.
 
-These items are captured by future-scope OpenSpec files and FUTURE-001 through FUTURE-007 in `docs/mvp-ticket-backlog.md`.
+These items are captured by future-scope OpenSpec files and FUTURE-001 through FUTURE-012 in `docs/mvp-ticket-backlog.md`.
 
 ## Future-Scope Unknowns Resolved
 
@@ -161,6 +162,20 @@ The following planning decisions were approved after the future-scope tickets we
 - Personal hosted sync defaults to end-to-end encrypted blobs.
 - Raw readable content or team/shared modes require explicit opt-in and policy.
 - Hosted runtime execution is allowed only per explicit capability policy and must remain Traverse-governed with trace evidence.
+
+### Hosted Public Gap Collector
+
+- GitHub Pages can host published chat and static knowledge artifacts without a server.
+- Painless public gap capture cannot be solved by browser WASM or GitHub Secrets because static browser code cannot safely hold write credentials.
+- Prefilled GitHub issue drafts are safe but cumbersome because they require a GitHub account and manual submission.
+- Low-friction public gap capture requires an optional trusted hosted boundary.
+- The minimum hosted architecture is a narrow gap collector, not full hosted youaskm3.
+- Recommended MVP architecture is GitHub Pages plus Cloudflare Worker, D1, and Turnstile or equivalent zero/near-zero-cost managed primitives.
+- The collector stores pending external gap reports only; it does not answer questions, run inference, mutate the local graph, or bypass local validation.
+- The local user-owned instance remains the source of truth.
+- The owner pulls, reviews, and imports accepted reports through the CLI.
+- The public client must provide a no-hosted fallback such as GitHub issue draft, copy markdown, or download gap package.
+- Cost controls, abuse controls, privacy disclosure, and retention policy are required before enabling a collector.
 
 ### Import Automation
 

--- a/docs/mvp-ticket-backlog.md
+++ b/docs/mvp-ticket-backlog.md
@@ -1326,6 +1326,14 @@ Approved expanded second-brain tranche after the 2026-06-29 brainstorming sessio
 - MVP-053 MCP answer, gaps, and simple fact resolution tools ([#150](https://github.com/enricopiovesan/youaskm3/issues/150))
 - MVP-054 expanded first-MVP acceptance gate with `m3 mvp-check` ([#151](https://github.com/enricopiovesan/youaskm3/issues/151))
 
+Approved hosted public gap collector tranche after the 2026-07-05 planning session:
+
+- FUTURE-008 hosted public gap collector architecture ([#187](https://github.com/enricopiovesan/youaskm3/issues/187))
+- FUTURE-009 static chat gap submission UX ([#190](https://github.com/enricopiovesan/youaskm3/issues/190))
+- FUTURE-010 minimal hosted gap collector endpoint ([#189](https://github.com/enricopiovesan/youaskm3/issues/189))
+- FUTURE-011 CLI pull/review/import for hosted gap reports ([#188](https://github.com/enricopiovesan/youaskm3/issues/188))
+- FUTURE-012 hosted gap collector security, privacy, and cost gate ([#186](https://github.com/enricopiovesan/youaskm3/issues/186))
+
 ## Ticket MVP-041: Build the Canonical Reasoning Skill and Generated Adapters
 
 ### Objective
@@ -2137,6 +2145,210 @@ Define and validate the evidence required before youaskm3 claims the model engin
 
 - What exact Traverse trace field names will expose the required evidence?
 - Should fully WASM-native inference become a release blocker later or remain a conformance badge?
+
+## Ticket FUTURE-008: Define Hosted Public Gap Collector Architecture ([#187](https://github.com/enricopiovesan/youaskm3/issues/187))
+
+### Objective
+
+Define the smallest optional hosted architecture that makes public GitHub Pages chat gap capture low-friction without creating a full hosted youaskm3 service.
+
+### Governing Specs
+
+- `openspec/specs/hosted-gap-collector/spec.md`
+- `openspec/specs/hosted-service/spec.md`
+- `openspec/specs/knowledge-gap-lifecycle/spec.md`
+
+### Scope
+
+- Document why browser WASM and GitHub Secrets cannot safely provide automatic public writes from GitHub Pages.
+- Define the recommended minimal architecture: GitHub Pages chat, trusted collector endpoint, abuse validation, pending gap storage, and CLI owner import.
+- Define accepted equivalent provider requirements for alternatives to Cloudflare Worker, D1, and Turnstile.
+- Define public gap report schema fields and stable error codes at the spec level.
+
+### Definition of Done
+
+- `openspec/specs/hosted-gap-collector/spec.md` describes local-first source-of-truth, no browser secrets, pending-only storage, owner review/import, abuse controls, privacy disclosure, and cost limits.
+- Architecture docs distinguish this narrow collector from full hosted youaskm3 accounts, sync, teams, hosted runtime, and inference.
+- Public gap report payload fields are listed: question, missing knowledge, published scope, checked evidence, source URL, timestamp, reporter context, schema version, and validation version.
+- Failure modes are documented for missing collector config, invalid payload, abuse challenge failure, rate limit, storage failure, and owner import failure.
+- No implementation claims direct graph writes or automatic local knowledge mutation from the public hosted collector.
+- Validation passes for OpenSpec/docs checks.
+
+### Resolved Planning Decisions
+
+- Low-friction GitHub Pages gap capture requires a trusted hosted boundary.
+- The collector is optional and narrow; it stores pending reports only.
+- The local user-owned instance remains the source of truth.
+- Cloudflare Worker, D1, and Turnstile are the recommended first near-zero-cost architecture, but equivalent providers are allowed if they preserve the same trust and cost boundaries.
+
+### Remaining Unknowns To Discuss
+
+- Which provider should be the first supported reference implementation?
+- What retention period should pending public gap reports use by default?
+
+## Ticket FUTURE-009: Add Static Chat Gap Submission UX ([#190](https://github.com/enricopiovesan/youaskm3/issues/190))
+
+### Objective
+
+Add the GitHub Pages/static-chat UX for reporting a knowledge gap to a configured hosted collector, with honest fallback behavior when no collector exists.
+
+### Governing Specs
+
+- `openspec/specs/hosted-gap-collector/spec.md`
+- `openspec/specs/pwa-shell/spec.md`
+- `openspec/specs/knowledge-gap-lifecycle/spec.md`
+
+### Scope
+
+- Add static client configuration for an optional gap collector endpoint and public scope metadata.
+- Show transparent insufficient-knowledge messaging and a submit-gap action for public chat.
+- Send a validated public gap report to the configured collector.
+- Provide fallback actions when no collector is configured: GitHub issue draft, copy markdown, or download gap package.
+- Keep the PWA UI-only: no graph mutation, no inference, no secret handling, and no business-logic shortcuts in the client.
+
+### Definition of Done
+
+- Static chat shows what was known, what is missing, and the action to submit a public gap.
+- Submit action posts only the public gap report payload to the configured collector endpoint.
+- The browser bundle contains no write token, GitHub secret, database credential, or hidden privileged endpoint.
+- UI discloses what data leaves the page before submission.
+- Missing collector config produces a clear fallback path and does not show fake one-click hosted submission.
+- Tests cover configured collector success, collector unavailable failure, invalid input, and no-collector fallback.
+- Accessibility checks cover the submit, fallback, success, and error states.
+- Validation passes.
+
+### Resolved Planning Decisions
+
+- GitHub Pages public chat may capture gaps through a hosted collector when configured.
+- Without a collector, the product must offer honest manual fallbacks instead of pretending the flow is painless.
+- Static client code must not contain secrets or mutate knowledge directly.
+
+### Remaining Unknowns To Discuss
+
+- What exact public UI label should distinguish hosted submit from manual fallback?
+- Should copy/download fallback use markdown only or a zip package from day one?
+
+## Ticket FUTURE-010: Implement Minimal Hosted Gap Collector Endpoint ([#189](https://github.com/enricopiovesan/youaskm3/issues/189))
+
+### Objective
+
+Implement the optional hosted collector reference endpoint that accepts public gap reports, validates abuse controls, and stores pending reports for owner review.
+
+### Governing Specs
+
+- `openspec/specs/hosted-gap-collector/spec.md`
+- `openspec/specs/hosted-service/spec.md`
+
+### Scope
+
+- Implement a reference Cloudflare Worker or equivalent serverless endpoint.
+- Validate payload schema, origin policy, Turnstile or equivalent challenge, body size, and rate limits.
+- Store accepted reports in D1 or equivalent pending storage.
+- Return stable success and error responses.
+- Avoid LLM calls, inference, graph writes, and automatic GitHub issue creation in the collector.
+
+### Definition of Done
+
+- Collector rejects requests with missing required fields, oversized payloads, failed challenge, disallowed origin, and rate limit violations.
+- Accepted reports receive a stable report id and are stored with pending status.
+- Stored report includes schema version, validation version, created timestamp, source URL, published scope, checked evidence, missing knowledge, and reporter context.
+- No browser-facing secret is required for submission.
+- No collector path can directly mutate local knowledge or mark a report imported without owner-side action.
+- Tests cover valid report, invalid report, challenge failure, rate limit, storage failure, and stable error codes.
+- Deployment docs list required environment variables/secrets and free-tier/cost assumptions.
+- Validation passes.
+
+### Resolved Planning Decisions
+
+- The first hosted feature should be a gap collector, not full hosted youaskm3.
+- The collector should use managed free/near-free primitives and conservative quotas.
+- The collector must store pending reports only.
+
+### Remaining Unknowns To Discuss
+
+- Should the first reference implementation live in this repo or a separate deployable package?
+- Should owner authentication for report-status updates be included in the first collector slice or deferred to CLI pull-only access?
+
+## Ticket FUTURE-011: Add CLI Pull, Review, and Import for Hosted Gap Reports ([#188](https://github.com/enricopiovesan/youaskm3/issues/188))
+
+### Objective
+
+Allow an owner to pull pending hosted gap reports, review them, and import accepted reports into the local knowledge gap lifecycle.
+
+### Governing Specs
+
+- `openspec/specs/hosted-gap-collector/spec.md`
+- `openspec/specs/knowledge-gap-lifecycle/spec.md`
+- `openspec/specs/local-runtime-sync/spec.md`
+
+### Scope
+
+- Add CLI configuration for hosted collector source credentials or read endpoint.
+- List pending reports with enough context for owner review.
+- Import accepted reports as local structured knowledge gaps.
+- Preserve hosted report provenance.
+- Reject or archive reports without importing when the owner chooses.
+
+### Definition of Done
+
+- CLI can list pending reports from a configured collector without importing them.
+- CLI can import a selected report into the local instance as a structured knowledge gap.
+- Imported gap records hosted report id, collector source, source URL, published scope, reporter context, timestamp, schema version, and validation version.
+- Import uses existing local validation and conflict/gap lifecycle rules.
+- CLI can reject or archive a report when supported by the collector, or record local ignore state when remote status update is unavailable.
+- Tests cover list, import, duplicate import prevention, reject/archive, invalid remote payload, and collector unavailable failure.
+- No report bypasses local user consent or local validation.
+- Validation passes.
+
+### Resolved Planning Decisions
+
+- Owner review/import is mandatory.
+- Public submissions do not become local knowledge until imported.
+- CLI is the bridge from hosted pending reports to local source-of-truth knowledge.
+
+### Remaining Unknowns To Discuss
+
+- What CLI command names should be used for hosted gap pull/review/import?
+- Should accepted reports default to open gaps or staged review files?
+
+## Ticket FUTURE-012: Add Hosted Gap Collector Security, Privacy, and Cost Gate ([#186](https://github.com/enricopiovesan/youaskm3/issues/186))
+
+### Objective
+
+Add release gating and documentation that prevents enabling the hosted gap collector without abuse controls, privacy disclosure, and cost limits.
+
+### Governing Specs
+
+- `openspec/specs/hosted-gap-collector/spec.md`
+- `openspec/specs/hosted-service/spec.md`
+
+### Scope
+
+- Document the security, privacy, retention, and cost model for the hosted collector.
+- Add validation that release docs do not claim painless public gap capture unless a collector or honest fallback exists.
+- Add configuration checks for required collector limits and disclosure.
+- Keep the gate independent from full hosted accounts/sync/team readiness.
+
+### Definition of Done
+
+- Docs list what public gap data is collected, where it is stored, who can read it, retention expectations, and owner deletion/export path.
+- Docs list expected free-tier assumptions and conservative default limits.
+- Validation fails if public hosted gap capture is enabled without configured abuse control, body limit, rate limit, and privacy disclosure.
+- Validation fails if GitHub Pages docs claim automatic one-click submission while only GitHub issue draft/manual fallback is configured.
+- Tests cover missing disclosure, missing abuse control, missing limits, configured collector success, and fallback-only success.
+- The gate does not require full hosted youaskm3 accounts, sync, teams, or hosted runtime.
+- Validation passes.
+
+### Resolved Planning Decisions
+
+- Reducing user friction must not hide privacy, abuse, or cost risks.
+- Hosted collector readiness is separate from full hosted-service readiness.
+- Fallback-only static deployments are valid, but must be labeled honestly.
+
+### Remaining Unknowns To Discuss
+
+- What usage threshold should trigger moving from free-tier collector assumptions to explicit billing alerts?
+- What default retention period balances useful owner review with privacy minimization?
 
 ## First Tickets to Start
 

--- a/docs/mvp-user-stories.md
+++ b/docs/mvp-user-stories.md
@@ -39,6 +39,7 @@ MVP runtime acceptance requires the real implementation. Browser demo, temporary
 - Production-quality hosted model service.
 - Claims that the local model engine itself is WASM-native before Traverse exposes that evidence.
 - Hosted youaskm3 sync service, user accounts, or cloud storage control plane.
+- Low-friction hosted public gap collection for GitHub Pages visitors.
 - Zip/archive decision-log package ingestion.
 - Automatic inbox watcher for decision-log packages.
 - Claim-level partial ingestion after failed semantic validation.
@@ -50,6 +51,7 @@ These post-MVP surfaces now have explicit future-scope specs:
 - `openspec/specs/semantic-quality-evaluation/spec.md`
 - `openspec/specs/multi-persona/spec.md`
 - `openspec/specs/hosted-service/spec.md`
+- `openspec/specs/hosted-gap-collector/spec.md`
 - `openspec/specs/federated-answer/spec.md`
 - `openspec/specs/wasm-native-model-evidence/spec.md`
 
@@ -308,6 +310,33 @@ Acceptance criteria:
 - AND remaining gaps are represented as backlog tickets rather than undocumented assumptions
 - AND confirmed missing Traverse public surfaces are escalated upstream with reproduction evidence instead of hidden in downstream workaround code
 - AND first-MVP completion is declared only after the final acceptance gate passes
+
+### Public Knowledge Visitor
+
+As a public knowledge visitor, I want to submit a knowledge gap from a published GitHub Pages chat without needing to manually create a GitHub issue, so that the instance owner can improve the published second brain with less friction.
+
+Capability and ticket map:
+
+- `hosted-gap-collector`
+- `knowledge-gap-lifecycle`
+- `pwa-shell`
+- FUTURE-008 hosted public gap collector architecture
+- FUTURE-009 static chat gap submission UX
+- FUTURE-010 minimal hosted gap collector endpoint
+- FUTURE-011 CLI pull/review/import for hosted gap reports
+- FUTURE-012 hosted gap collector security, privacy, and cost gate
+
+Acceptance criteria:
+
+- GIVEN a published GitHub Pages chat has a hosted gap collector configured
+- WHEN the visitor submits a gap report
+- THEN no browser secret or GitHub token is exposed
+- AND the report is validated and stored as pending external input
+- AND the visitor sees honest success or failure feedback
+- AND the local knowledge graph is not mutated
+- AND the owner can later pull, review, and import the report through the CLI
+- AND deployments without a collector show an honest fallback such as GitHub issue draft, copy markdown, or download gap package
+- AND the UI discloses what public gap data leaves the page
 
 ## Demo Acceptance Path
 

--- a/openspec/specs/hosted-gap-collector/spec.md
+++ b/openspec/specs/hosted-gap-collector/spec.md
@@ -1,0 +1,160 @@
+# hosted-gap-collector Specification
+
+Status: Future scope, planning approved
+
+## Purpose
+
+The hosted-gap-collector capability defines the smallest optional hosted surface
+needed to make public GitHub Pages chat gap capture low-friction without turning
+youaskm3 into a full hosted product.
+
+The collector is a narrow gap inbox. It accepts gap reports from a published
+static chat client, validates and rate-limits them, stores them as pending
+reports, and exposes them for owner review/import through the youaskm3 CLI. It
+does not answer questions, run inference, mutate the local knowledge graph, or
+replace the local Traverse-backed runtime.
+
+The recommended first architecture is GitHub Pages plus Cloudflare Worker, D1,
+and Turnstile or equivalent zero/near-zero-cost managed primitives. Equivalent
+providers are allowed only if they preserve the same trust boundary, cost
+controls, portability, and owner-review semantics.
+
+## Requirements
+
+### Requirement: Preserve local-first source of truth
+
+The system SHALL keep the local user-owned instance as the source of truth for
+knowledge gaps and graph updates.
+
+#### Scenario: Public gap is submitted
+
+- GIVEN a public visitor submits a gap from a published chat client
+- WHEN the hosted collector accepts the report
+- THEN the collector stores it as a pending external gap report
+- AND the local knowledge instance is not mutated
+- AND the knowledge graph is not updated until the owner imports or rejects the report locally
+
+### Requirement: Avoid browser secrets
+
+The system SHALL NOT expose write credentials, GitHub tokens, database tokens,
+or hosted service secrets to the GitHub Pages browser client.
+
+#### Scenario: Static chat submits a gap
+
+- GIVEN the chat client runs from static hosting
+- WHEN it sends a gap report
+- THEN it sends the report to a trusted collector endpoint
+- AND the browser bundle contains no write credentials
+- AND the collector owns any required server-side secrets
+
+### Requirement: Validate portable gap payloads
+
+The system SHALL define a portable public gap report payload that can be
+validated before storage and imported later through the CLI.
+
+#### Scenario: Valid report
+
+- GIVEN a report includes question, missing knowledge, published scope, checked evidence, source URL, timestamp, and reporter-provided context
+- WHEN validation runs
+- THEN the collector accepts the report
+- AND records a stable report id
+- AND records validation version and schema version
+
+#### Scenario: Invalid report
+
+- GIVEN a report omits required fields or exceeds configured limits
+- WHEN validation runs
+- THEN the collector rejects the report with a stable error code
+- AND no pending gap report is stored
+
+### Requirement: Require abuse controls
+
+The system SHALL protect the public collector from unauthenticated abuse before
+accepting external writes.
+
+#### Scenario: Abuse checks pass
+
+- GIVEN a visitor submits a gap report
+- WHEN Turnstile or equivalent challenge verification, origin checks, size limits, and rate limits pass
+- THEN the collector may store the pending report
+
+#### Scenario: Abuse checks fail
+
+- GIVEN challenge verification, origin checks, size limits, or rate limits fail
+- WHEN the collector receives the report
+- THEN the collector rejects the report with a stable error code
+- AND records only the minimum operational telemetry needed for abuse analysis
+
+### Requirement: Keep reports pending until owner review
+
+The system SHALL keep hosted reports in a pending/review state until the owner
+explicitly imports, rejects, or archives them.
+
+#### Scenario: Owner pulls reports
+
+- GIVEN pending hosted reports exist
+- WHEN the owner runs the CLI pull/review command
+- THEN the CLI fetches pending reports
+- AND shows report id, question, missing knowledge, source URL, published scope, evidence checked, timestamp, and validation status
+- AND does not import any report without an explicit owner action
+
+### Requirement: Import through the existing gap lifecycle
+
+The system SHALL import accepted hosted reports through the same local knowledge
+gap lifecycle used by local chat.
+
+#### Scenario: Owner imports report
+
+- GIVEN the owner accepts a hosted report
+- WHEN the CLI imports it into a local instance
+- THEN the CLI creates or updates a local structured knowledge gap
+- AND preserves hosted report id, source URL, published scope, reporter context, timestamp, and validation version
+- AND marks the hosted report as imported when the provider supports status updates
+- AND no report bypasses local validation, provenance, or conflict policy
+
+### Requirement: Support no-account fallback
+
+The system SHALL keep a non-hosted fallback for public gap capture when the
+hosted collector is not configured.
+
+#### Scenario: Collector absent
+
+- GIVEN the published chat has no collector endpoint configured
+- WHEN a gap is detected
+- THEN the UI offers a GitHub issue draft, copy markdown, or download gap package fallback
+- AND it clearly states any GitHub account or manual sharing requirement
+
+### Requirement: Bound operating cost
+
+The system SHALL document free-tier assumptions and enforce limits that prevent
+unexpected cost growth.
+
+#### Scenario: Collector is configured
+
+- GIVEN an instance enables hosted gap collection
+- WHEN setup completes
+- THEN the docs list expected provider resources, free-tier assumptions, rate limits, body limits, retention policy, and owner cleanup path
+- AND the implementation defaults to conservative quotas suitable for MVP use
+
+### Requirement: Preserve privacy and consent
+
+The system SHALL disclose that public gap submissions leave the static page and
+are stored in the configured hosted collector.
+
+#### Scenario: Visitor submits report
+
+- GIVEN a visitor is about to submit a gap
+- WHEN the UI presents the submit action
+- THEN it states what will be sent and where it will be stored
+- AND it does not request or store more personal data than needed for the gap report
+
+### Requirement: Keep hosted collector optional
+
+The system SHALL keep the hosted collector optional and independent from local
+runtime, local MCP, local inference, hosted sync, and full hosted accounts.
+
+#### Scenario: Collector disabled
+
+- GIVEN the hosted collector is disabled or unavailable
+- WHEN local chat, local CLI, local MCP, or local Traverse-backed workflows run
+- THEN they continue to work without hosted collector configuration


### PR DESCRIPTION
## Summary
- Add the hosted-gap-collector OpenSpec for low-friction public GitHub Pages gap capture.
- Record the planning decision that browser WASM/GitHub Secrets cannot safely remove the write-boundary problem, and that the first hosted feature should be a narrow pending-gap collector.
- Add five independent tickets with full DoD: #187, #190, #189, #188, #186.
- Update SPEC, MVP user stories, decision log, and backlog.

## Spec References
- openspec/specs/hosted-gap-collector/spec.md
- openspec/specs/hosted-service/spec.md
- openspec/specs/knowledge-gap-lifecycle/spec.md
- openspec/specs/pwa-shell/spec.md
- openspec/specs/local-runtime-sync/spec.md

## Validation
- PATH=/Users/enricopiovesan/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh
- Result: passed, including OpenSpec validation.