### PR TITLE
Add static public gap submission UX

### DIFF
--- a/app/components/browser-runtime.test.ts
+++ b/app/components/browser-runtime.test.ts
@@ -7,6 +7,7 @@ import {
   BROWSER_TOOL_DESCRIPTORS,
   browserArtifactState,
   browserToolNames,
+  buildPublicGapReport,
   buildTraverseRuntimeRequest,
   callBrowserTool,
   documentsFromSearchIndex,
@@ -14,6 +15,7 @@ import {
   isMissingInferenceDependency,
   isBrowserToolName,
   mapTraverseAnswerFailure,
+  submitPublicGapReport,
   temporaryTraverseChatHarness
 } from "./browser-runtime";
 
@@ -59,6 +61,19 @@ const graphFixture = {
       source_chunk_ids: ["knowledge-blog-mvp-fixture-article-index:chunk:0"]
     }
   ]
+};
+
+const hostedGapCollectorConfig = {
+  enabled: true,
+  endpoint: "https://collector.example.test/gaps",
+  publicScope: {
+    instanceId: "youaskm3-author",
+    title: "youaskm3 author instance",
+    shellUrl: "https://enricopiovesan.github.io/youaskm3/",
+    knowledgeBase: "knowledge/"
+  },
+  fallbackIssueUrl: "https://github.com/enricopiovesan/youaskm3/issues/new",
+  fallbackPackageName: "youaskm3-public-gap.md"
 };
 
 describe("browser runtime tool descriptors", () => {
@@ -516,6 +531,124 @@ describe("Traverse HTTP answer adapter", () => {
       message: "Traverse runtime endpoint is not configured.",
       recoverable: true
     });
+  });
+});
+
+describe("hosted public gap report submission", () => {
+  const publicGapInput = {
+    question: "What does the public instance know about collector UX?",
+    missingKnowledge: "No source-backed citation explains the public collector UX.",
+    checkedEvidence: ["No source-backed citations were returned."],
+    sourceUrl: "https://enricopiovesan.github.io/youaskm3/",
+    reporterContext: "Visitor saw an unanswered public chat question."
+  };
+
+  it("builds the portable public gap report payload", () => {
+    const report = buildPublicGapReport(
+      publicGapInput,
+      hostedGapCollectorConfig,
+      "2026-07-05T13:00:00.000Z"
+    );
+
+    expect(report).toEqual({
+      schema_version: "1.0.0",
+      validation_version: "hosted-gap-collector/0.1.0",
+      question: publicGapInput.question,
+      missing_knowledge: publicGapInput.missingKnowledge,
+      published_scope: hostedGapCollectorConfig.publicScope,
+      checked_evidence: publicGapInput.checkedEvidence,
+      source_url: publicGapInput.sourceUrl,
+      submitted_at: "2026-07-05T13:00:00.000Z",
+      reporter_context: publicGapInput.reporterContext
+    });
+  });
+
+  it("submits to a configured collector without browser secrets", async () => {
+    const requests: Array<{ input: string; body: unknown; headers: Record<string, string> }> = [];
+    const output = await submitPublicGapReport(
+      publicGapInput,
+      hostedGapCollectorConfig,
+      async (input, init) => {
+        requests.push({
+          input,
+          body: JSON.parse(init?.body ?? "{}"),
+          headers: init?.headers ?? {}
+        });
+        return {
+          ok: true,
+          status: 202,
+          json: async () => ({ report_id: "gap-report-1" })
+        };
+      },
+      "2026-07-05T13:00:00.000Z"
+    );
+
+    expect(output).toEqual({
+      status: "submitted",
+      reportId: "gap-report-1",
+      code: "HOSTED_GAP_REPORT_ACCEPTED"
+    });
+    expect(requests[0]?.input).toBe("https://collector.example.test/gaps");
+    expect(requests[0]?.headers).toEqual({
+      accept: "application/json",
+      "content-type": "application/json"
+    });
+    expect(JSON.stringify(requests[0]?.body)).not.toMatch(/token|secret|credential/i);
+  });
+
+  it("maps collector unavailable failures to the stable storage code", async () => {
+    const output = await submitPublicGapReport(
+      publicGapInput,
+      hostedGapCollectorConfig,
+      async () => {
+        throw new Error("collector unavailable");
+      },
+      "2026-07-05T13:00:00.000Z"
+    );
+
+    expect(output).toMatchObject({
+      status: "failed",
+      code: "HOSTED_GAP_STORAGE_FAILED",
+      recoverable: true
+    });
+  });
+
+  it("rejects invalid public gap reports before posting", async () => {
+    let called = false;
+    const output = await submitPublicGapReport(
+      { ...publicGapInput, missingKnowledge: "   " },
+      hostedGapCollectorConfig,
+      async () => {
+        called = true;
+        throw new Error("should not post invalid reports");
+      },
+      "2026-07-05T13:00:00.000Z"
+    );
+
+    expect(output).toMatchObject({
+      status: "failed",
+      code: "HOSTED_GAP_REPORT_INVALID"
+    });
+    expect(called).toBe(false);
+  });
+
+  it("returns manual fallback data when no collector is configured", async () => {
+    const output = await submitPublicGapReport(publicGapInput, {
+      ...hostedGapCollectorConfig,
+      enabled: false,
+      endpoint: null
+    });
+
+    expect(output).toMatchObject({
+      status: "fallback",
+      code: "HOSTED_GAP_COLLECTOR_NOT_CONFIGURED",
+      downloadFileName: "youaskm3-public-gap.md"
+    });
+    if (output.status !== "fallback") {
+      throw new Error("expected fallback output");
+    }
+    expect(output.fallbackMarkdown).toContain(publicGapInput.question);
+    expect(output.fallbackMarkdown).toContain(publicGapInput.missingKnowledge);
   });
 });
 

