### PR TITLE
Implement hosted gap collector endpoint

### DIFF
--- a/app/hosted-gap-collector/worker.test.ts
+++ b/app/hosted-gap-collector/worker.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createHostedGapCollectorHandler,
+  d1HostedGapCollectorStorage,
+  envToHostedGapCollectorConfig,
+  type D1DatabaseBinding,
+  type HostedGapCollectorConfig,
+  type HostedGapCollectorStorage,
+  type PendingGapReportRecord,
+  type PublicGapReport
+} from "./worker";
+
+const validReport: PublicGapReport = {
+  schema_version: "public-gap-report/0.1.0",
+  validation_version: "hosted-gap-collector/0.1.0",
+  question: "What does this instance know about public collector setup?",
+  missing_knowledge: "No public source explains the hosted collector deployment path.",
+  published_scope: "youaskm3-public-demo",
+  checked_evidence: ["search-index:0 results", "knowledge-graph:no matching node"],
+  source_url: "https://example.test/chat?q=collector",
+  submitted_at: "2026-07-05T12:00:00.000Z",
+  reporter_context: "Visitor expected deployment notes."
+};
+
+const baseConfig = {
+  allowedOrigins: ["https://example.test"],
+  collectorId: "collector-test",
+  maxBodyBytes: 4096,
+  rateLimitMax: 2,
+  rateLimitWindowSeconds: 3600,
+  turnstileSecretKey: "turnstile-secret"
+} satisfies HostedGapCollectorConfig;
+
+const configWithoutChallenge: HostedGapCollectorConfig = {
+  allowedOrigins: baseConfig.allowedOrigins,
+  collectorId: baseConfig.collectorId,
+  maxBodyBytes: baseConfig.maxBodyBytes,
+  rateLimitMax: baseConfig.rateLimitMax,
+  rateLimitWindowSeconds: baseConfig.rateLimitWindowSeconds
+};
+
+describe("hosted gap collector worker", () => {
+  it("accepts a valid report, verifies challenge, and stores pending-only data", async () => {
+    const storage = memoryStorage();
+    const handler = createHostedGapCollectorHandler({
+      storage,
+      config: baseConfig,
+      verifyChallenge: async (token) => token === "challenge-ok",
+      clientKey: async () => "client-a",
+      createReportId: () => "gap_test_1",
+      now: () => new Date("2026-07-05T12:01:00.000Z")
+    });
+
+    const response = await handler(
+      request({
+        report: validReport,
+        challenge_token: "challenge-ok"
+      })
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      code: "HOSTED_GAP_REPORT_ACCEPTED",
+      report_id: "gap_test_1",
+      status: "pending"
+    });
+    expect(response.status).toBe(202);
+    expect(storage.records).toHaveLength(1);
+    expect(storage.records[0]).toMatchObject({
+      reportId: "gap_test_1",
+      status: "pending",
+      collectorId: "collector-test",
+      clientKey: "client-a",
+      origin: "https://example.test"
+    });
+    expect(storage.records[0]?.report).toMatchObject({
+      schema_version: "public-gap-report/0.1.0",
+      validation_version: "hosted-gap-collector/0.1.0",
+      source_url: validReport.source_url,
+      published_scope: validReport.published_scope,
+      checked_evidence: validReport.checked_evidence,
+      missing_knowledge: validReport.missing_knowledge,
+      reporter_context: validReport.reporter_context
+    });
+    expect(JSON.stringify(storage.records[0])).not.toContain("imported");
+  });
+
+  it("rejects invalid payloads before storage", async () => {
+    const storage = memoryStorage();
+    const handler = createHostedGapCollectorHandler({
+      storage,
+      config: configWithoutChallenge,
+      clientKey: async () => "client-a"
+    });
+
+    const response = await handler(request({ ...validReport, question: "" }));
+
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      code: "HOSTED_GAP_REPORT_INVALID"
+    });
+    expect(response.status).toBe(400);
+    expect(storage.records).toHaveLength(0);
+  });
+
+  it("rejects oversized request bodies", async () => {
+    const storage = memoryStorage();
+    const handler = createHostedGapCollectorHandler({
+      storage,
+      config: { ...configWithoutChallenge, maxBodyBytes: 10 }
+    });
+
+    const response = await handler(request(validReport));
+
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      code: "HOSTED_GAP_REPORT_INVALID"
+    });
+    expect(response.status).toBe(413);
+    expect(storage.records).toHaveLength(0);
+  });
+
+  it("rejects failed challenge and disallowed origins with stable abuse code", async () => {
+    const failedChallenge = await createHostedGapCollectorHandler({
+      storage: memoryStorage(),
+      config: baseConfig,
+      verifyChallenge: async () => false
+    })(
+      request({
+        report: validReport,
+        challenge_token: "bad-token"
+      })
+    );
+
+    await expect(failedChallenge.json()).resolves.toMatchObject({
+      ok: false,
+      code: "HOSTED_GAP_ABUSE_CHALLENGE_FAILED"
+    });
+    expect(failedChallenge.status).toBe(403);
+
+    const disallowedOrigin = await createHostedGapCollectorHandler({
+      storage: memoryStorage(),
+      config: configWithoutChallenge
+    })(request(validReport, "https://evil.example"));
+
+    await expect(disallowedOrigin.json()).resolves.toMatchObject({
+      ok: false,
+      code: "HOSTED_GAP_ABUSE_CHALLENGE_FAILED"
+    });
+    expect(disallowedOrigin.status).toBe(403);
+  });
+
+  it("rate limits before storing another pending report", async () => {
+    const storage = memoryStorage();
+    storage.recentCount = 2;
+    const handler = createHostedGapCollectorHandler({
+      storage,
+      config: configWithoutChallenge,
+      clientKey: async () => "client-a"
+    });
+
+    const response = await handler(request(validReport));
+
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      code: "HOSTED_GAP_RATE_LIMITED"
+    });
+    expect(response.status).toBe(429);
+    expect(storage.records).toHaveLength(0);
+  });
+
+  it("maps storage failures to the stable storage code", async () => {
+    const storage = memoryStorage();
+    storage.failStore = true;
+    const handler = createHostedGapCollectorHandler({
+      storage,
+      config: configWithoutChallenge,
+      clientKey: async () => "client-a"
+    });
+
+    const response = await handler(request(validReport));
+
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      code: "HOSTED_GAP_STORAGE_FAILED"
+    });
+    expect(response.status).toBe(500);
+  });
+
+  it("adapts Cloudflare D1 storage without browser-facing secrets", async () => {
+    const database = fakeD1();
+    const storage = d1HostedGapCollectorStorage(database);
+
+    await storage.storePendingReport({
+      reportId: "gap_d1",
+      collectorId: "collector-test",
+      status: "pending",
+      report: validReport,
+      receivedAt: "2026-07-05T12:01:00.000Z",
+      clientKey: "client-hash",
+      origin: "https://example.test"
+    });
+
+    expect(database.insertValues).toContain("gap_d1");
+    expect(database.insertValues).toContain("pending");
+    expect(database.insertValues).toContain(validReport.validation_version);
+    expect(database.insertValues.join(" ")).not.toContain("secret");
+  });
+
+  it("parses conservative deployment config from Worker environment", () => {
+    expect(
+      envToHostedGapCollectorConfig({
+        GAP_REPORTS: fakeD1(),
+        ALLOWED_ORIGINS: "https://example.test, https://www.example.test",
+        COLLECTOR_ID: "collector-prod",
+        MAX_BODY_BYTES: "2048",
+        RATE_LIMIT_MAX: "5",
+        RATE_LIMIT_WINDOW_SECONDS: "600"
+      })
+    ).toMatchObject({
+      allowedOrigins: ["https://example.test", "https://www.example.test"],
+      collectorId: "collector-prod",
+      maxBodyBytes: 2048,
+      rateLimitMax: 5,
+      rateLimitWindowSeconds: 600
+    });
+  });
+});
+
+function request(body: unknown, origin = "https://example.test"): Request {
+  return new Request("https://collector.example.test/gaps", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      origin
+    },
+    body: JSON.stringify(body)
+  });
+}
+
+function memoryStorage(): HostedGapCollectorStorage & {
+  records: PendingGapReportRecord[];
+  recentCount: number;
+  failStore: boolean;
+} {
+  return {
+    records: [],
+    recentCount: 0,
+    failStore: false,
+    async countRecentReports(): Promise<number> {
+      return this.recentCount;
+    },
+    async storePendingReport(record: PendingGapReportRecord): Promise<void> {
+      if (this.failStore) {
+        throw new Error("storage unavailable");
+      }
+      this.records.push(record);
+    }
+  };
+}
+
+function fakeD1(): D1DatabaseBinding & { insertValues: unknown[] } {
+  return {
+    insertValues: [] as unknown[],
+    prepare(query: string) {
+      const statement = {
+        bind: (...values: unknown[]) => {
+          if (query.startsWith("INSERT")) {
+            this.insertValues = values;
+          }
+          return statement;
+        },
+        first: async <T = unknown>() => 0 as T,
+        run: async () => ({ success: true })
+      };
+      return statement;
+    }
+  };
+}