--- a/app/components/browser-runtime.ts
+++ b/app/components/browser-runtime.ts
@@ -104,6 +104,62 @@ export type TraverseFetch = (
   }
 ) => Promise<TraverseFetchResponse>;
 
+export type HostedGapCollectorConfig = {
+  enabled: boolean;
+  endpoint: string | null;
+  publicScope: {
+    instanceId: string;
+    title: string;
+    shellUrl: string;
+    knowledgeBase: string;
+  };
+  fallbackIssueUrl?: string;
+  fallbackPackageName?: string;
+};
+
+export type PublicGapReportInput = {
+  question: string;
+  missingKnowledge: string;
+  checkedEvidence: string[];
+  sourceUrl: string;
+  reporterContext?: string;
+};
+
+export type PublicGapReport = {
+  schema_version: "1.0.0";
+  validation_version: "hosted-gap-collector/0.1.0";
+  question: string;
+  missing_knowledge: string;
+  published_scope: HostedGapCollectorConfig["publicScope"];
+  checked_evidence: string[];
+  source_url: string;
+  submitted_at: string;
+  reporter_context?: string;
+};
+
+export type HostedGapSubmissionResult =
+  | {
+      status: "submitted";
+      reportId: string;
+      code: "HOSTED_GAP_REPORT_ACCEPTED";
+    }
+  | {
+      status: "fallback";
+      code: "HOSTED_GAP_COLLECTOR_NOT_CONFIGURED";
+      fallbackMarkdown: string;
+      downloadFileName: string;
+    }
+  | {
+      status: "failed";
+      code:
+        | "HOSTED_GAP_REPORT_INVALID"
+        | "HOSTED_GAP_ABUSE_CHALLENGE_FAILED"
+        | "HOSTED_GAP_RATE_LIMITED"
+        | "HOSTED_GAP_STORAGE_FAILED";
+      message: string;
+      recoverable: boolean;
+    };
+
 export type BrowserCitation = {
   citation_id: string;
   artifact_id: string;
@@ -257,6 +313,102 @@ export function isMissingInferenceDependency(code: string): boolean {
   return MISSING_INFERENCE_DEPENDENCY_CODES.includes(
     code as (typeof MISSING_INFERENCE_DEPENDENCY_CODES)[number]
   );
+}
+
+export function buildPublicGapReport(
+  input: PublicGapReportInput,
+  config: HostedGapCollectorConfig,
+  submittedAt = new Date().toISOString()
+): PublicGapReport {
+  const question = requireInput(input.question);
+  const missingKnowledge = requireInput(input.missingKnowledge);
+  const sourceUrl = requireInput(input.sourceUrl);
+  const checkedEvidence = input.checkedEvidence
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  if (checkedEvidence.length === 0) {
+    throw new Error("public gap report needs checked evidence");
+  }
+
+  return {
+    schema_version: "1.0.0",
+    validation_version: "hosted-gap-collector/0.1.0",
+    question,
+    missing_knowledge: missingKnowledge,
+    published_scope: config.publicScope,
+    checked_evidence: checkedEvidence,
+    source_url: sourceUrl,
+    submitted_at: submittedAt,
+    ...(input.reporterContext?.trim()
+      ? { reporter_context: input.reporterContext.trim() }
+      : {})
+  };
+}
+
+export async function submitPublicGapReport(
+  input: PublicGapReportInput,
+  config: HostedGapCollectorConfig,
+  fetchImpl: TraverseFetch = globalThis.fetch,
+  submittedAt = new Date().toISOString()
+): Promise<HostedGapSubmissionResult> {
+  if (!config.enabled || !config.endpoint || config.endpoint.trim().length === 0) {
+    return {
+      status: "fallback",
+      code: "HOSTED_GAP_COLLECTOR_NOT_CONFIGURED",
+      fallbackMarkdown: publicGapFallbackMarkdown(input),
+      downloadFileName: config.fallbackPackageName ?? "youaskm3-public-gap.md"
+    };
+  }
+
+  let report: PublicGapReport;
+  try {
+    report = buildPublicGapReport(input, config, submittedAt);
+  } catch (error) {
+    return {
+      status: "failed",
+      code: "HOSTED_GAP_REPORT_INVALID",
+      message: error instanceof Error ? error.message : "Invalid public gap report.",
+      recoverable: true
+    };
+  }
+
+  const response = await fetchImpl(config.endpoint, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(report)
+  }).catch((error) =>
+    Promise.resolve({
+      ok: false,
+      status: 503,
+      json: async () => ({
+        code: "HOSTED_GAP_STORAGE_FAILED",
+        message:
+          error instanceof Error
+            ? error.message
+            : "Hosted gap collector is unavailable."
+      })
+    })
+  );
+  const body = (await response.json()) as Record<string, unknown>;
+
+  if (!response.ok) {
+    return {
+      status: "failed",
+      code: hostedGapFailureCode(body.code),
+      message: stringValue(body.message, "Hosted gap collector rejected the report."),
+      recoverable: response.status >= 500 || response.status === 429
+    };
+  }
+
+  return {
+    status: "submitted",
+    reportId: stringValue(body.report_id, "pending-report"),
+    code: "HOSTED_GAP_REPORT_ACCEPTED"
+  };
 }
 
 export function mapTraverseAnswerFailure(
@@ -529,6 +681,42 @@ function stringValue(value: unknown, fallback: string): string {
 
 function arrayValue(value: unknown): unknown[] {
   return Array.isArray(value) ? value : [];
+}
+
+function hostedGapFailureCode(
+  value: unknown
+): "HOSTED_GAP_REPORT_INVALID" | "HOSTED_GAP_ABUSE_CHALLENGE_FAILED" | "HOSTED_GAP_RATE_LIMITED" | "HOSTED_GAP_STORAGE_FAILED" {
+  return [
+    "HOSTED_GAP_REPORT_INVALID",
+    "HOSTED_GAP_ABUSE_CHALLENGE_FAILED",
+    "HOSTED_GAP_RATE_LIMITED",
+    "HOSTED_GAP_STORAGE_FAILED"
+  ].includes(String(value))
+    ? (value as
+        | "HOSTED_GAP_REPORT_INVALID"
+        | "HOSTED_GAP_ABUSE_CHALLENGE_FAILED"
+        | "HOSTED_GAP_RATE_LIMITED"
+        | "HOSTED_GAP_STORAGE_FAILED")
+    : "HOSTED_GAP_STORAGE_FAILED";
+}
+
+function publicGapFallbackMarkdown(input: PublicGapReportInput): string {
+  return [
+    "# Public knowledge gap",
+    "",
+    `Question: ${input.question.trim()}`,
+    "",
+    `Missing knowledge: ${input.missingKnowledge.trim()}`,
+    "",
+    `Source URL: ${input.sourceUrl.trim()}`,
+    "",
+    "Checked evidence:",
+    ...input.checkedEvidence.map((entry) => `- ${entry.trim()}`).filter((entry) => entry !== "-"),
+    "",
+    input.reporterContext?.trim()
+      ? `Reporter context: ${input.reporterContext.trim()}`
+      : "Reporter context: not provided"
+  ].join("\n");
 }
 
 export function temporaryTraverseChatHarness(

--- a/app/components/index.test.ts
+++ b/app/components/index.test.ts
@@ -7,6 +7,7 @@ import {
   chatTagName,
   componentNamespace,
   providerConfigPath,
+  renderPublicGapSubmission,
   renderChatCard,
   renderRuntimeChatResponse,
   renderResultCard,
@@ -74,6 +75,8 @@ describe("renderRuntimeChatResponse", () => {
     expect(markup).toContain("I need one simple fact before I can answer.");
     expect(markup).toContain('class="m3-direct-fact"');
     expect(markup).toContain('data-gap-id="gap-author-name"');
+    expect(markup).toContain("Public gap submission");
+    expect(markup).toContain("HOSTED_GAP_COLLECTOR_NOT_CONFIGURED");
   });
 
   it("discloses only conflicts that affect the answer", () => {
@@ -117,6 +120,82 @@ describe("renderRuntimeChatResponse", () => {
     expect(markup).not.toContain("temporary harness");
     expect(markup).not.toContain("retrieval");
     expect(markup).not.toContain("context packing");
+  });
+});
+
+describe("renderPublicGapSubmission", () => {
+  it("renders a hosted submit action only when a collector is configured", () => {
+    const markup = renderPublicGapSubmission({
+      question: "What public source is missing?",
+      knownSummary: "The static shell checked public citations.",
+      missingKnowledge: "No source-backed citation covered the answer.",
+      collectorConfigured: true,
+      disclosure: "This sends a public gap report to the configured collector.",
+      fallbackMarkdown: "# gap",
+      downloadFileName: "gap.md"
+    });
+
+    expect(markup).toContain('data-collector="configured"');
+    expect(markup).toContain("Submit public gap");
+    expect(markup).not.toContain("Draft GitHub issue");
+  });
+
+  it("renders honest manual fallbacks when no collector is configured", () => {
+    const markup = renderPublicGapSubmission({
+      question: "What public source is missing?",
+      knownSummary: "No source-backed citations were returned.",
+      missingKnowledge: "The public artifact set does not answer this question.",
+      collectorConfigured: false,
+      disclosure: "Public hosted submission is not configured.",
+      fallbackIssueUrl: "https://github.com/enricopiovesan/youaskm3/issues/new",
+      fallbackMarkdown: "# Public knowledge gap",
+      downloadFileName: "youaskm3-public-gap.md",
+      status: {
+        kind: "fallback",
+        message: "HOSTED_GAP_COLLECTOR_NOT_CONFIGURED"
+      }
+    });
+
+    expect(markup).toContain('data-collector="missing"');
+    expect(markup).toContain("Draft GitHub issue");
+    expect(markup).toContain("Copy gap markdown");
+    expect(markup).toContain("Download gap package");
+    expect(markup).toContain('role="status"');
+    expect(markup).toContain("HOSTED_GAP_COLLECTOR_NOT_CONFIGURED");
+  });
+
+  it("renders accessible success and error status states", () => {
+    const success = renderPublicGapSubmission({
+      question: "What public source is missing?",
+      knownSummary: "The collector accepted the report.",
+      missingKnowledge: "The answer needs a missing public source.",
+      collectorConfigured: true,
+      disclosure: "This sends a public gap report to the configured collector.",
+      fallbackMarkdown: "# gap",
+      downloadFileName: "gap.md",
+      status: {
+        kind: "success",
+        message: "HOSTED_GAP_REPORT_ACCEPTED"
+      }
+    });
+    const failure = renderPublicGapSubmission({
+      question: "What public source is missing?",
+      knownSummary: "The collector rejected the report.",
+      missingKnowledge: "The answer needs a missing public source.",
+      collectorConfigured: true,
+      disclosure: "This sends a public gap report to the configured collector.",
+      fallbackMarkdown: "# gap",
+      downloadFileName: "gap.md",
+      status: {
+        kind: "error",
+        message: "HOSTED_GAP_STORAGE_FAILED"
+      }
+    });
+
+    expect(success).toContain('role="status"');
+    expect(success).toContain('data-status="success"');
+    expect(failure).toContain('role="status"');
+    expect(failure).toContain('data-status="error"');
   });
 });
 

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -67,6 +67,21 @@ export type RuntimeChatResponse = {
   };
 };
 
+export type PublicGapSubmissionView = {
+  question: string;
+  knownSummary: string;
+  missingKnowledge: string;
+  collectorConfigured: boolean;
+  disclosure: string;
+  fallbackIssueUrl?: string;
+  fallbackMarkdown: string;
+  downloadFileName: string;
+  status?: {
+    kind: "success" | "error" | "fallback";
+    message: string;
+  };
+};
+
 export function componentNamespace(): string {
   return COMPONENT_NAMESPACE;
 }
@@ -144,8 +159,53 @@ export function renderRuntimeChatResponse(response: RuntimeChatResponse): string
     renderRuntimeCitations(response.citations),
     renderRuntimeGraphEvidence(response.graph_evidence),
     renderRuntimeGaps(directFactGaps),
+    response.failure
+      ? renderPublicGapSubmission({
+          question: response.failure.message,
+          knownSummary:
+            response.citations.length > 0
+              ? `${response.citations.length} citation(s) were checked.`
+              : "No source-backed citations were returned.",
+          missingKnowledge: response.failure.message,
+          collectorConfigured: false,
+          disclosure:
+            "Public gap submission is not configured for this static shell. Use a manual fallback.",
+          fallbackMarkdown: publicGapMarkdown(response.failure.message),
+          downloadFileName: "youaskm3-public-gap.md",
+          status: {
+            kind: "fallback",
+            message: "HOSTED_GAP_COLLECTOR_NOT_CONFIGURED"
+          }
+        })
+      : "",
     renderRuntimeConflicts(relevantConflicts),
     `</article>`
+  ].join("");
+}
+
+export function renderPublicGapSubmission(view: PublicGapSubmissionView): string {
+  const hostedAction = view.collectorConfigured
+    ? `<button class="m3-public-gap-submit" type="button" aria-label="Submit public knowledge gap">Submit public gap</button>`
+    : [
+        view.fallbackIssueUrl
+          ? `<a class="m3-public-gap-fallback" href="${escapeHtml(view.fallbackIssueUrl)}">Draft GitHub issue</a>`
+          : "",
+        `<button class="m3-public-gap-copy" type="button" aria-label="Copy public gap markdown">Copy gap markdown</button>`,
+        `<a class="m3-public-gap-download" download="${escapeHtml(view.downloadFileName)}" href="data:text/markdown;charset=utf-8,${encodeURIComponent(view.fallbackMarkdown)}">Download gap package</a>`
+      ].join("");
+  const status = view.status
+    ? `<p class="m3-public-gap-status" role="status" data-status="${escapeHtml(view.status.kind)}">${escapeHtml(view.status.message)}</p>`
+    : "";
+
+  return [
+    `<section class="m3-public-gap" aria-label="Public gap submission" data-collector="${view.collectorConfigured ? "configured" : "missing"}">`,
+    `<h3>Report missing public knowledge</h3>`,
+    `<p class="m3-public-gap-known"><strong>Known:</strong> ${escapeHtml(view.knownSummary)}</p>`,
+    `<p class="m3-public-gap-missing"><strong>Missing:</strong> ${escapeHtml(view.missingKnowledge)}</p>`,
+    `<p class="m3-public-gap-disclosure">${escapeHtml(view.disclosure)}</p>`,
+    `<div class="m3-public-gap-actions">${hostedAction}</div>`,
+    status,
+    `</section>`
   ].join("");
 }
 
@@ -240,4 +300,17 @@ function renderRuntimeConflicts(conflicts: RuntimeConflict[]): string {
     .join("");
 
   return `<section class="m3-runtime-conflicts" aria-label="Relevant conflicts"><h3>Relevant conflicts</h3><ul>${items}</ul></section>`;
+}
+
+function publicGapMarkdown(question: string): string {
+  return [
+    "# Public knowledge gap",
+    "",
+    `Question: ${question}`,
+    "",
+    "Missing knowledge: not enough public source-backed evidence was available.",
+    "",
+    "Checked evidence:",
+    "- No source-backed citations were returned."
+  ].join("\n");
 }

--- a/app/components/provider-config.test.ts
+++ b/app/components/provider-config.test.ts
@@ -50,5 +50,13 @@ describe("author instance manifest", () => {
     expect(DEFAULT_AUTHOR_INSTANCE.shellUrl).toContain("github.io/youaskm3");
     expect(DEFAULT_AUTHOR_INSTANCE.providerProfiles).toContain("browser-demo");
     expect(DEFAULT_AUTHOR_INSTANCE.providerProfiles).toContain("traverse-local");
+    expect(DEFAULT_AUTHOR_INSTANCE.hostedGapCollector).toMatchObject({
+      enabled: false,
+      endpoint: null,
+      publicScope: {
+        instanceId: "youaskm3-author",
+        knowledgeBase: "knowledge/"
+      }
+    });
   });
 });

--- a/app/components/provider-config.ts
+++ b/app/components/provider-config.ts
@@ -20,6 +20,18 @@ export type AuthorInstanceManifest = {
   shellUrl: string;
   providerProfiles: string[];
   knowledgeBase: string;
+  hostedGapCollector?: {
+    enabled: boolean;
+    endpoint: string | null;
+    publicScope: {
+      instanceId: string;
+      title: string;
+      shellUrl: string;
+      knowledgeBase: string;
+    };
+    fallbackIssueUrl?: string;
+    fallbackPackageName?: string;
+  };
 };
 
 export const DEFAULT_PROVIDER_CONFIG: ProviderConfig = {
@@ -68,7 +80,20 @@ export const DEFAULT_AUTHOR_INSTANCE: AuthorInstanceManifest = {
   title: "youaskm3 author instance",
   shellUrl: "https://enricopiovesan.github.io/youaskm3/",
   providerProfiles: ["browser-demo", "traverse-local", "claude-api", "openai-api"],
-  knowledgeBase: "knowledge/"
+  knowledgeBase: "knowledge/",
+  hostedGapCollector: {
+    enabled: false,
+    endpoint: null,
+    publicScope: {
+      instanceId: "youaskm3-author",
+      title: "youaskm3 author instance",
+      shellUrl: "https://enricopiovesan.github.io/youaskm3/",
+      knowledgeBase: "knowledge/"
+    },
+    fallbackIssueUrl:
+      "https://github.com/enricopiovesan/youaskm3/issues/new?title=Public%20knowledge%20gap",
+    fallbackPackageName: "youaskm3-public-gap.md"
+  }
 };
 
 export function activeProvider(

--- a/app/site/author-instance.json
+++ b/app/site/author-instance.json
@@ -3,5 +3,17 @@
   "title": "youaskm3 author instance",
   "shellUrl": "https://enricopiovesan.github.io/youaskm3/",
   "providerProfiles": ["browser-demo", "traverse-local", "claude-api", "openai-api"],
-  "knowledgeBase": "knowledge/"
+  "knowledgeBase": "knowledge/",
+  "hostedGapCollector": {
+    "enabled": false,
+    "endpoint": null,
+    "publicScope": {
+      "instanceId": "youaskm3-author",
+      "title": "youaskm3 author instance",
+      "shellUrl": "https://enricopiovesan.github.io/youaskm3/",
+      "knowledgeBase": "knowledge/"
+    },
+    "fallbackIssueUrl": "https://github.com/enricopiovesan/youaskm3/issues/new?title=Public%20knowledge%20gap",
+    "fallbackPackageName": "youaskm3-public-gap.md"
+  }
 }

--- a/app/site/build-manifest.json
+++ b/app/site/build-manifest.json
@@ -1,7 +1,7 @@
 {
   "instanceId": "youaskm3-author",
   "shellUrl": "https://enricopiovesan.github.io/youaskm3/",
-  "sourceFingerprint": "13264bac965e20bbb85e13da0dce40db75961dbcb48a44afb41f702b1ff7d048",
+  "sourceFingerprint": "baf025b62caf5744c02d4403cf0a69d8fd111d0727f437d529dbc6b06984fcee",
   "knowledgeDocumentCount": 3,
   "pendingInputCount": 0,
   "artifacts": [
@@ -16,7 +16,7 @@
     {
       "path": "app/site/author-instance.json",
       "kind": "instance-manifest",
-      "sha256": "0a045d9c35c48f8e3ebb198ca872c0bb275eab35368e5777dda196e8c6d56702"
+      "sha256": "eb9043af4993b6139b0d4335aa4d6756d1a4567f5599c43ddfe4ccfbfa389ef6"
     },
     {
       "path": "knowledge/blog/mvp-fixture-article/index.md",

--- a/app/site/components.js
+++ b/app/site/components.js
@@ -2,6 +2,7 @@ import {
   callBrowserTool,
   executeTraverseAnswerHttp,
   loadBrowserArtifacts,
+  submitPublicGapReport,
   TOOL_DESCRIPTORS
 } from "./runtime.js";
 
@@ -198,6 +199,45 @@ const styles = `
     padding: 12px 14px;
     border-radius: 16px;
     background: rgba(23, 53, 47, 0.06);
+    color: #587168;
+  }
+
+  .gap-panel {
+    display: grid;
+    gap: 10px;
+    margin-top: 18px;
+    padding: 16px;
+    border-radius: 18px;
+    border: 1px solid rgba(189, 139, 57, 0.28);
+    background: rgba(189, 139, 57, 0.1);
+  }
+
+  .gap-panel h3,
+  .gap-panel p {
+    margin: 0;
+  }
+
+  .gap-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .secondary-button,
+  .gap-link {
+    border: 1px solid rgba(23, 53, 47, 0.2);
+    border-radius: 14px;
+    background: rgba(255, 252, 246, 0.92);
+    color: #17352f;
+    cursor: pointer;
+    display: inline-flex;
+    font: inherit;
+    font-weight: 700;
+    padding: 10px 14px;
+    text-decoration: none;
+  }
+
+  .gap-status {
     color: #587168;
   }
 
@@ -411,6 +451,41 @@ class M3Chat extends HTMLElement {
       this.getAttribute("instance-title") ?? "youaskm3 author instance";
     const instanceUrl = this.getAttribute("instance-url") ?? "";
     const busy = this.getAttribute("busy") === "true";
+    const gapVisible = this.getAttribute("gap-visible") === "true";
+    const collectorConfigured = this.getAttribute("gap-collector-configured") === "true";
+    const gapKnown = this.getAttribute("gap-known") ?? "";
+    const gapMissing = this.getAttribute("gap-missing") ?? "";
+    const gapDisclosure = this.getAttribute("gap-disclosure") ?? "";
+    const gapStatus = this.getAttribute("gap-status") ?? "";
+    const gapStatusKind = this.getAttribute("gap-status-kind") ?? "";
+    const fallbackIssueUrl = this.getAttribute("gap-fallback-issue-url") ?? "";
+    const fallbackMarkdown = this.getAttribute("gap-fallback-markdown") ?? "";
+    const fallbackDownload = this.getAttribute("gap-fallback-download") ?? "youaskm3-public-gap.md";
+    const fallbackDownloadHref = `data:text/markdown;charset=utf-8,${encodeURIComponent(fallbackMarkdown)}`;
+    const gapPanel = gapVisible
+      ? `
+          <section class="gap-panel" aria-label="Public gap submission" data-collector="${collectorConfigured ? "configured" : "missing"}">
+            <h3>Report missing public knowledge</h3>
+            <p><strong>Known:</strong> ${escapeHtml(gapKnown)}</p>
+            <p><strong>Missing:</strong> ${escapeHtml(gapMissing)}</p>
+            <p>${escapeHtml(gapDisclosure)}</p>
+            <div class="gap-actions">
+              ${
+                collectorConfigured
+                  ? '<button id="public-gap-submit" class="submit-button" type="button" aria-label="Submit public knowledge gap">Submit public gap</button>'
+                  : [
+                      fallbackIssueUrl
+                        ? `<a class="gap-link" href="${escapeHtml(fallbackIssueUrl)}">Draft GitHub issue</a>`
+                        : "",
+                      '<button id="public-gap-copy" class="secondary-button" type="button" aria-label="Copy public gap markdown">Copy gap markdown</button>',
+                      `<a class="gap-link" download="${escapeHtml(fallbackDownload)}" href="${fallbackDownloadHref}">Download gap package</a>`
+                    ].join("")
+              }
+            </div>
+            ${gapStatus ? `<p class="gap-status" role="status" data-status="${escapeHtml(gapStatusKind)}">${escapeHtml(gapStatus)}</p>` : ""}
+          </section>
+        `
+      : "";
 
     root.innerHTML = template(`
       <section class="chat-shell">
@@ -479,6 +554,7 @@ class M3Chat extends HTMLElement {
             Browser shell runtime is executing locally through the contract-shaped tool adapter in <code>runtime.js</code>.
             Traverse mode delegates answer execution to the configured HTTP/JSON runtime.
           </div>
+          ${gapPanel}
         </article>
         <aside class="panel">
           <div class="sources">
@@ -545,6 +621,26 @@ class M3Chat extends HTMLElement {
         })
       );
     });
+
+    root.querySelector("#public-gap-submit")?.addEventListener("click", () => {
+      this.dispatchEvent(
+        new CustomEvent("publicgapsubmit", {
+          bubbles: true
+        })
+      );
+    });
+
+    root.querySelector("#public-gap-copy")?.addEventListener("click", () => {
+      if (navigator.clipboard && fallbackMarkdown) {
+        void navigator.clipboard.writeText(fallbackMarkdown);
+      }
+      this.dispatchEvent(
+        new CustomEvent("publicgapcopy", {
+          detail: { markdown: fallbackMarkdown },
+          bubbles: true
+        })
+      );
+    });
   }
 }
 