--- a/app/hosted-gap-collector/worker.ts
+++ b/app/hosted-gap-collector/worker.ts
@@ -1,0 +1,427 @@
+export type HostedGapErrorCode =
+  | "HOSTED_GAP_REPORT_INVALID"
+  | "HOSTED_GAP_ABUSE_CHALLENGE_FAILED"
+  | "HOSTED_GAP_RATE_LIMITED"
+  | "HOSTED_GAP_STORAGE_FAILED";
+
+export type PublicGapReport = {
+  schema_version: "public-gap-report/0.1.0";
+  validation_version: "hosted-gap-collector/0.1.0";
+  question: string;
+  missing_knowledge: string;
+  published_scope: string;
+  checked_evidence: string[];
+  source_url: string;
+  submitted_at: string;
+  reporter_context?: string;
+};
+
+export type PendingGapReportRecord = {
+  reportId: string;
+  collectorId: string;
+  status: "pending";
+  report: PublicGapReport;
+  receivedAt: string;
+  clientKey: string;
+  origin: string;
+};
+
+export type HostedGapCollectorStorage = {
+  countRecentReports(clientKey: string, sinceIso: string): Promise<number>;
+  storePendingReport(record: PendingGapReportRecord): Promise<void>;
+};
+
+export type HostedGapCollectorConfig = {
+  allowedOrigins: string[];
+  collectorId: string;
+  maxBodyBytes: number;
+  rateLimitMax: number;
+  rateLimitWindowSeconds: number;
+  turnstileSecretKey?: string;
+};
+
+type HostedGapCollectorEnv = {
+  GAP_REPORTS: D1DatabaseBinding;
+  ALLOWED_ORIGINS: string;
+  COLLECTOR_ID?: string;
+  MAX_BODY_BYTES?: string;
+  RATE_LIMIT_MAX?: string;
+  RATE_LIMIT_WINDOW_SECONDS?: string;
+  TURNSTILE_SECRET_KEY?: string;
+};
+
+export type D1DatabaseBinding = {
+  prepare(query: string): D1PreparedStatementBinding;
+};
+
+type D1PreparedStatementBinding = {
+  bind(...values: unknown[]): D1PreparedStatementBinding;
+  first<T = unknown>(column?: string): Promise<T | null>;
+  run(): Promise<unknown>;
+};
+
+type ChallengeVerifier = (token: string, request: Request, config: HostedGapCollectorConfig) => Promise<boolean>;
+type ClientKeyHasher = (request: Request) => Promise<string>;
+type IdFactory = () => string;
+type Clock = () => Date;
+
+type HostedGapCollectorDependencies = {
+  storage: HostedGapCollectorStorage;
+  config: HostedGapCollectorConfig;
+  verifyChallenge?: ChallengeVerifier;
+  clientKey?: ClientKeyHasher;
+  createReportId?: IdFactory;
+  now?: Clock;
+};
+
+type GapReportEnvelope = {
+  report: PublicGapReport;
+  challengeToken?: string;
+};
+
+const DEFAULT_MAX_BODY_BYTES = 8192;
+const DEFAULT_RATE_LIMIT_MAX = 10;
+const DEFAULT_RATE_LIMIT_WINDOW_SECONDS = 3600;
+const VALIDATION_VERSION = "hosted-gap-collector/0.1.0";
+
+export function createHostedGapCollectorHandler(dependencies: HostedGapCollectorDependencies) {
+  return async function handleHostedGapCollectorRequest(request: Request): Promise<Response> {
+    if (request.method === "OPTIONS") {
+      return corsResponse(null, dependencies.config, request, 204);
+    }
+
+    if (request.method !== "POST") {
+      return errorResponse("HOSTED_GAP_REPORT_INVALID", "Only POST submissions are accepted.", dependencies.config, request, 405);
+    }
+
+    const origin = request.headers.get("origin") ?? "";
+    if (!originAllowed(origin, dependencies.config.allowedOrigins)) {
+      return errorResponse("HOSTED_GAP_ABUSE_CHALLENGE_FAILED", "Origin is not allowed.", dependencies.config, request, 403);
+    }
+
+    const bodyText = await readBoundedBody(request, dependencies.config.maxBodyBytes);
+    if (bodyText === null) {
+      return errorResponse("HOSTED_GAP_REPORT_INVALID", "Public gap report exceeds the configured body limit.", dependencies.config, request, 413);
+    }
+
+    const envelope = parseGapReportEnvelope(bodyText);
+    if (!envelope.ok) {
+      return errorResponse("HOSTED_GAP_REPORT_INVALID", envelope.message, dependencies.config, request, 400);
+    }
+
+    if (dependencies.config.turnstileSecretKey) {
+      const challengeToken = envelope.value.challengeToken;
+      const verifyChallenge = dependencies.verifyChallenge ?? verifyTurnstileChallenge;
+      if (!challengeToken || !(await verifyChallenge(challengeToken, request, dependencies.config))) {
+        return errorResponse(
+          "HOSTED_GAP_ABUSE_CHALLENGE_FAILED",
+          "Abuse challenge verification failed.",
+          dependencies.config,
+          request,
+          403
+        );
+      }
+    }
+
+    const clientKey = await (dependencies.clientKey ?? defaultClientKey)(request);
+    const now = (dependencies.now ?? (() => new Date()))();
+    const windowStart = new Date(now.getTime() - dependencies.config.rateLimitWindowSeconds * 1000).toISOString();
+
+    try {
+      const recentReports = await dependencies.storage.countRecentReports(clientKey, windowStart);
+      if (recentReports >= dependencies.config.rateLimitMax) {
+        return errorResponse(
+          "HOSTED_GAP_RATE_LIMITED",
+          "Hosted gap report rate limit exceeded.",
+          dependencies.config,
+          request,
+          429
+        );
+      }
+
+      const reportId = (dependencies.createReportId ?? defaultReportId)();
+      const receivedAt = now.toISOString();
+      await dependencies.storage.storePendingReport({
+        reportId,
+        collectorId: dependencies.config.collectorId,
+        status: "pending",
+        report: envelope.value.report,
+        receivedAt,
+        clientKey,
+        origin
+      });
+
+      return corsResponse(
+        {
+          ok: true,
+          code: "HOSTED_GAP_REPORT_ACCEPTED",
+          report_id: reportId,
+          status: "pending",
+          validation_version: VALIDATION_VERSION,
+          received_at: receivedAt
+        },
+        dependencies.config,
+        request,
+        202
+      );
+    } catch {
+      return errorResponse(
+        "HOSTED_GAP_STORAGE_FAILED",
+        "Hosted gap collector could not store the pending report.",
+        dependencies.config,
+        request,
+        500
+      );
+    }
+  };
+}
+
+export function envToHostedGapCollectorConfig(env: HostedGapCollectorEnv): HostedGapCollectorConfig {
+  return {
+    allowedOrigins: env.ALLOWED_ORIGINS.split(",").map((origin) => origin.trim()).filter(Boolean),
+    collectorId: env.COLLECTOR_ID ?? "youaskm3-hosted-gap-collector",
+    maxBodyBytes: positiveInteger(env.MAX_BODY_BYTES, DEFAULT_MAX_BODY_BYTES),
+    rateLimitMax: positiveInteger(env.RATE_LIMIT_MAX, DEFAULT_RATE_LIMIT_MAX),
+    rateLimitWindowSeconds: positiveInteger(env.RATE_LIMIT_WINDOW_SECONDS, DEFAULT_RATE_LIMIT_WINDOW_SECONDS),
+    ...(env.TURNSTILE_SECRET_KEY ? { turnstileSecretKey: env.TURNSTILE_SECRET_KEY } : {})
+  };
+}
+
+export function d1HostedGapCollectorStorage(database: D1DatabaseBinding): HostedGapCollectorStorage {
+  return {
+    async countRecentReports(clientKey: string, sinceIso: string): Promise<number> {
+      const count = await database
+        .prepare("SELECT COUNT(*) AS count FROM pending_gap_reports WHERE client_key = ?1 AND received_at >= ?2")
+        .bind(clientKey, sinceIso)
+        .first<number>("count");
+      return count ?? 0;
+    },
+    async storePendingReport(record: PendingGapReportRecord): Promise<void> {
+      await database
+        .prepare(
+          `INSERT INTO pending_gap_reports (
+            report_id,
+            collector_id,
+            status,
+            schema_version,
+            validation_version,
+            question,
+            missing_knowledge,
+            published_scope,
+            checked_evidence_json,
+            source_url,
+            submitted_at,
+            reporter_context,
+            received_at,
+            client_key,
+            origin
+          ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)`
+        )
+        .bind(
+          record.reportId,
+          record.collectorId,
+          record.status,
+          record.report.schema_version,
+          record.report.validation_version,
+          record.report.question,
+          record.report.missing_knowledge,
+          record.report.published_scope,
+          JSON.stringify(record.report.checked_evidence),
+          record.report.source_url,
+          record.report.submitted_at,
+          record.report.reporter_context ?? null,
+          record.receivedAt,
+          record.clientKey,
+          record.origin
+        )
+        .run();
+    }
+  };
+}
+
+export default {
+  async fetch(request: Request, env: HostedGapCollectorEnv): Promise<Response> {
+    const handler = createHostedGapCollectorHandler({
+      storage: d1HostedGapCollectorStorage(env.GAP_REPORTS),
+      config: envToHostedGapCollectorConfig(env)
+    });
+    return handler(request);
+  }
+};
+
+function parseGapReportEnvelope(bodyText: string): { ok: true; value: GapReportEnvelope } | { ok: false; message: string } {
+  let value: unknown;
+  try {
+    value = JSON.parse(bodyText);
+  } catch {
+    return { ok: false, message: "Public gap report body must be valid JSON." };
+  }
+
+  const candidate = objectValue(value);
+  if (!candidate) {
+    return { ok: false, message: "Public gap report body must be an object." };
+  }
+
+  const reportCandidate = objectValue(candidate.report) ?? candidate;
+  const challengeToken = stringField(candidate.challenge_token) ?? stringField(candidate.turnstile_token);
+  const report = publicGapReport(reportCandidate);
+  if (!report.ok) {
+    return report;
+  }
+
+  return { ok: true, value: { report: report.value, ...(challengeToken ? { challengeToken } : {}) } };
+}
+
+function publicGapReport(value: Record<string, unknown>): { ok: true; value: PublicGapReport } | { ok: false; message: string } {
+  const schemaVersion = stringField(value.schema_version);
+  const validationVersion = stringField(value.validation_version);
+  const question = boundedString(value.question, 1, 1000);
+  const missingKnowledge = boundedString(value.missing_knowledge, 1, 2000);
+  const publishedScope = boundedString(value.published_scope, 1, 500);
+  const checkedEvidence = stringArray(value.checked_evidence, 20, 500);
+  const sourceUrl = boundedString(value.source_url, 1, 2048);
+  const submittedAt = stringField(value.submitted_at);
+  const reporterContext = boundedString(value.reporter_context, 0, 2000);
+
+  if (schemaVersion !== "public-gap-report/0.1.0") {
+    return { ok: false, message: "Unsupported public gap report schema_version." };
+  }
+  if (validationVersion !== VALIDATION_VERSION) {
+    return { ok: false, message: "Unsupported public gap report validation_version." };
+  }
+  if (!question || !missingKnowledge || !publishedScope || !checkedEvidence || !sourceUrl || !submittedAt) {
+    return { ok: false, message: "Public gap report is missing required fields or exceeds field limits." };
+  }
+  if (!validUrl(sourceUrl) || Number.isNaN(Date.parse(submittedAt))) {
+    return { ok: false, message: "Public gap report source_url or submitted_at is invalid." };
+  }
+
+  return {
+    ok: true,
+    value: {
+      schema_version: "public-gap-report/0.1.0",
+      validation_version: VALIDATION_VERSION,
+      question,
+      missing_knowledge: missingKnowledge,
+      published_scope: publishedScope,
+      checked_evidence: checkedEvidence,
+      source_url: sourceUrl,
+      submitted_at: submittedAt,
+      ...(reporterContext ? { reporter_context: reporterContext } : {})
+    }
+  };
+}
+
+async function readBoundedBody(request: Request, maxBodyBytes: number): Promise<string | null> {
+  const contentLength = request.headers.get("content-length");
+  if (contentLength && Number(contentLength) > maxBodyBytes) {
+    return null;
+  }
+
+  const bodyText = await request.text();
+  return new TextEncoder().encode(bodyText).byteLength <= maxBodyBytes ? bodyText : null;
+}
+
+async function verifyTurnstileChallenge(
+  token: string,
+  request: Request,
+  config: HostedGapCollectorConfig
+): Promise<boolean> {
+  const body = new FormData();
+  body.set("secret", config.turnstileSecretKey ?? "");
+  body.set("response", token);
+  const remoteIp = request.headers.get("cf-connecting-ip");
+  if (remoteIp) {
+    body.set("remoteip", remoteIp);
+  }
+
+  const response = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+    method: "POST",
+    body
+  });
+  const verification = objectValue(await response.json());
+  return response.ok && verification?.success === true;
+}
+
+async function defaultClientKey(request: Request): Promise<string> {
+  const source = [
+    request.headers.get("cf-connecting-ip") ?? "unknown-ip",
+    request.headers.get("origin") ?? "unknown-origin",
+    request.headers.get("user-agent") ?? "unknown-agent"
+  ].join("|");
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(source));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function defaultReportId(): string {
+  return `gap_${crypto.randomUUID()}`;
+}
+
+function errorResponse(
+  code: HostedGapErrorCode,
+  message: string,
+  config: HostedGapCollectorConfig,
+  request: Request,
+  status: number
+): Response {
+  return corsResponse({ ok: false, code, message }, config, request, status);
+}
+
+function corsResponse(body: unknown, config: HostedGapCollectorConfig, request: Request, status: number): Response {
+  const origin = request.headers.get("origin") ?? "";
+  const headers = new Headers({
+    "access-control-allow-methods": "POST, OPTIONS",
+    "access-control-allow-headers": "content-type",
+    "content-type": "application/json; charset=utf-8",
+    vary: "Origin"
+  });
+  if (originAllowed(origin, config.allowedOrigins)) {
+    headers.set("access-control-allow-origin", origin);
+  }
+  return new Response(body === null ? null : JSON.stringify(body), { status, headers });
+}
+
+function originAllowed(origin: string, allowedOrigins: string[]): boolean {
+  return allowedOrigins.includes(origin);
+}
+
+function positiveInteger(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" ? value.trim() : undefined;
+}
+
+function boundedString(value: unknown, minLength: number, maxLength: number): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length >= minLength && trimmed.length <= maxLength ? trimmed : undefined;
+}
+
+function stringArray(value: unknown, maxItems: number, maxItemLength: number): string[] | undefined {
+  if (!Array.isArray(value) || value.length > maxItems) {
+    return undefined;
+  }
+  const items = value.map((item) => boundedString(item, 1, maxItemLength));
+  return items.every((item): item is string => Boolean(item)) ? items : undefined;
+}
+
+function validUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+}