@@ -569,6 +665,7 @@ let artifactState = {
   graph: null,
   message: "Generated search-index.json is missing or unavailable."
 };
+let gapSubmissionStatus = null;
 
 async function loadProviderConfig() {
   const response = await fetch("./provider-config.json");
@@ -623,6 +720,61 @@ function providerSummary(profile) {
   return `${profile.label} uses ${profile.endpoint}, ${authCopy}, and hints ${profile.modelHint}.${runtimeCopy}`;
 }
 
+function collectorConfig() {
+  const collector = authorInstance?.hostedGapCollector;
+  if (collector) {
+    return collector;
+  }
+
+  return {
+    enabled: false,
+    endpoint: null,
+    publicScope: {
+      instanceId: authorInstance?.instanceId ?? "youaskm3-author",
+      title: authorInstance?.title ?? "youaskm3 author instance",
+      shellUrl: authorInstance?.shellUrl ?? window.location.href,
+      knowledgeBase: authorInstance?.knowledgeBase ?? "knowledge/"
+    },
+    fallbackIssueUrl:
+      "https://github.com/enricopiovesan/youaskm3/issues/new?title=Public%20knowledge%20gap",
+    fallbackPackageName: "youaskm3-public-gap.md"
+  };
+}
+
+function gapInput(input, sources) {
+  return {
+    question: input,
+    missingKnowledge:
+      sources.length > 0
+        ? "The public answer still needs owner-reviewed missing knowledge."
+        : "No source-backed citations were returned for this question.",
+    checkedEvidence:
+      sources.length > 0
+        ? sources.map((source) => `${source.label}: ${source.detail}`)
+        : [artifactState.message, "No source-backed citations were returned."],
+    sourceUrl: window.location.href,
+    reporterContext: "Submitted from the public static chat shell."
+  };
+}
+
+function gapMarkdown(input, sources) {
+  const report = gapInput(input, sources);
+  return [
+    "# Public knowledge gap",
+    "",
+    `Question: ${report.question}`,
+    "",
+    `Missing knowledge: ${report.missingKnowledge}`,
+    "",
+    `Source URL: ${report.sourceUrl}`,
+    "",
+    "Checked evidence:",
+    ...report.checkedEvidence.map((entry) => `- ${entry}`),
+    "",
+    `Reporter context: ${report.reporterContext}`
+  ].join("\n");
+}
+
 async function runBrowserTool(toolName, input) {
   const provider = providerConfig ? activeProvider(providerConfig) : null;
   if (toolName === "answer" && provider?.runtime === "traverse-http") {
@@ -673,6 +825,9 @@ async function syncShell(toolName, input, state = "ready") {
 
   const result = shell.querySelector("m3-result");
   const provider = providerConfig ? activeProvider(providerConfig) : null;
+  const collector = collectorConfig();
+  const gapVisible = toolName === "answer" && state !== "loading" && sources.length === 0;
+  const fallbackMarkdown = gapMarkdown(input, sources);
 
   shell.setAttribute("tool", toolName);
   shell.setAttribute("input", input);
@@ -689,6 +844,24 @@ async function syncShell(toolName, input, state = "ready") {
     authorInstance?.title ?? "youaskm3 author instance"
   );
   shell.setAttribute("instance-url", authorInstance?.shellUrl ?? window.location.href);
+  shell.setAttribute("gap-visible", gapVisible ? "true" : "false");
+  shell.setAttribute("gap-collector-configured", collector.enabled && collector.endpoint ? "true" : "false");
+  shell.setAttribute("gap-known", artifactState.message);
+  shell.setAttribute(
+    "gap-missing",
+    "No source-backed citations were returned for this question."
+  );
+  shell.setAttribute(
+    "gap-disclosure",
+    collector.enabled && collector.endpoint
+      ? "Submitting sends this public gap report to the configured hosted collector for owner review."
+      : "Hosted gap submission is not configured; use a manual fallback instead."
+  );
+  shell.setAttribute("gap-fallback-issue-url", collector.fallbackIssueUrl ?? "");
+  shell.setAttribute("gap-fallback-markdown", fallbackMarkdown);
+  shell.setAttribute("gap-fallback-download", collector.fallbackPackageName ?? "youaskm3-public-gap.md");
+  shell.setAttribute("gap-status", gapSubmissionStatus?.message ?? "");
+  shell.setAttribute("gap-status-kind", gapSubmissionStatus?.kind ?? "");
 
   if (result instanceof HTMLElement) {
     result.setAttribute("prompt", summary.prompt);
@@ -752,6 +925,7 @@ if (shell instanceof HTMLElement) {
     const detail = event instanceof CustomEvent ? event.detail : null;
     currentInput = detail?.value ?? currentInput;
     currentTool = "answer";
+    gapSubmissionStatus = null;
     void syncShell(currentTool, currentInput, "loading");
     window.setTimeout(() => void syncShell(currentTool, currentInput), 0);
   });
@@ -769,5 +943,32 @@ if (shell instanceof HTMLElement) {
       );
     }
     void syncShell(currentTool, currentInput);
+  });
+
+  shell.addEventListener("publicgapsubmit", () => {
+    const collector = collectorConfig();
+    const currentSources = Array.from(shell.querySelectorAll("m3-source")).map((source) => ({
+      label: source.getAttribute("label") ?? "Evidence",
+      detail: source.getAttribute("detail") ?? ""
+    }));
+    void submitPublicGapReport(gapInput(currentInput, currentSources), collector).then((result) => {
+      if (result.status === "submitted") {
+        gapSubmissionStatus = {
+          kind: "success",
+          message: `HOSTED_GAP_REPORT_ACCEPTED: ${result.reportId}`
+        };
+      } else if (result.status === "fallback") {
+        gapSubmissionStatus = {
+          kind: "fallback",
+          message: result.code
+        };
+      } else {
+        gapSubmissionStatus = {
+          kind: "error",
+          message: `${result.code}: ${result.message}`
+        };
+      }
+      void syncShell(currentTool, currentInput);
+    });
   });
 }

--- a/app/site/runtime.js
+++ b/app/site/runtime.js
@@ -127,6 +127,98 @@ export function isMissingInferenceDependency(code) {
   ].includes(code);
 }
 
+export function buildPublicGapReport(input, config, submittedAt = new Date().toISOString()) {
+  const question = requireInput(input.question);
+  const missingKnowledge = requireInput(input.missingKnowledge);
+  const sourceUrl = requireInput(input.sourceUrl);
+  const checkedEvidence = input.checkedEvidence
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  if (checkedEvidence.length === 0) {
+    throw new Error("public gap report needs checked evidence");
+  }
+
+  return {
+    schema_version: "1.0.0",
+    validation_version: "hosted-gap-collector/0.1.0",
+    question,
+    missing_knowledge: missingKnowledge,
+    published_scope: config.publicScope,
+    checked_evidence: checkedEvidence,
+    source_url: sourceUrl,
+    submitted_at: submittedAt,
+    ...(input.reporterContext?.trim()
+      ? { reporter_context: input.reporterContext.trim() }
+      : {})
+  };
+}
+
+export async function submitPublicGapReport(
+  input,
+  config,
+  fetchImpl = globalThis.fetch,
+  submittedAt = new Date().toISOString()
+) {
+  if (!config.enabled || !config.endpoint || config.endpoint.trim().length === 0) {
+    return {
+      status: "fallback",
+      code: "HOSTED_GAP_COLLECTOR_NOT_CONFIGURED",
+      fallbackMarkdown: publicGapFallbackMarkdown(input),
+      downloadFileName: config.fallbackPackageName ?? "youaskm3-public-gap.md"
+    };
+  }
+
+  let report;
+  try {
+    report = buildPublicGapReport(input, config, submittedAt);
+  } catch (error) {
+    return {
+      status: "failed",
+      code: "HOSTED_GAP_REPORT_INVALID",
+      message: error instanceof Error ? error.message : "Invalid public gap report.",
+      recoverable: true
+    };
+  }
+
+  const response = await fetchImpl(config.endpoint, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(report)
+  }).catch((error) =>
+    Promise.resolve({
+      ok: false,
+      status: 503,
+      json: async () => ({
+        code: "HOSTED_GAP_STORAGE_FAILED",
+        message:
+          error instanceof Error
+            ? error.message
+            : "Hosted gap collector is unavailable."
+      })
+    })
+  );
+  const body = await response.json();
+
+  if (!response.ok) {
+    return {
+      status: "failed",
+      code: hostedGapFailureCode(body.code),
+      message: stringValue(body.message, "Hosted gap collector rejected the report."),
+      recoverable: response.status >= 500 || response.status === 429
+    };
+  }
+
+  return {
+    status: "submitted",
+    reportId: stringValue(body.report_id, "pending-report"),
+    code: "HOSTED_GAP_REPORT_ACCEPTED"
+  };
+}
+
 export function mapTraverseAnswerFailure(query, failure) {
   const missingInference = isMissingInferenceDependency(failure.code);
 
@@ -327,6 +419,36 @@ function asRecord(value) {
 
 function stringValue(value, fallback) {
   return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+function hostedGapFailureCode(value) {
+  return [
+    "HOSTED_GAP_REPORT_INVALID",
+    "HOSTED_GAP_ABUSE_CHALLENGE_FAILED",
+    "HOSTED_GAP_RATE_LIMITED",
+    "HOSTED_GAP_STORAGE_FAILED"
+  ].includes(String(value))
+    ? value
+    : "HOSTED_GAP_STORAGE_FAILED";
+}
+
+function publicGapFallbackMarkdown(input) {
+  return [
+    "# Public knowledge gap",
+    "",
+    `Question: ${input.question.trim()}`,
+    "",
+    `Missing knowledge: ${input.missingKnowledge.trim()}`,
+    "",
+    `Source URL: ${input.sourceUrl.trim()}`,
+    "",
+    "Checked evidence:",
+    ...input.checkedEvidence.map((entry) => `- ${entry.trim()}`).filter((entry) => entry !== "-"),
+    "",
+    input.reporterContext?.trim()
+      ? `Reporter context: ${input.reporterContext.trim()}`
+      : "Reporter context: not provided"
+  ].join("\n");
 }
 
 function arrayValue(value) {

--- a/app/site/search-index.json
+++ b/app/site/search-index.json
@@ -2,7 +2,7 @@
   "instanceId": "youaskm3-author",
   "title": "youaskm3 author instance",
   "shellUrl": "https://enricopiovesan.github.io/youaskm3/",
-  "sourceFingerprint": "13264bac965e20bbb85e13da0dce40db75961dbcb48a44afb41f702b1ff7d048",
+  "sourceFingerprint": "baf025b62caf5744c02d4403cf0a69d8fd111d0727f437d529dbc6b06984fcee",
   "documents": [
     {
       "id": "knowledge--blog--mvp-fixture-article--index",

--- a/app/site/sync-state.json
+++ b/app/site/sync-state.json
@@ -1,6 +1,6 @@
 {
   "instanceId": "youaskm3-author",
-  "sourceFingerprint": "13264bac965e20bbb85e13da0dce40db75961dbcb48a44afb41f702b1ff7d048",
+  "sourceFingerprint": "baf025b62caf5744c02d4403cf0a69d8fd111d0727f437d529dbc6b06984fcee",
   "knowledgeDocumentCount": 3,
   "pendingInputCount": 0,
   "trackedSourcePaths": [
@@ -13,7 +13,7 @@
     {
       "path": "app/site/author-instance.json",
       "kind": "instance-manifest",
-      "sha256": "0a045d9c35c48f8e3ebb198ca872c0bb275eab35368e5777dda196e8c6d56702"
+      "sha256": "eb9043af4993b6139b0d4335aa4d6756d1a4567f5599c43ddfe4ccfbfa389ef6"
     },
     {
       "path": "knowledge/blog/mvp-fixture-article/index.md",


### PR DESCRIPTION
## What this changes

Adds static public gap submission UX for FUTURE-009. The browser shell now reads optional hosted collector config from the author-instance manifest, renders transparent public gap submission/fallback UI when source-backed citations are missing, builds the portable public gap report payload, posts only that payload to a configured collector endpoint, and keeps no-collector behavior honest with issue/copy/download fallbacks.

## Spec reference

- `openspec/specs/hosted-gap-collector/spec.md` - public gap payload, no browser secrets, honest fallback, and hosted submit boundary
- `openspec/specs/pwa-shell/spec.md` - UI-only PWA shell and runtime delegation boundary
- `openspec/specs/knowledge-gap-lifecycle/spec.md` - owner-reviewed gap lifecycle

## Spec delta

None.

## Test coverage

- `npm run typecheck`
- `npm run lint`
- `npm test`
- `PATH="/opt/homebrew/opt/rustup/bin:$HOME/.cargo/bin:$PATH" PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`

## Lean ops / minimality

[confirm: used focused evidence, avoided broad dumps/logs, and applied the Minimality Ladder before adding code]

## Breaking changes

None.

Closes #190