--- a/docs/hosted-gap-collector-deployment.md
+++ b/docs/hosted-gap-collector-deployment.md
@@ -1,0 +1,121 @@
+# Hosted Gap Collector Deployment
+
+Status: Reference deployment notes for `hosted-gap-collector`
+
+## Purpose
+
+The hosted gap collector is an optional public write boundary for GitHub Pages
+chat. It accepts public gap reports, validates abuse controls, and stores
+pending reports for owner review. It does not run inference, mutate local
+knowledge, update the graph, create GitHub issues, or mark reports imported.
+
+## Reference Provider
+
+The first reference endpoint is a Cloudflare Worker-shaped module at
+`app/hosted-gap-collector/worker.ts`. It is intentionally provider-light: the
+core handler is testable without Cloudflare, while the default export expects a
+Worker request and a D1 binding.
+
+Required Worker bindings and variables:
+
+| Name | Type | Required | Purpose |
+|---|---|---:|---|
+| `GAP_REPORTS` | D1 database binding | yes | Pending report storage. |
+| `ALLOWED_ORIGINS` | comma-separated origins | yes | Public pages allowed to submit reports. |
+| `TURNSTILE_SECRET_KEY` | secret | recommended | Verifies public abuse challenge tokens server-side. |
+| `COLLECTOR_ID` | text | no | Stable collector id stored with reports. |
+| `MAX_BODY_BYTES` | integer | no | Defaults to `8192`. |
+| `RATE_LIMIT_MAX` | integer | no | Defaults to `10`. |
+| `RATE_LIMIT_WINDOW_SECONDS` | integer | no | Defaults to `3600`. |
+
+The browser must never receive `TURNSTILE_SECRET_KEY`, D1 credentials, GitHub
+tokens, or any other write secret.
+
+## D1 Schema
+
+The reference storage adapter expects a pending-only table:
+
+```sql
+CREATE TABLE pending_gap_reports (
+  report_id TEXT PRIMARY KEY,
+  collector_id TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status = 'pending'),
+  schema_version TEXT NOT NULL,
+  validation_version TEXT NOT NULL,
+  question TEXT NOT NULL,
+  missing_knowledge TEXT NOT NULL,
+  published_scope TEXT NOT NULL,
+  checked_evidence_json TEXT NOT NULL,
+  source_url TEXT NOT NULL,
+  submitted_at TEXT NOT NULL,
+  reporter_context TEXT,
+  received_at TEXT NOT NULL,
+  client_key TEXT NOT NULL,
+  origin TEXT NOT NULL
+);
+
+CREATE INDEX pending_gap_reports_client_window
+  ON pending_gap_reports (client_key, received_at);
+```
+
+`client_key` is a server-side hash used for rate limiting. It is operational
+telemetry, not identity, and should not be shown as reporter metadata.
+
+## Request Shape
+
+The endpoint accepts either a raw public gap report JSON object or an envelope:
+
+```json
+{
+  "report": {
+    "schema_version": "public-gap-report/0.1.0",
+    "validation_version": "hosted-gap-collector/0.1.0",
+    "question": "What is missing?",
+    "missing_knowledge": "No source-backed citation answered the question.",
+    "published_scope": "public-demo",
+    "checked_evidence": ["search-index:0 results"],
+    "source_url": "https://example.com/chat",
+    "submitted_at": "2026-07-05T12:00:00.000Z",
+    "reporter_context": "Optional visitor context"
+  },
+  "challenge_token": "public-turnstile-token"
+}
+```
+
+When `TURNSTILE_SECRET_KEY` is configured, `challenge_token` is required and is
+verified server-side. Accepted reports return `202` with
+`HOSTED_GAP_REPORT_ACCEPTED`, a report id, and `pending` status.
+
+## Stable Errors
+
+The endpoint maps failures to stable codes:
+
+| Failure | Code |
+|---|---|
+| Invalid JSON, missing fields, unsupported schema, oversized body | `HOSTED_GAP_REPORT_INVALID` |
+| Disallowed origin or failed challenge | `HOSTED_GAP_ABUSE_CHALLENGE_FAILED` |
+| Rate limit exceeded | `HOSTED_GAP_RATE_LIMITED` |
+| Storage unavailable | `HOSTED_GAP_STORAGE_FAILED` |
+
+## Free-Tier And Cost Assumptions
+
+The default quotas are conservative for an MVP public instance:
+
+- request body limit: `8192` bytes
+- rate limit: `10` accepted reports per hashed client key per hour
+- storage: one D1 row per accepted pending report
+- retention: owner should review and delete, reject, archive, or import reports
+  regularly once CLI support is enabled
+
+Before enabling the collector on a public instance, configure provider billing
+alerts or hard limits where available. If expected traffic exceeds free-tier
+usage, treat that as a release readiness blocker rather than silently raising
+limits.
+
+## Owner Review Boundary
+
+Every stored row remains `pending`. Owner import belongs to the local CLI gap
+lifecycle and must preserve hosted report id, source URL, published scope,
+reporter context, timestamps, schema version, and validation version. The
+collector must not mark a report imported without an explicit owner-side
+workflow.

--- a/openspec/specs/hosted-gap-collector/spec.md
+++ b/openspec/specs/hosted-gap-collector/spec.md
@@ -22,6 +22,9 @@ controls, portability, and owner-review semantics.
 The architecture is documented in
 `docs/hosted-gap-collector-architecture.md`.
 
+The reference endpoint and deployment boundary are documented in
+`docs/hosted-gap-collector-deployment.md`.
+
 ## Requirements
 
 ### Requirement: Preserve local-first source of truth
@@ -176,6 +179,19 @@ unexpected cost growth.
 - WHEN setup completes
 - THEN the docs list expected provider resources, free-tier assumptions, rate limits, body limits, retention policy, and owner cleanup path
 - AND the implementation defaults to conservative quotas suitable for MVP use
+
+### Requirement: Provide a pending-only reference endpoint
+
+The system SHALL provide a minimal reference endpoint that accepts public gap
+reports, validates abuse controls, and stores pending reports for owner review.
+
+#### Scenario: Reference endpoint accepts report
+
+- GIVEN a configured hosted gap collector receives a valid public gap report
+- WHEN origin, challenge, body size, schema, and rate-limit checks pass
+- THEN it returns `HOSTED_GAP_REPORT_ACCEPTED`
+- AND stores the report with `pending` status, stable report id, validation version, source URL, published scope, checked evidence, missing knowledge, and reporter context when present
+- AND no local knowledge, graph artifact, inference path, GitHub issue, or import status is mutated
 
 ### Requirement: Preserve privacy and consent
 


### PR DESCRIPTION
## What this changes

Implements the minimal hosted gap collector reference endpoint for FUTURE-010. The new Worker-shaped handler accepts public gap reports, enforces origin checks, optional Turnstile challenge verification, body-size limits, rate limits, stable schema validation, and pending-only D1 storage.

The collector returns stable success/error codes and does not run inference, mutate local knowledge, update graph artifacts, create GitHub issues, or mark reports imported. Deployment notes document required bindings, D1 schema, free-tier assumptions, and the owner-review boundary.

## Spec reference

- `openspec/specs/hosted-gap-collector/spec.md` - pending-only public gap collector behavior, stable codes, abuse controls, and reference endpoint requirement
- `openspec/specs/hosted-service/spec.md` - optional hosted feature boundary and explicit opt-in model

## Spec delta

- Adds a hosted-gap-collector requirement for the pending-only reference endpoint and links the deployment notes.

## Test coverage

- `npm run typecheck`
- `npm run lint`
- `npm test`
- `PATH="/opt/homebrew/opt/rustup/bin:$HOME/.cargo/bin:$PATH" PYTHON=/opt/homebrew/bin/python3.14 bash scripts/smoke.sh`

## Lean ops / minimality

[confirm: used focused evidence, avoided broad dumps/logs, and applied the Minimality Ladder before adding code]

## Breaking changes

None.

Closes #189
